### PR TITLE
fix(migrations): ensure lock is released on unexpected errors

### DIFF
--- a/packages/modelence/src/migration/index.test.ts
+++ b/packages/modelence/src/migration/index.test.ts
@@ -113,6 +113,16 @@ describe('migration/index', () => {
     });
   });
 
+  test('releases lock if unexpected error occurs before migration loop', async () => {
+    mockFetch.mockRejectedValue(new Error('db failure') as never);
+
+    await expect(
+      runMigrations([{ version: 1, description: 'one', handler: async () => undefined }])
+    ).rejects.toThrow('db failure');
+
+    expect(mockReleaseLock).toHaveBeenCalledWith('migrations');
+  });
+
   test('startMigrations schedules execution and logs errors', async () => {
     jest.useFakeTimers();
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
# Fix: Ensure Migration Lock Is Always Released

## Overview

This PR ensures that the migration lock is **always released**, even if unexpected errors occur during migration execution.

Previously, `releaseLock('migrations')` was only called at the end of the function. If an unhandled exception occurred before that point (e.g., during DB operations), the lock would remain held until the 30-second stale-lock timeout expired.

This change wraps the migration logic in a `try/finally` block to guarantee immediate lock release.

Fixes #185 

------------------------------------------------------------------------

## Problem

In `packages/modelence/src/migration/index.ts`, migrations acquire a lock using:

``` ts
const hasLock = await acquireLock('migrations');
```

If an unexpected error occurred outside the per-migration `try/catch` (for example in:

-   `dbMigrations.fetch()`
-   `dbMigrations.upsertOne()`
-   or other pre-loop DB operations

the function could exit before reaching `releaseLock('migrations')`.

While the lock auto-expires after 30 seconds, this creates:

-   Temporary blocking of migrations in multi-instance setups
-   Slower failover during DB instability
-   Reliance on timeout instead of deterministic cleanup

------------------------------------------------------------------------

## Solution

Wrap migration execution in a `try/finally` block:

``` ts
try {
  // existing migration logic (unchanged)
} finally {
  await releaseLock('migrations');
}
```

This guarantees:

-   Immediate lock release
-   No behavior change on the happy path
-   Improved reliability during failure scenarios

------------------------------------------------------------------------

## Tests

Added regression test to verify that the lock is released if an
unexpected error occurs before the migration loop.

All existing tests continue to pass.

------------------------------------------------------------------------

## Impact

-   Low risk
-   No functional behavior change
-   Improves failure safety
-   Aligns with proper resource cleanup principles

------------------------------------------------------------------------

Fi

Would be grateful if the team could look at this.
Thanks 😊
@artahian @omegascorp @eduard-piliposyan 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change limited to lock cleanup around migrations; behavior is otherwise unchanged and covered by a new test.
> 
> **Overview**
> Ensures `runMigrations` always releases the `migrations` lock by wrapping all post-acquire work (including pre-loop DB reads) in a `try/finally`, preventing stale locks when unexpected errors occur.
> 
> Adds a regression test that simulates a DB failure before the migration loop and asserts `releaseLock('migrations')` is still called.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c749e705c1451e3b0ff031f8063df9bb117a806d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->