### PR TITLE
Fix npm publish

### DIFF
--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "modelence",
-  "version": "0.11.0-dev.9",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.11.0-dev.9",
+  "version": "0.11.0",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the release pipeline trigger, runtime Node version, and npm publish/auth mechanics (provenance/OIDC), which could break publishing if tag formats or environment assumptions differ.
> 
> **Overview**
> Updates the NPM publish GitHub Action to run on `push` tag events (e.g. `modelence@*` / `@modelence/*@*`) instead of GitHub Releases, and switches tag parsing to use `github.ref_name`.
> 
> Bumps the workflow Node version to `24.x`, adds OIDC `id-token: write` permissions, and publishes with npm provenance enabled (`NPM_CONFIG_PROVENANCE` + `--provenance`). Removes the package-level `packages/modelence/.npmrc` registry override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02871445bbbed805a761e7d3795b9e99f91f6b96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->