### PR TITLE
Block disposable email addresses during signup

### DIFF
--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.2",
+  "version": "0.5.3-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.2",
+      "version": "0.5.3-dev.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@octokit/rest": "^20.0.2",

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.3-dev.0",
+  "version": "0.5.3-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.3-dev.0",
+      "version": "0.5.3-dev.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@octokit/rest": "^20.0.2",

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.3-dev.1",
+  "version": "0.5.3-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.3-dev.1",
+      "version": "0.5.3-dev.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@octokit/rest": "^20.0.2",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.3-dev.0",
+  "version": "0.5.3-dev.1",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.2",
+  "version": "0.5.3-dev.0",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.3-dev.1",
+  "version": "0.5.3-dev.2",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -116,7 +116,7 @@ async function getCallContext(req: Request) {
 
   const hasDatabase = Boolean(getMongodbUri());
   if (hasDatabase) {
-    const { session, user, roles } = await authenticate(authToken, connectionInfo);
+    const { session, user, roles } = await authenticate(authToken);
     return {
       clientInfo,
       connectionInfo,

--- a/packages/modelence/src/auth/db.ts
+++ b/packages/modelence/src/auth/db.ts
@@ -50,3 +50,16 @@ export const usersCollection = new Store('_modelenceUsers', {
     },
   ]
 });
+
+export const dbDisposableEmailDomains = new Store('_modelenceDisposableEmailDomains', {
+  schema: {
+    domain: schema.string(),
+    addedAt: schema.date(),
+  },
+  indexes: [
+    {
+      key: { domain: 1 },
+      unique: true
+    }
+  ]
+});

--- a/packages/modelence/src/auth/disposableEmails.ts
+++ b/packages/modelence/src/auth/disposableEmails.ts
@@ -1,0 +1,53 @@
+import { time } from '../time';
+import { dbDisposableEmailDomains } from './db';
+
+export async function isDisposableEmail(email: string): Promise<boolean> {
+  const emailParts = email.toLowerCase().trim().split('@');
+  if (emailParts.length !== 2) {
+    return false;
+  }
+  
+  const domain = emailParts[1];
+  const result = await dbDisposableEmailDomains.findOne({ domain });
+  return Boolean(result);
+}
+
+export const updateDisposableEmailListCron = {
+  interval: time.days(1),
+  async handler() {
+    const response = await fetch('https://disposable.github.io/disposable-email-domains/domains.txt');
+    
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    
+    const domainsText = await response.text();
+    
+    const domains = domainsText
+      .split('\n')
+      .map(domain => domain.trim().toLowerCase())
+      .filter(domain => domain.length > 0);
+    
+    const now = new Date();
+    
+    // Insert domains in batches to avoid overwhelming the database
+    const batchSize = 500;
+    for (let i = 0; i < domains.length; i += batchSize) {
+      const batch = domains.slice(i, i + batchSize);
+      
+      try {
+        await dbDisposableEmailDomains.insertMany(
+          batch.map(domain => ({
+            domain,
+            addedAt: now,
+          }))
+        );
+      } catch (error: any) {
+        // MongoDB throws BulkWriteError when some documents are duplicates
+        if (error.name === 'MongoBulkWriteError' && error.result?.nInserted) {
+          // console.warn(`Error inserting batch starting at index ${i}:`, error.message);
+        }
+      }
+    }
+  }
+}

--- a/packages/modelence/src/auth/signup.ts
+++ b/packages/modelence/src/auth/signup.ts
@@ -3,6 +3,7 @@ import bcrypt from 'bcrypt';
 
 import { Args, Context } from '../methods/types';
 import { usersCollection } from './db';
+import { isDisposableEmail } from './disposableEmails';
 
 export async function handleSignupWithPassword(args: Args, { user }: Context) {
   const email = z.string().email().parse(args.email);
@@ -10,7 +11,10 @@ export async function handleSignupWithPassword(args: Args, { user }: Context) {
     .min(8, { message: 'Password must contain at least 8 characters' })
     .parse(args.password);
 
-  // TODO: block disposable email providers
+  if (await isDisposableEmail(email)) {
+    throw new Error('Please use a permanent email address');
+  }
+
   // TODO: captcha check
   // TODO: rate limiting
 

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -4,7 +4,7 @@ import { Module } from '../app/module';
 import { handleSignupWithPassword } from './signup';
 import { handleLoginWithPassword, handleLogout } from './login';
 import { getOwnProfile } from './profile';
-import { usersCollection } from './db';
+import { dbDisposableEmailDomains, usersCollection } from './db';
 import { updateDisposableEmailListCron } from './disposableEmails';
 
 async function createGuestUser() {
@@ -27,7 +27,7 @@ async function createGuestUser() {
 }
 
 export default new Module('_system.user', {
-  stores: [usersCollection],
+  stores: [usersCollection, dbDisposableEmailDomains],
   queries: {
     getOwnProfile,
   },

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -5,6 +5,7 @@ import { handleSignupWithPassword } from './signup';
 import { handleLoginWithPassword, handleLogout } from './login';
 import { getOwnProfile } from './profile';
 import { usersCollection } from './db';
+import { updateDisposableEmailListCron } from './disposableEmails';
 
 async function createGuestUser() {
   // TODO: add rate-limiting and captcha handling
@@ -34,5 +35,8 @@ export default new Module('_system.user', {
     signupWithPassword: handleSignupWithPassword,
     loginWithPassword: handleLoginWithPassword,
     logout: handleLogout,
+  },
+  cronJobs: {
+    updateDisposableEmailList: updateDisposableEmailListCron
   }
 });

--- a/packages/modelence/src/server.ts
+++ b/packages/modelence/src/server.ts
@@ -5,11 +5,16 @@ export { ObjectId } from 'mongodb';
 
 export { createQuery } from './methods';
 
+// Auth
 export { usersCollection as dbUsers } from './auth/db';
 export type { UserInfo } from './auth/types';
 
+// Database
 export { schema } from './data/types';
 export { Store } from './data/store';
+
+// Cron jobs
+export { CronJobInputParams } from './cron/types';
 
 export { getConfig } from './config/server';
 export type { CloudBackendConnectResponse } from './app/backendApi';


### PR DESCRIPTION
Prevents users from signing up with throwaway email addresses by checking against a database of ~100k known disposable domains.

## What it does
- Automatically fetches and updates disposable email domains daily from [disposable.github.io](https://disposable.github.io/disposable-email-domains/domains.txt)
- Blocks signup attempts using domains like `tempmail.com`, `10minutemail.com`, `guerrillamail.com`, etc.
- Shows users a clear error: *"Please use a permanent email address"*