### PR TITLE
docs: update Modelence Cloud URL

### DIFF
--- a/docs/web/setup.mdx
+++ b/docs/web/setup.mdx
@@ -3,7 +3,7 @@ title: 'Setup'
 icon: 'gear'
 ---
 
-You can either continue using your Modelence project as it is, or connect it to <a href="https://modelence.com/cloud" target="_blank">Modelence Cloud</a>.
+You can either continue using your Modelence project as it is, or connect it to <a href="https://cloud.modelence.com" target="_blank">Modelence Cloud</a>.
 
 We've built **Modelence Cloud** to seamlessly host and monitor Modelence applications,
 and it's designed for both scalable production apps as well as local development environments.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -41,4 +41,4 @@ The function automatically uses API keys from Modelence configuration:
 - Anthropic: `_system.anthropic.apiKey`
 - Google: `_system.google.apiKey`
 
-You don't need to manually set any of these configs as long as your application is using a [Modelence Cloud](https://modelence.com/cloud) backend - simply use the AI > Integrations tab in your Modelence Cloud dashboard to configure keys, and it will be automatically used and recognized by this package.
+You don't need to manually set any of these configs as long as your application is using a [Modelence Cloud](https://cloud.modelence.com) backend - simply use the AI > Integrations tab in your Modelence Cloud dashboard to configure keys, and it will be automatically used and recognized by this package.


### PR DESCRIPTION
Replaced the deprecated URL [https://modelence.com/cloud](https://modelence.com/cloud) with the new address [https://cloud.modelence.com](https://cloud.modelence.com) in a few locations to ensure links are working correctly.