### PR TITLE
WIP: Remove backend dependencies from the schema

### DIFF
--- a/packages/modelence/src/data/types.ts
+++ b/packages/modelence/src/data/types.ts
@@ -1,6 +1,8 @@
-import { ObjectId } from 'mongodb';
 import { z, ZodArray, ZodNumber } from 'zod';
-import { Store } from './store';
+
+type ObjectId = {
+  toString(): string;
+};
 
 type ObjectTypeDefinition = {
   [key: string]: SchemaTypeDefinition;
@@ -39,16 +41,26 @@ export const schema = {
   embedding(): ZodArray<ZodNumber> {
     return z.array(z.number());
   },
-  objectId(): z.ZodType<ObjectId> {
-    return z.instanceof(ObjectId).describe('ObjectId');
+  objectId(): z.ZodType<string, z.ZodTypeDef, string | ObjectId> {
+    return z
+      .union([
+        z.string().min(24).max(24),
+        z.object({ toString: z.function().returns(z.string()) }).transform((val) => val.toString()),
+      ])
+      .describe('ObjectId');
   },
-  userId(): z.ZodType<ObjectId> {
-    return z.instanceof(ObjectId).describe('UserId');
+  userId(): z.ZodType<string, z.ZodTypeDef, string | ObjectId> {
+    return z
+      .union([
+        z.string().min(24).max(24),
+        z.object({ toString: z.function().returns(z.string()) }).transform((val) => val.toString()),
+      ])
+      .describe('UserId');
   },
-  ref<T extends ModelSchema>(
-    _collection: string | Store<T, InferDocumentType<T>>
-  ): z.ZodType<ObjectId> {
-    return z.instanceof(ObjectId).describe('Ref');
+  ref(
+    _collection: string
+  ): z.ZodType<string> {
+    return z.string().describe('Ref');
   },
   union: z.union.bind(z),
   infer<T extends SchemaTypeDefinition>(_schema: T): InferDocumentType<T> {


### PR DESCRIPTION
The idea here is to remove all backend dependencies from the schema and convert ObjectIds to strings. In this case, we can use the schema to:
1. Validate endpoint inputs (if we define top-level schema as an object, we can use pick on it to filter out specific fields)
2. Use the types on the front-end. It would be helpful if we had a way to subscribe to data, similar to how Meteor did it, and we could make it type-safe.
3. Validate forms on the front-end. We can use the same schema validation on the front-end, and we can pick from zod to validate specific fields.

Breaking changes:
I've removed the option to pass the store to ref, since in this case, we need to make the schema independent.

@artahian @eduard-piliposyan the PR is not finalized, please share your thoughts on this.