### PR TITLE
System reads gemini instead of google

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -39,6 +39,6 @@ console.log(response.text);
 The function automatically uses API keys from Modelence configuration:
 - OpenAI: `_system.openai.apiKey`
 - Anthropic: `_system.anthropic.apiKey`
-- Google: `_system.google.apiKey`
+- Google: `_system.gemini.apiKey`
 
 You don't need to manually set any of these configs as long as your application is using a [Modelence Cloud](https://modelence.com/cloud) backend - simply use the AI > Integrations tab in your Modelence Cloud dashboard to configure keys, and it will be automatically used and recognized by this package.

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -40,7 +40,7 @@ function getProviderModel(provider: Provider, model: string) {
     
     case 'google':
       return createGoogleGenerativeAI({
-        apiKey: String(getConfig('_system.google.apiKey')),
+        apiKey: String(getConfig('_system.gemini.apiKey')),
       })(model);
     
     default:


### PR DESCRIPTION
Fixes #164

### What was wrong
- Gemini API key was not being resolved correctly in the runtime configuration
- This caused Modelence AI to fail when calling the Gemini provider

### Changes
- Now System reads `_system.gemini.apiKey` instead of `_system.google.apiKey` 
- Updated README.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted config-key change affecting only Gemini authentication; low risk but could break users relying on the old `_system.google.apiKey` name.
> 
> **Overview**
> Fixes Google/Gemini provider configuration in `@modelence/ai` by changing the Google provider’s API key lookup from `_system.google.apiKey` to `_system.gemini.apiKey`, ensuring Gemini calls can authenticate correctly.
> 
> Updates the README to reflect the corrected configuration key for Google/Gemini.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 603165b3a08baa2160ad23bd5c85245b8036fd2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->