### PR TITLE
Add modelence config

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -77,6 +77,13 @@ jobs:
       
       - name: Publish to NPM
         working-directory: ./packages/${{ steps.package-info.outputs.package-dir }}
-        run: npm publish
+        run: |
+          if [[ "${{ steps.package-info.outputs.version }}" == *"dev"* ]]; then
+            echo "Publishing dev version without latest tag"
+            npm publish --tag dev
+          else
+            echo "Publishing with latest tag"
+            npm publish
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/auth-ui/package-lock.json
+++ b/packages/auth-ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.12",
       "license": "ISC",
       "dependencies": {
-        "@modelence/react-query": "^1.0.0",
+        "@modelence/react-query": "^1.0.2",
         "clsx": "^2.0.0",
         "tailwind-merge": "^2.0.0"
       },

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@modelence/react-query": "^1.0.0",
+    "@modelence/react-query": "^1.0.2",
     "clsx": "^2.0.0",
     "tailwind-merge": "^2.0.0"
   },

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.6",
+  "version": "0.5.7-dev.1",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/client/config.ts
+++ b/packages/modelence/src/client/config.ts
@@ -1,0 +1,37 @@
+declare global {
+  var modelenceConfig: ModelenceConfig;
+}
+
+function getGlobalObject() {
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  return {
+    modelenceConfig: {} as ModelenceConfig,
+  };
+}
+
+const globalObject = getGlobalObject();
+
+globalObject.modelenceConfig = {};
+
+interface ModelenceConfig {
+  errorHandler?: (error: Error, methodName: string) => void
+}
+
+export function getModelenceConfig() {
+  return globalObject.modelenceConfig;
+}
+
+export function setModelenceConfig(config: ModelenceConfig) {
+  globalObject.modelenceConfig = {
+    ...globalObject.modelenceConfig,
+    ...config,
+  };
+}

--- a/packages/modelence/src/client/errorHandler.ts
+++ b/packages/modelence/src/client/errorHandler.ts
@@ -1,13 +1,16 @@
+import { getModelenceConfig, setModelenceConfig } from "./config";
+
 export type ErrorHandler = (error: Error, methodName: string) => void;
 
-let errorHandler: ErrorHandler = (error, methodName) => {
+let defaultErrorHandler: ErrorHandler = (error, methodName) => {
   throw new Error(`Error calling method '${methodName}': ${error.toString()}`);
 };
 
 export function setErrorHandler(handler: ErrorHandler) {
-  errorHandler = handler;
+  setModelenceConfig({ errorHandler: handler });
 }
 
 export function handleError(error: Error, methodName: string) {
+  const errorHandler = getModelenceConfig().errorHandler || defaultErrorHandler;
   return errorHandler(error, methodName);
 }

--- a/packages/modelence/src/client/errorHandler.ts
+++ b/packages/modelence/src/client/errorHandler.ts
@@ -2,12 +2,12 @@ import { getModelenceConfig, setModelenceConfig } from "./config";
 
 export type ErrorHandler = (error: Error, methodName: string) => void;
 
-let defaultErrorHandler: ErrorHandler = (error, methodName) => {
+const defaultErrorHandler: ErrorHandler = (error, methodName) => {
   throw new Error(`Error calling method '${methodName}': ${error.toString()}`);
 };
 
-export function setErrorHandler(handler: ErrorHandler) {
-  setModelenceConfig({ errorHandler: handler });
+export function setErrorHandler(errorHandler: ErrorHandler) {
+  setModelenceConfig({ errorHandler });
 }
 
 export function handleError(error: Error, methodName: string) {


### PR DESCRIPTION
There is an issue with the configs shared between Modelence and its other packages. At this point, we have handleError, which is set on a local property. When, for some reason, versions do not match, we get multiple versions of the configs, which breaks some of the functionality.

The issue we currently face is that when we link auth-ui to a local version, it installs its own modelence, resulting in two copies of modelence.
