### PR TITLE
Add Startup URL Log on Server Boot

### DIFF
--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -102,7 +102,7 @@ export async function startServer(server: AppServer, { combinedModules }: { comb
   const port = process.env.PORT || 3000;
   httpServer.listen(port, () => {
     logInfo(`Application started`, { source: 'app' });
-    console.log(`Application started on port ${port}`);
+    console.log(`\nApplication started on http://localhost:${port}\n`);
   });
 }
 


### PR DESCRIPTION
While working on the Modelence hackathon project, I kept manually typing the local server URL into my browser. To streamline the development experience, I added a simple console log (like other frameworks such as React, Vite, etc) that prints the full application URL (http://localhost:${port}) when the server starts.

This small but useful addition makes it easier for developers to quickly navigate to the running app from their IDE without typing in the URL.

**Example Output:**
```text
Starting Modelence dev server...
Pinged your deployment. You successfully connected to MongoDB!
Starting Vite dev server...
Application started on http://localhost:3000
```