### PR TITLE
fix: add entryPoints and tsconfig to typedoc.json for @modelence/next

### DIFF
--- a/packages/ai/typedoc.json
+++ b/packages/ai/typedoc.json
@@ -2,6 +2,8 @@
   "$schema": "https://typedoc.org/schema.json",
   "readme": "none",
   "excludePrivate": true,
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "./tsconfig.json",
   "excludeInternal": true,
   "exclude": [
     "**/node_modules/**",

--- a/packages/next/package-lock.json
+++ b/packages/next/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@types/express": "^5.0.3",
-        "modelence": "*",
+        "modelence": "^0.6.2",
         "next": "^15.4.6",
         "tsup": "^8.3.6",
         "typescript": "^5.7.2"
@@ -1668,13 +1668,6 @@
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
       }
-    },
-    "node_modules/@modelence/types": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@modelence/types/-/types-1.0.3.tgz",
-      "integrity": "sha512-J2+4M/mhXBEmFrvwF6TqryGfAEZowJ/QLlX2z70oxb0STdVvKY+QrSNYuvvPaoRzAIdW5yU15GwSIBQskdaAGw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.3.1",
@@ -6066,13 +6059,12 @@
       }
     },
     "node_modules/modelence": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/modelence/-/modelence-0.6.0.tgz",
-      "integrity": "sha512-kRebdIOnK+CRkwA6Lm2dBavUg5Tw5n7ZnH+1LpveTWz9pmvjjwR5DSpx7huYDLbUhcI0KmJsPWk4BVUrTAVapA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/modelence/-/modelence-0.6.2.tgz",
+      "integrity": "sha512-kEK68lOluyIH97bXJNqE3wo2WZvfDeZJf/h+RvWp11EvkPPRBRfeGz2525GJu9cxTZ5KLnJjhFC27hFpJ8UmKg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@modelence/types": "^1.0.3",
         "@socket.io/mongo-adapter": "^0.4.0",
         "@vitejs/plugin-react": "^4.3.4",
         "archiver": "^7.0.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/express": "^5.0.3",
-    "modelence": "*",
+    "modelence": "^0.6.2",
     "next": "^15.4.6",
     "tsup": "^8.3.6",
     "typescript": "^5.7.2"

--- a/packages/next/typedoc.json
+++ b/packages/next/typedoc.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "excludePrivate": true,
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "./tsconfig.json",
   "readme": "none",
   "excludeInternal": true,
   "exclude": [


### PR DESCRIPTION
## This PR addresses #24: Typedoc is not generating function docs for @modelence/next

### Changes:

* Added the `entryPoints` and `tsconfig` fields to the `typedoc.json` configuration for the `@modelence/next` package
* Fixes the issue where Typedoc wasn't generating function docs, enabling auto-generation when running npm run docs
---