### PR TITLE
Better handling for heartbeat errors

### DIFF
--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.6.22",
+      "version": "0.6.23",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@socket.io/mongo-adapter": "^0.4.0",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/client/method.ts
+++ b/packages/modelence/src/client/method.ts
@@ -13,14 +13,20 @@ import { reviveResponseTypes } from '../methods/serialize';
 
 export type MethodArgs = Record<string, unknown>;
 
+export type CallMethodOptions = {
+  errorHandler?: (error: Error, methodName: string) => void;
+};
+
 export async function callMethod<T = unknown>(
   methodName: string,
-  args: MethodArgs = {}
+  args: MethodArgs = {},
+  options: CallMethodOptions = {}
 ): Promise<T> {
   try {
     return await call<T>(`/api/_internal/method/${methodName}`, args);
   } catch (error) {
-    handleError(error as Error, methodName);
+    const handler = options.errorHandler ?? handleError;
+    handler(error as Error, methodName);
     throw error;
   }
 }

--- a/packages/modelence/src/client/session.ts
+++ b/packages/modelence/src/client/session.ts
@@ -71,7 +71,11 @@ export async function initSession() {
 }
 
 async function loopSessionHeartbeat() {
-  await callMethod('_system.session.heartbeat');
+  try {
+    await callMethod('_system.session.heartbeat', {}, { errorHandler: () => {} });
+  } catch {
+    // Silently ignore heartbeat errors - they're expected during HMR/reconnects
+  }
   heartbeatTimer = setTimeout(loopSessionHeartbeat, SESSION_HEARTBEAT_INTERVAL);
 }
 


### PR DESCRIPTION
Sometimes there are strange toasts showing up with these type of contents while making changes to the app code:

<img width="508" height="839" alt="image" src="https://github.com/user-attachments/assets/4857d42a-55fe-4ac0-97a9-1a9aa885299a" />

This is most likely caused by the periodic heartbeat. This PR silences the errors from heartbeat method calls, and adds a way to customize the error handler for method calls in general (previously it was always calling the default error handler in all cases).