### PR TITLE
fix: make mongodbUri a secret config

### DIFF
--- a/packages/modelence/src/system/index.ts
+++ b/packages/modelence/src/system/index.ts
@@ -2,8 +2,8 @@ import { Module } from '../app/module';
 
 export default new Module('_system', {
   configSchema: {
-    mongodbUrl: {
-      type: 'string',
+    mongodbUri: {
+      type: 'secret',
       isPublic: false,
       default: '',
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Config key rename can break existing deployments until configs are migrated, and changing to `secret` may alter how values are loaded/stored.
> 
> **Overview**
> Updates the `_system` module config schema to replace `mongodbUrl` with `mongodbUri` and changes its type from `string` to `secret`, keeping it non-public.
> 
> This affects how the MongoDB connection setting is stored/handled (now treated as sensitive) and requires consumers/configuration to use the new `mongodbUri` key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99c8f8fb27a2910d0f915444eb684ae68ef557c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->