### PR TITLE
Docs: add auth and rate limits to reference

### DIFF
--- a/docs/web/README.md
+++ b/docs/web/README.md
@@ -22,6 +22,12 @@ Run the following command at the root of your documentation (where docs.json is)
 mintlify dev
 ```
 
+or
+
+```
+npx mint dev
+```
+
 ### Publishing Changes
 
 Install our Github App to auto propagate changes from your repo to your deployment. Changes will be deployed to production automatically after pushing to the default branch. Find the link to install on your dashboard. 

--- a/docs/web/docs.json
+++ b/docs/web/docs.json
@@ -50,11 +50,20 @@
             ]
           },
           {
+            "group": "Authentication",
+            "pages": [
+              "api-reference/modelence/client/functions/signupWithPassword",
+              "api-reference/modelence/client/functions/loginWithPassword",
+              "api-reference/modelence/client/functions/logout",
+              "api-reference/modelence/client/functions/useSession",
+              "api-reference/modelence/server/variables/dbUsers"
+            ]
+          },
+          {
             "group": "Database",
             "pages": [
               "api-reference/modelence/server/classes/Store",
-              "api-reference/modelence/server/variables/schema",
-              "api-reference/modelence/server/variables/dbUsers"
+              "api-reference/modelence/server/variables/schema"
             ]
           },
           {
@@ -62,6 +71,13 @@
             "pages": [
               "api-reference/modelence/server/functions/getConfig",
               "api-reference/modelence/client/functions/getConfig"
+            ]
+          },
+          {
+            "group": "Rate Limits",
+            "pages": [
+              "api-reference/modelence/server/type-aliases/RateLimitRule",
+              "api-reference/modelence/server/functions/consumeRateLimit"
             ]
           }
         ]

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -6,19 +6,45 @@ export type UserInfo = {
   handle: string;
 };
 
-export async function signupWithPassword({ email, password }: { email: string, password: string }) {
+/**
+ * Sign up a new user with an email and password.
+ * 
+ * @example
+ * ```ts
+ * await signupWithPassword({ email: 'test@example.com', password: '12345678' });
+ * ```
+ * @param options.email - The email of the user.
+ * @param options.password - The password of the user.
+ */
+export async function signupWithPassword(options: { email: string, password: string }) {
+  const { email, password } = options;
   await callMethod('_system.user.signupWithPassword', { email, password });
 
   // TODO: handle auto-login from the signup method itself to avoid a second method call
   await loginWithPassword({ email, password });
 }
 
-export async function loginWithPassword({ email, password }: { email: string, password: string }) {
+/**
+ * Login a user with an email and password.
+ * 
+ * @example
+ * ```ts
+ * await loginWithPassword({ email: 'test@example.com', password: '12345678' });
+ * ```
+ * @param options.email - The email of the user.
+ * @param options.password - The password of the user.
+ */
+export async function loginWithPassword(options: { email: string, password: string }) {
+  const { email, password } = options;
   const { user } = await callMethod<{ user: UserInfo }>('_system.user.loginWithPassword', { email, password });
   setCurrentUser(user);
   return user;
 }
 
+/**
+ * Logout the current user.
+ * 
+ */
 export async function logout() {
   await callMethod('_system.user.logout');
   setCurrentUser(null);

--- a/packages/modelence/src/auth/db.ts
+++ b/packages/modelence/src/auth/db.ts
@@ -8,16 +8,6 @@ import { Store } from '../data/store';
  * 
  * @example
  * ```typescript
- * // Create a new user
- * const result = await dbUsers.insertOne({
- *   handle: 'john_doe',
- *   emails: [{ address: 'john@example.com', verified: false }],
- *   createdAt: new Date(),
- *   authMethods: {
- *     password: { hash: 'hashed_password' }
- *   }
- * });
- * 
  * // Find user by email
  * const user = await dbUsers.findOne(
  *   { 'emails.address': 'john@example.com' }

--- a/packages/modelence/src/client/session.ts
+++ b/packages/modelence/src/client/session.ts
@@ -54,6 +54,19 @@ export function setCurrentUser(user: User | null) {
   useSessionStore.getState().setUser(user);
 }
 
+/**
+ * `useSession` is a hook that returns the current user, and in the future will also return other details about the current session.
+ * 
+ * @example
+ * ```ts
+ * import { useSession } from 'modelence/client';
+ * 
+ * function MyComponent() {
+ *   const { user } = useSession();
+ *   return <div>{user?.handle}</div>;
+ * }
+ * ```
+ */
 export function useSession() {
   const user = useSessionStore(state => state.user);
   return { user };

--- a/packages/modelence/src/rate-limit/rules.ts
+++ b/packages/modelence/src/rate-limit/rules.ts
@@ -12,9 +12,24 @@ export function initRateLimits(rateLimits: RateLimitRule[]) {
   allRules = rateLimits;
 }
 
+/**
+ * This function will check all rate limit rules on the specified bucket and type,
+ * throw an error if any of them are exceeded and increase the count of the rate limit record.
+ * 
+ * @category Rate Limits
+ * 
+ * @example
+ * ```ts
+ * await consumeRateLimit({ bucket: 'api', type: 'ip', value: '127.0.0.1' });
+ * ```
+ * @param options.bucket - The bucket for the rate limit.
+ * @param options.type - The type of the rate limit.
+ * @param options.value - The value for the rate limit.
+ */
 export async function consumeRateLimit(
-  { bucket, type, value }: { bucket: string, type: RateLimitType, value: string }
+  options: { bucket: string, type: RateLimitType, value: string }
 ) {
+  const { bucket, type, value } = options;
   const rules = allRules.filter(rule => rule.bucket === bucket && rule.type === type);
 
   for (const rule of rules) {

--- a/packages/modelence/src/server.ts
+++ b/packages/modelence/src/server.ts
@@ -17,7 +17,7 @@ export { Store } from './data/store';
 export { CronJobInputParams } from './cron/types';
 
 // Rate limits
-export type { RateLimitRule } from './rate-limit/types';
+export type { RateLimitRule, RateLimitType } from './rate-limit/types';
 export { consumeRateLimit } from './rate-limit/rules';
 
 export { getConfig } from './config/server';


### PR DESCRIPTION
Added a missing `Authentication` section to API reference as well as `Rate Limits` that was newly added.

To run docs locally:
- `npm run docs` while in https://github.com/modelence/modelence/tree/main/docs/gen
- `npx mint dev` while in https://github.com/modelence/modelence/tree/main/docs/web
