### PR TITLE
Vite allowed hosts

### DIFF
--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.17-dev.0",
+  "version": "0.5.17-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.17-dev.0",
+      "version": "0.5.17-dev.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelence/types": "^1.0.3",

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.5.15",
+  "version": "0.5.17-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.5.15",
+      "version": "0.5.17-dev.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelence/types": "^1.0.3",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.17-dev.0",
+  "version": "0.5.17-dev.1",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.5.16",
+  "version": "0.5.17-dev.0",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/viteServer.ts
+++ b/packages/modelence/src/viteServer.ts
@@ -17,6 +17,8 @@ class ViteServer implements AppServer {
         ...defineConfig(this.config),
         server: {
           middlewareMode: true,
+          host: '0.0.0.0',
+          allowedHosts: true,
         },
         root: './src/client'
       }); 
@@ -100,8 +102,6 @@ async function getConfig(): Promise<UserConfig> {
       emptyOutDir: true
     },
     server: {
-      host: '0.0.0.0',
-      allowedHosts: true,
       proxy: {
         '/api': 'http://localhost:4000'
       },

--- a/packages/modelence/src/viteServer.ts
+++ b/packages/modelence/src/viteServer.ts
@@ -65,7 +65,7 @@ async function loadUserViteConfig() {
   }
 }
 
-async function getConfig() {
+async function getConfig(): Promise<UserConfig> {
   const appDir = process.cwd();
   const userConfig = await loadUserViteConfig();
 
@@ -100,6 +100,8 @@ async function getConfig() {
       emptyOutDir: true
     },
     server: {
+      host: '0.0.0.0',
+      allowedHosts: true,
       proxy: {
         '/api': 'http://localhost:4000'
       },


### PR DESCRIPTION
With these changes now we can run projects in dev mode under custom subdomains (needed for sandbox environments like tenant-123.sandbox.modelence.app).