### PR TITLE
feat(core): remove MODELENCE_CRON_ENABLED cron flag and always enable cron jobs & migrations

### DIFF
--- a/packages/modelence/src/app/index.ts
+++ b/packages/modelence/src/app/index.ts
@@ -57,7 +57,6 @@ export async function startApp({
   dotenv.config({ path: '.modelence.env' });
 
   const hasRemoteBackend = Boolean(process.env.MODELENCE_SERVICE_ENDPOINT);
-  const isCronEnabled = process.env.MODELENCE_CRON_ENABLED === 'true';
 
   trackAppStart()
     .then(() => {
@@ -91,9 +90,7 @@ export async function startApp({
   const stores = getStores(combinedModules);
   const channels = getChannels(combinedModules);
 
-  if (isCronEnabled) {
-    defineCronJobs(combinedModules);
-  }
+  defineCronJobs(combinedModules);
 
   const rateLimits = getRateLimits(combinedModules);
   initRateLimits(rateLimits);
@@ -102,7 +99,7 @@ export async function startApp({
     const { configs, environmentId, appAlias, environmentAlias, telemetry } =
       await connectCloudBackend({
         configSchema,
-        cronJobsMetadata: isCronEnabled ? getCronJobsMetadata() : undefined,
+        cronJobsMetadata: getCronJobsMetadata(),
         stores,
       });
     loadConfigs(configs);
@@ -124,9 +121,7 @@ export async function startApp({
     initStores(stores);
   }
 
-  if (isCronEnabled) {
-    startMigrations(migrations);
-  }
+  startMigrations(migrations);
 
   if (mongodbUri) {
     for (const store of stores) {
@@ -139,9 +134,7 @@ export async function startApp({
     startConfigSync();
   }
 
-  if (isCronEnabled) {
-    startCronJobs().catch(console.error);
-  }
+  startCronJobs().catch(console.error);
 
   await startServer(server, { combinedModules, channels });
 }

--- a/packages/modelence/src/bin/setup.ts
+++ b/packages/modelence/src/bin/setup.ts
@@ -90,7 +90,6 @@ export async function setup(options: { token: string; host: string }) {
     // Update environment variables
     const newEnv = {
       ...existingEnv,
-      MODELENCE_CRON_ENABLED: 'true',
       MODELENCE_TELEMETRY_ENABLED: 'false', // TODO: Remove after all usages are gone
       MODELENCE_ENVIRONMENT_ID: config.environmentId,
       MODELENCE_SERVICE_ENDPOINT: options.host, // TODO: Replace with config.serviceEndpoint in the future


### PR DESCRIPTION
# Remove MODELENCE_CRON_ENABLED and Always Enable Cron & Migrations

## Overview

This PR removes the `MODELENCE_CRON_ENABLED` flag and makes **cron jobs and migrations always enabled by default**.  
Execution safety is already guaranteed by the existing **database-backed locking mechanism**, so the flag is no longer required.

This change follows the maintainer discussion confirming that locks handle multi-instance correctness.

---

## What Changed

- Removed `MODELENCE_CRON_ENABLED` from:
  - core startup logic
  - setup script
  - tests
- Cron jobs always start
- Migrations always run
- No conditional gating based on environment flags
- Startup behavior simplified and made predictable

---

## Why This Is Safe

The following locks already exist and are correctly used:

| Component | File | Lock |
|---------|------|------|
| Migrations | `migration/index.ts` | `acquireLock('migrations')` |
| Cron Jobs | `cron/jobs.ts` | `acquireLock(...)` |

These ensure:
- Only one instance runs migrations
- Cron jobs do not execute concurrently across instances

---

## Benefits

- Removes configuration foot-guns
- Simplifies deployment and setup
- Aligns with maintainer guidance
- Improves developer experience
- No behavior ambiguity between environments

---

## Context

Related discussion:
- https://github.com/modelence/modelence/issues/180

Maintainer confirmation that flags are no longer required due to locking.


---
@artahian @omegascorp  @eduard-piliposyan 
Thank you 😊

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cron jobs and migrations will now start in all environments, which can change behavior in multi-instance or dev setups if locks/mongo connectivity aren’t as expected.
> 
> **Overview**
> Removes the `MODELENCE_CRON_ENABLED` feature flag and makes startup always register cron jobs, send cron metadata to the cloud backend, run migrations, and start the cron runner in `startApp()`.
> 
> Updates tests and the `setup` script to drop the env var and to assert cron/migration behavior is no longer conditional.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb655fccf3bb29bee83a79a3a90b7812cc904abc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->