### PR TITLE
fix(db): ensure MongoDB Retries to connect db making its connection self healing

### DIFF
--- a/packages/modelence/src/app/index.ts
+++ b/packages/modelence/src/app/index.ts
@@ -13,7 +13,7 @@ import { startConfigSync } from '../config/sync';
 import { AppConfig, ConfigSchema, ConfigType } from '../config/types';
 import cronModule, { defineCronJob, getCronJobsMetadata, startCronJobs } from '../cron/jobs';
 import { Store } from '../data/store';
-import { connect, getClient, getMongodbUri } from '../db/client';
+import { connect,dbEvents, getClient, getMongodbUri } from '../db/client';
 import { _createSystemMutation, _createSystemQuery, createMutation, createQuery } from '../methods';
 import { MigrationScript, default as migrationModule, runMigrations } from '../migration';
 import rateLimitModule from '../rate-limit';
@@ -89,6 +89,7 @@ export async function startApp(
 
   const mongodbUri = getMongodbUri();
   if (mongodbUri) {
+    setupStoreReinitEvent(stores);
     await connect();
     initStores(stores);
   }
@@ -280,4 +281,11 @@ async function getAppDetails() {
       name: 'unknown'
     };
   }
+}
+
+
+function setupStoreReinitEvent(stores: Store<any, any>[]) {
+  dbEvents.on("reconnected", () => {
+    initStores(stores);
+  });
 }

--- a/packages/modelence/src/data/store.ts
+++ b/packages/modelence/src/data/store.ts
@@ -101,7 +101,7 @@ export class Store<
 
   /** @internal */
   init(client: MongoClient) {
-    if (this.collection) {
+    if (this.collection && client === this.client) {
       throw new Error(`Collection ${this.name} is already initialized`);
     }
 

--- a/packages/modelence/src/db/client.ts
+++ b/packages/modelence/src/db/client.ts
@@ -52,10 +52,7 @@ export async function closeConnection() {
     healthCheckInterval = null;
   }
   
-  if (client) {
-    await client.close();
-    client = null;
-  }
+  await closeExistingClientConnection();
   
   reconnecting = false;
 }


### PR DESCRIPTION
Fixed Issue #26 

## With this Update
- Updated `client.ts` to retry connection with mongodb when connection lost.
- Max Retry of 10 Attempts to connect to mongodb
- Verified locally with a test script.

### Testing
- Ran `npx tsx test-db.js` successfully after the change.

test-db.js code below
```
import { connect } from "./src/db/client";

async function run() {
  const client = await connect();
  const db = client.db("testdb");

  setInterval(async () => {
    try {
      await db.command({ ping: 1 });
      console.log("✅ Ping succeeded");
    } catch (err) {
      // console.error("❌ Ping failed", err);
    }
  }, 2000);
}

run();

```

Used Docker to run mongodb locally and connect to `packages/modelence/src/db/client.ts` with custom mongodb URI of docker mongodb

**Test Case 1: Mongodb Is running on docker**
<img width="1021" height="181" alt="Screenshot (159)" src="https://github.com/user-attachments/assets/ae66535f-35ea-48f3-add3-91edee0545d7" />
Succeded✔

**Test Case 2: Mongodb Stopped on docker**
<img width="1214" height="726" alt="Screenshot (160)" src="https://github.com/user-attachments/assets/f62007cb-4ac0-4d85-9dc6-90b2128fee10" />
Succeded✔

**Test Case 3: Mongodb Restart On Docker**
<img width="1230" height="505" alt="Screenshot (161)" src="https://github.com/user-attachments/assets/dac8fc57-e839-464b-9a11-8a1d815a92d9" />
Succeded✔



