### PR TITLE
modelence, auth-ui: Make email verification mandatory

### DIFF
--- a/packages/auth-ui/package-lock.json
+++ b/packages/auth-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelence/auth-ui",
-  "version": "0.1.15-dev.0",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelence/auth-ui",
-      "version": "0.1.15-dev.0",
+      "version": "0.1.15",
       "license": "ISC",
       "dependencies": {
         "@modelence/react-query": "^1.0.0",

--- a/packages/auth-ui/package-lock.json
+++ b/packages/auth-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelence/auth-ui",
-  "version": "0.1.14",
+  "version": "0.1.15-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelence/auth-ui",
-      "version": "0.1.14",
+      "version": "0.1.15-dev.0",
       "license": "ISC",
       "dependencies": {
         "@modelence/react-query": "^1.0.0",

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@modelence/auth-ui",
-  "version": "0.1.15-dev.0",
+  "version": "0.1.15",
   "description": "Authentication UI components for Modelence",
   "exports": {
     ".": {

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@modelence/auth-ui",
-  "version": "0.1.14",
+  "version": "0.1.15-dev.0",
   "description": "Authentication UI components for Modelence",
   "exports": {
     ".": {

--- a/packages/auth-ui/src/components/SignupForm.tsx
+++ b/packages/auth-ui/src/components/SignupForm.tsx
@@ -1,5 +1,5 @@
 import { getConfig, signupWithPassword } from 'modelence/client';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { GoogleIcon } from './icons/GoogleIcon';
 import { Button } from './ui/Button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from './ui/Card';
@@ -83,6 +83,7 @@ export function SignupForm({
   labelClassName = "",
   consents
 }: SignupFormProps) {
+  const [isSignupSuccess, setIsSignupSuccess] = useState(false);
   const isGoogleAuthEnabled = getConfig('_system.user.auth.google.enabled');
 
   const handleSubmit = useCallback(async (event: React.FormEvent<HTMLFormElement>) => {
@@ -98,8 +99,13 @@ export function SignupForm({
       return;
     }
     
-    await signupWithPassword({ email, password });
-  }, []);
+    try {
+      await signupWithPassword({ email, password });
+      setIsSignupSuccess(true);
+    } catch (error) {
+      onError(error as Error);
+    }
+  }, [onError]);
 
   const openGoogleAuth = useCallback(() => {
     window.location.href = '/api/_internal/auth/google';
@@ -123,6 +129,27 @@ export function SignupForm({
     }
     return buttons;
   }, []);
+
+  if (isSignupSuccess) {
+    return (
+      <Card className={`w-full max-w-md mx-auto bg-white dark:bg-gray-900 text-gray-900 dark:text-white ${cardClassName}`}>
+        <CardHeader className="text-center">
+          <CardTitle className="text-xl">
+            Check your email
+          </CardTitle>
+        </CardHeader>
+        
+        <CardContent className="text-center space-y-4">
+          <p className="text-gray-600 dark:text-gray-400">
+            We've sent you a verification email. Please check your inbox and click the verification link to activate your account.
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-500">
+            Don't see the email? Check your spam folder.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card className={`w-full max-w-md mx-auto bg-white dark:bg-gray-900 text-gray-900 dark:text-white ${cardClassName}`}>

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.11-dev.1",
+  "version": "0.5.11-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.11-dev.1",
+      "version": "0.5.11-dev.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelence/types": "^1.0.3",

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.12-dev.0",
+  "version": "0.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.12-dev.0",
+      "version": "0.5.12",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelence/types": "^1.0.3",

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.10",
+  "version": "0.5.11-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.10",
+      "version": "0.5.11-dev.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelence/types": "^1.0.3",

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.11-dev.2",
+  "version": "0.5.12-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.11-dev.2",
+      "version": "0.5.12-dev.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelence/types": "^1.0.3",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.11-dev.1",
+  "version": "0.5.11-dev.2",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.11-dev.0",
+  "version": "0.5.11-dev.1",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.12-dev.0",
+  "version": "0.5.12",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.11-dev.2",
+  "version": "0.5.12-dev.0",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -19,9 +19,6 @@ export type UserInfo = {
 export async function signupWithPassword(options: { email: string, password: string }) {
   const { email, password } = options;
   await callMethod('_system.user.signupWithPassword', { email, password });
-
-  // TODO: handle auto-login from the signup method itself to avoid a second method call
-  await loginWithPassword({ email, password });
 }
 
 /**

--- a/packages/modelence/src/auth/login.ts
+++ b/packages/modelence/src/auth/login.ts
@@ -5,6 +5,7 @@ import { Args, Context } from '../methods/types';
 import { usersCollection } from './db';
 import { clearSessionUser, setSessionUser } from './session';
 import { sendVerificationEmail } from './verification';
+import { getEmailConfig } from '@/app/emailConfig';
 
 export async function handleLoginWithPassword(args: Args, { user, session, connectionInfo }: Context) {
   if (!session) {
@@ -31,12 +32,13 @@ export async function handleLoginWithPassword(args: Args, { user, session, conne
 
   const emailDoc = userDoc?.emails?.find(e => e.address === email);
 
-  if (!emailDoc?.verified) {
+  if (!emailDoc?.verified && getEmailConfig()?.provider) {
     await sendVerificationEmail({
       userId: userDoc?._id,
       email,
       baseUrl: connectionInfo?.baseUrl,
     });
+    throw new Error("Your email address hasn't been verified yet. We've sent a new verification email to your inbox.");
   }
 
   const passwordHash = userDoc.authMethods?.password?.hash;

--- a/packages/modelence/src/auth/login.ts
+++ b/packages/modelence/src/auth/login.ts
@@ -30,7 +30,7 @@ export async function handleLoginWithPassword(args: Args, { user, session, conne
     throw incorrectCredentialsError();
   }
 
-  const emailDoc = userDoc?.emails?.find(e => e.address === email);
+  const emailDoc = userDoc.emails?.find(e => e.address === email);
 
   if (!emailDoc?.verified && getEmailConfig()?.provider) {
     await sendVerificationEmail({

--- a/packages/modelence/src/auth/login.ts
+++ b/packages/modelence/src/auth/login.ts
@@ -47,8 +47,8 @@ export async function handleLoginWithPassword(args: Args, { user, session, conne
       try {
         await consumeRateLimit({
           bucket: 'verification',
-          type: 'ip',
-          value: ip,
+          type: 'user',
+          value: userDoc._id.toString(),
         });
       } catch {
         throw new Error("Your email address hasn't been verified yet. Please use the verification email we've send earlier to your inbox.");

--- a/packages/modelence/src/auth/login.ts
+++ b/packages/modelence/src/auth/login.ts
@@ -36,7 +36,8 @@ export async function handleLoginWithPassword(args: Args, { user, session, conne
     { collation: { locale: 'en', strength: 2 } }
   );
 
-  if (!userDoc) {
+  const passwordHash = userDoc?.authMethods?.password?.hash;
+  if (!passwordHash) {
     throw incorrectCredentialsError();
   }
 
@@ -61,11 +62,6 @@ export async function handleLoginWithPassword(args: Args, { user, session, conne
       baseUrl: connectionInfo?.baseUrl,
     });
     throw new Error("Your email address hasn't been verified yet. We've sent a new verification email to your inbox.");
-  }
-
-  const passwordHash = userDoc.authMethods?.password?.hash;
-  if (!userDoc || !passwordHash) {
-    throw incorrectCredentialsError();
   }
 
   const isValidPassword = await bcrypt.compare(password, passwordHash);

--- a/packages/modelence/src/auth/signup.ts
+++ b/packages/modelence/src/auth/signup.ts
@@ -1,23 +1,11 @@
 import { z } from 'zod';
 import bcrypt from 'bcrypt';
-import { randomBytes } from 'crypto';
 
 import { Args, Context } from '../methods/types';
-import { usersCollection, emailVerificationTokensCollection } from './db';
+import { usersCollection } from './db';
 import { isDisposableEmail } from './disposableEmails';
 import { consumeRateLimit } from '../rate-limit/rules';
-import { getConfig } from '@/server';
-import { getEmailConfig } from '@/app/emailConfig';
-import { time } from '@/time';
-
-function defaultEmailVerificationTemplate({ name, email, verificationUrl }: { name?: string; email: string; verificationUrl: string }) {
-  return `
-    <p>Hi${name ? ` ${name}` : ''},</p>
-    <p>Please verify your email address ${email} by clicking the link below:</p>
-    <p><a href="${verificationUrl}">${verificationUrl}</a></p>
-    <p>If you did not request this, please ignore this email.</p>
-  `;
-}
+import { sendVerificationEmail } from './verification';
 
 export async function handleSignupWithPassword(args: Args, { user, connectionInfo }: Context) {
   const email = z.string().email().parse(args.email);
@@ -71,38 +59,11 @@ export async function handleSignupWithPassword(args: Args, { user, connectionInf
     }
   });
 
-  if (getEmailConfig().provider) {
-    const emailProvider = getEmailConfig().provider;
-    const baseUrl = process.env.MODELENCE_SITE_URL || connectionInfo?.baseUrl;
-
-    // Generate verification token
-    const verificationToken = randomBytes(32).toString('hex');
-    const expiresAt = new Date(Date.now() + time.hours(24));
-
-    // Store token in database
-    await emailVerificationTokensCollection.insertOne({
-      userId: result.insertedId,
-      email,
-      token: verificationToken,
-      createdAt: new Date(),
-      expiresAt,
-    });
-    
-    const verifyUrl = `${baseUrl}/api/_internal/auth/verify-email?token=${verificationToken}`;
-    
-    const template = getEmailConfig()?.verification?.template || defaultEmailVerificationTemplate;
-    // TODO: we should have also the name on this step
-    const htmlTemplate = template({ name: '', email, verificationUrl: verifyUrl });
-    const textContent = htmlTemplate.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
-    
-    await emailProvider?.sendEmail({
-      to: email,
-      from: getEmailConfig()?.from || 'noreply@modelence.com',
-      subject: getEmailConfig()?.verification?.subject || 'Verify your email address',
-      text: textContent,
-      html: htmlTemplate,
-    });
-  }
+  await sendVerificationEmail({
+    userId: result?.insertedId,
+    email,
+    baseUrl: connectionInfo?.baseUrl,
+  });
   
 
   return result.insertedId;

--- a/packages/modelence/src/auth/signup.ts
+++ b/packages/modelence/src/auth/signup.ts
@@ -13,6 +13,15 @@ export async function handleSignupWithPassword(args: Args, { user, connectionInf
     .min(8, { message: 'Password must contain at least 8 characters' })
     .parse(args.password);
 
+  const ip = connectionInfo?.ip;
+  if (ip) {
+    await consumeRateLimit({
+      bucket: 'signup',
+      type: 'ip',
+      value: ip,
+    });
+  }
+
   if (await isDisposableEmail(email)) {
     throw new Error('Please use a permanent email address');
   }
@@ -31,15 +40,6 @@ export async function handleSignupWithPassword(args: Args, { user, connectionInf
   if (existingUser) {
     const existingEmail = existingUser.emails?.find(e => e.address === email);
     throw new Error(`User with email already exists: ${existingEmail?.address}`);
-  }
-
-  const ip = connectionInfo?.ip;
-  if (ip) {
-    await consumeRateLimit({
-      bucket: 'signup',
-      type: 'ip',
-      value: ip,
-    });
   }
 
   // Hash password with bcrypt (salt is automatically generated)

--- a/packages/modelence/src/auth/signup.ts
+++ b/packages/modelence/src/auth/signup.ts
@@ -16,7 +16,7 @@ export async function handleSignupWithPassword(args: Args, { user, connectionInf
   const ip = connectionInfo?.ip;
   if (ip) {
     await consumeRateLimit({
-      bucket: 'signup',
+      bucket: 'signupAttempt',
       type: 'ip',
       value: ip,
     });
@@ -58,6 +58,14 @@ export async function handleSignupWithPassword(args: Args, { user, connectionInf
       }
     }
   });
+
+  if (ip) {
+    await consumeRateLimit({
+      bucket: 'signup',
+      type: 'ip',
+      value: ip,
+    });
+  }
 
   await sendVerificationEmail({
     userId: result?.insertedId,

--- a/packages/modelence/src/auth/signup.ts
+++ b/packages/modelence/src/auth/signup.ts
@@ -42,6 +42,14 @@ export async function handleSignupWithPassword(args: Args, { user, connectionInf
     throw new Error(`User with email already exists: ${existingEmail?.address}`);
   }
 
+  if (ip) {
+    await consumeRateLimit({
+      bucket: 'signup',
+      type: 'ip',
+      value: ip,
+    });
+  }
+
   // Hash password with bcrypt (salt is automatically generated)
   const hash = await bcrypt.hash(password, 10);
 
@@ -58,14 +66,6 @@ export async function handleSignupWithPassword(args: Args, { user, connectionInf
       }
     }
   });
-
-  if (ip) {
-    await consumeRateLimit({
-      bucket: 'signup',
-      type: 'ip',
-      value: ip,
-    });
-  }
 
   await sendVerificationEmail({
     userId: result?.insertedId,

--- a/packages/modelence/src/auth/templates/emailVerficationTemplate.ts
+++ b/packages/modelence/src/auth/templates/emailVerficationTemplate.ts
@@ -1,0 +1,8 @@
+export function emailVerificationTemplate({ name, email, verificationUrl }: { name?: string; email: string; verificationUrl: string }) {
+  return `
+    <p>Hi${name ? ` ${name}` : ''},</p>
+    <p>Please verify your email address ${email} by clicking the link below:</p>
+    <p><a href="${verificationUrl}">${verificationUrl}</a></p>
+    <p>If you did not request this, please ignore this email.</p>
+  `;
+}

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -11,7 +11,7 @@ import { updateDisposableEmailListCron } from './disposableEmails';
 import { handleLoginWithPassword, handleLogout } from './login';
 import { getOwnProfile } from './profile';
 import { handleSignupWithPassword } from './signup';
-import { handleVerifyEmail } from './verifyEmail';
+import { handleVerifyEmail } from './verification';
 
 async function createGuestUser() {
   // TODO: add rate-limiting and captcha handling

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -59,6 +59,26 @@ export default new Module('_system.user', {
     type: 'ip',
     window: time.days(1),
     limit: 200,
+  }, {
+    bucket: 'signin',
+    type: 'ip',
+    window: time.minutes(15),
+    limit: 20,
+  }, {
+    bucket: 'signin',
+    type: 'ip',
+    window: time.days(1),
+    limit: 200,
+  }, {
+    bucket: 'verification',
+    type: 'ip',
+    window: time.minutes(15),
+    limit: 3,
+  }, {
+    bucket: 'verification',
+    type: 'ip',
+    window: time.days(1),
+    limit: 10,
   }],
   configSchema: {
     'auth.email.enabled': {

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -60,23 +60,33 @@ export default new Module('_system.user', {
     window: time.days(1),
     limit: 200,
   }, {
+    bucket: 'signupAttempt',
+    type: 'ip',
+    window: time.minutes(15),
+    limit: 50,
+  }, {
+    bucket: 'signupAttempt',
+    type: 'ip',
+    window: time.days(1),
+    limit: 500,
+  }, {
     bucket: 'signin',
     type: 'ip',
     window: time.minutes(15),
-    limit: 20,
+    limit: 50,
   }, {
     bucket: 'signin',
     type: 'ip',
     window: time.days(1),
-    limit: 200,
+    limit: 500,
   }, {
     bucket: 'verification',
-    type: 'ip',
+    type: 'user',
     window: time.minutes(15),
     limit: 3,
   }, {
     bucket: 'verification',
-    type: 'ip',
+    type: 'user',
     window: time.days(1),
     limit: 10,
   }],

--- a/packages/modelence/src/utils/index.ts
+++ b/packages/modelence/src/utils/index.ts
@@ -7,3 +7,7 @@ export function requireServer() {
     throw new Error('This function can only be called on the server');
   }
 }
+
+export function htmlToText(html: string) {
+  return html.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim()
+}


### PR DESCRIPTION
* Send email verification on sign-up
* Send email verification on sign-in if the email is not verified, and don't allow them to sign in
* If there is no email provider, it allows signing in without confirmation. I think this will work well for the initial setup when the email is not set up yet

<img width="1512" height="757" alt="Screenshot 2025-08-06 at 11 07 52" src="https://github.com/user-attachments/assets/d400e881-144e-46eb-a8fa-ed52cf24621f" />

<img width="1512" height="757" alt="Screenshot 2025-08-06 at 11 16 33" src="https://github.com/user-attachments/assets/5e089dda-8209-4f13-860f-46d4904cde80" />

