### PR TITLE
Require also application alias when deploying application to cloud

### DIFF
--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.7",
+  "version": "0.5.7-dev.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.7",
+      "version": "0.5.7-dev.7",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelence/types": "^1.0.2",

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.7-dev.3",
+  "version": "0.5.7-dev.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.7-dev.3",
+      "version": "0.5.7-dev.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelence/types": "^1.0.2",

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.7-dev.5",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.7-dev.5",
+      "version": "0.5.7",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelence/types": "^1.0.2",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.7",
+  "version": "0.5.7-dev.7",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.7-dev.5",
+  "version": "0.5.7",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/bin/config.ts
+++ b/packages/modelence/src/bin/config.ts
@@ -25,11 +25,7 @@ export function getConfig() {
 }
 
 export function getStudioUrl(path: string) {
-  const studioBaseUrl = getEnv().MODELENCE_SERVICE_ENDPOINT;
-  if (!studioBaseUrl) {
-    throw new Error('MODELENCE_SERVICE_ENDPOINT not found in environment variables');
-  }
-
+  const studioBaseUrl = getEnv().MODELENCE_SERVICE_ENDPOINT || 'https://cloud.modelence.com';
   return `${studioBaseUrl}${path}`;
 }
 

--- a/packages/modelence/src/bin/deploy.ts
+++ b/packages/modelence/src/bin/deploy.ts
@@ -98,7 +98,7 @@ async function createBundle(bundlePath: string) {
 }
 
 async function uploadBundle(appAlias: string, envAlias: string, bundlePath: string, token: string) {
-  const response = await fetch(getStudioUrl(`/api/upload`), {
+  const response = await fetch(getStudioUrl(`/api/upload-bundle`), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/modelence/src/bin/modelence.ts
+++ b/packages/modelence/src/bin/modelence.ts
@@ -32,7 +32,8 @@ program
 program
   .command('deploy')
   .description('Deploy to Modelence Cloud')
-  .requiredOption('-e, --env <env>', 'Environment (deployment alias)')
+  .requiredOption('-a, --app <app>', 'Application alias')
+  .requiredOption('-e, --env <env>', 'Environment alias')
   .action(async (options) => {
     await loadEnv();
     await deploy(options);


### PR DESCRIPTION
We should require also application alias when deploying application to cloud. New deployment command will be "npx modelence deploy --app appAlias --env envAlias".
This way we will define application in a unique way and if user will approve the deployment it will be deployed for the correct {application, environment} pair.