### PR TITLE
feat(auth): add errorComponent support for OAuth error rendering

### DIFF
--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -1,4 +1,4 @@
-import { AuthErrorProps, AuthSuccessProps, User } from '@/auth/types';
+import { AuthErrorProps, AuthSuccessProps, OAuthErrorInfo, User } from '@/auth/types';
 import { UpdateProfileProps, SignupProps } from '@/methods/types';
 
 type GenerateHandleProps = {
@@ -87,6 +87,7 @@ export type AuthConfig = {
    *   if the provider email is verified.
    */
   oauthAccountLinking?: 'auto' | 'manual';
+  errorComponent?: (props: OAuthErrorInfo) => string;
 };
 
 let authConfig: AuthConfig = Object.freeze({});

--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -87,7 +87,7 @@ export type AuthConfig = {
    *   if the provider email is verified.
    */
   oauthAccountLinking?: 'auto' | 'manual';
-  errorComponent?: (props: OAuthErrorInfo) => string;
+  errorComponent?: (props: OAuthErrorInfo) => string | null | undefined;
 };
 
 let authConfig: AuthConfig = Object.freeze({});

--- a/packages/modelence/src/auth/providers/github.test.ts
+++ b/packages/modelence/src/auth/providers/github.test.ts
@@ -29,6 +29,7 @@ const mockValidateOAuthCode = jest.fn<() => string | null>();
 const mockClearOAuthLinkCookie = jest.fn();
 const mockValidateOAuthStateAndGetMode =
   jest.fn<(req: Request, res: Response, cookieName: string) => string | null>();
+const mockSendOAuthError = jest.fn();
 
 jest.unstable_mockModule('./oauth-common', () => ({
   getRedirectUri: mockGetRedirectUri,
@@ -37,6 +38,7 @@ jest.unstable_mockModule('./oauth-common', () => ({
   validateOAuthCode: mockValidateOAuthCode,
   validateOAuthStateAndGetMode: mockValidateOAuthStateAndGetMode,
   clearOAuthLinkCookie: mockClearOAuthLinkCookie,
+  sendOAuthError: mockSendOAuthError,
 }));
 
 const fetchMock = jest.fn();
@@ -93,8 +95,11 @@ describe('auth/providers/github', () => {
 
     check({} as Request, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(503);
-    expect(res.json).toHaveBeenCalledWith({ error: 'GitHub authentication is not configured' });
+    expect(mockSendOAuthError).toHaveBeenCalledWith(
+      res,
+      503,
+      'GitHub authentication is not configured'
+    );
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -203,11 +208,11 @@ describe('auth/providers/github', () => {
       res
     );
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
-      error:
-        'Unable to retrieve a primary verified email from GitHub. Please ensure your GitHub account has a verified email set as primary.',
-    });
+    expect(mockSendOAuthError).toHaveBeenCalledWith(
+      res,
+      400,
+      'Unable to retrieve a primary verified email from GitHub. Please ensure your GitHub account has a verified email set as primary.'
+    );
     expect(mockHandleOAuthUserAuthentication).not.toHaveBeenCalled();
   });
 
@@ -219,13 +224,12 @@ describe('auth/providers/github', () => {
 
     await handler({ query: {}, cookies: {} } as unknown as Request, res);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Missing authorization code' });
+    expect(mockSendOAuthError).toHaveBeenCalledWith(res, 400, 'Missing authorization code');
   });
 
   test('callback handler returns 400 when state invalid', async () => {
     mockValidateOAuthStateAndGetMode.mockImplementationOnce((req: Request, res: Response) => {
-      res.status(400).json({ error: 'Invalid OAuth state - possible CSRF attack' });
+      mockSendOAuthError(res, 400, 'Invalid OAuth state - possible CSRF attack');
       return null;
     });
     const route = findRoute('/api/_internal/auth/github/callback');
@@ -240,8 +244,11 @@ describe('auth/providers/github', () => {
       res
     );
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid OAuth state - possible CSRF attack' });
+    expect(mockSendOAuthError).toHaveBeenCalledWith(
+      res,
+      400,
+      'Invalid OAuth state - possible CSRF attack'
+    );
   });
 
   test('callback handler responds 500 when token exchange fails', async () => {
@@ -268,8 +275,7 @@ describe('auth/providers/github', () => {
       res
     );
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Authentication failed' });
+    expect(mockSendOAuthError).toHaveBeenCalledWith(res, 500, 'Authentication failed');
     consoleError.mockRestore();
   });
 });

--- a/packages/modelence/src/auth/providers/github.ts
+++ b/packages/modelence/src/auth/providers/github.ts
@@ -16,6 +16,7 @@ import {
   type OAuthUserData,
   clearOAuthLinkCookie,
   validateOAuthStateAndGetMode,
+  sendOAuthError,
 } from './oauth-common';
 
 interface GitHubTokenResponse {
@@ -112,7 +113,7 @@ async function handleGitHubAuthenticationCallback(req: Request, res: Response) {
   const code = validateOAuthCode(req.query.code);
 
   if (!code) {
-    res.status(400).json({ error: 'Missing authorization code' });
+    sendOAuthError(res, 400, 'Missing authorization code');
     return;
   }
 
@@ -143,10 +144,11 @@ async function handleGitHubAuthenticationCallback(req: Request, res: Response) {
         clearOAuthLinkCookie(res);
       }
 
-      res.status(400).json({
-        error:
-          'Unable to retrieve a primary verified email from GitHub. Please ensure your GitHub account has a verified email set as primary.',
-      });
+      sendOAuthError(
+        res,
+        400,
+        'Unable to retrieve a primary verified email from GitHub. Please ensure your GitHub account has a verified email set as primary.'
+      );
       return;
     }
 
@@ -174,7 +176,7 @@ async function handleGitHubAuthenticationCallback(req: Request, res: Response) {
     if (mode === 'link') {
       clearOAuthLinkCookie(res);
     }
-    res.status(500).json({ error: 'Authentication failed' });
+    sendOAuthError(res, 500, 'Authentication failed');
   }
 }
 
@@ -188,7 +190,7 @@ function getRouter(): ExpressRouter {
     const githubClientSecret = String(getConfig('_system.user.auth.github.clientSecret'));
 
     if (!githubEnabled || !githubClientId || !githubClientSecret) {
-      res.status(503).json({ error: 'GitHub authentication is not configured' });
+      sendOAuthError(res, 503, 'GitHub authentication is not configured');
       return;
     }
 

--- a/packages/modelence/src/auth/providers/google.test.ts
+++ b/packages/modelence/src/auth/providers/google.test.ts
@@ -29,6 +29,7 @@ const mockValidateOAuthCode = jest.fn<() => string | null>();
 const mockClearOAuthLinkCookie = jest.fn();
 const mockValidateOAuthStateAndGetMode =
   jest.fn<(req: Request, res: Response, cookieName: string) => string | null>();
+const mockSendOAuthError = jest.fn();
 
 jest.unstable_mockModule('./oauth-common', () => ({
   getRedirectUri: mockGetRedirectUri,
@@ -37,6 +38,7 @@ jest.unstable_mockModule('./oauth-common', () => ({
   validateOAuthCode: mockValidateOAuthCode,
   validateOAuthStateAndGetMode: mockValidateOAuthStateAndGetMode,
   clearOAuthLinkCookie: mockClearOAuthLinkCookie,
+  sendOAuthError: mockSendOAuthError,
 }));
 
 const fetchMock = jest.fn();
@@ -95,8 +97,11 @@ describe('auth/providers/google', () => {
 
     check({} as Request, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(503);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Google authentication is not configured' });
+    expect(mockSendOAuthError).toHaveBeenCalledWith(
+      res,
+      503,
+      'Google authentication is not configured'
+    );
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -192,13 +197,12 @@ describe('auth/providers/google', () => {
 
     await handler({ query: {}, cookies: {} } as unknown as Request, res);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Missing authorization code' });
+    expect(mockSendOAuthError).toHaveBeenCalledWith(res, 400, 'Missing authorization code');
   });
 
   test('callback handler returns 400 when state invalid', async () => {
     mockValidateOAuthStateAndGetMode.mockImplementationOnce((req, res) => {
-      res.status(400).json({ error: 'Invalid OAuth state - possible CSRF attack' });
+      mockSendOAuthError(res, 400, 'Invalid OAuth state - possible CSRF attack');
       return null;
     });
     const route = findRoute('/api/_internal/auth/google/callback');
@@ -213,8 +217,11 @@ describe('auth/providers/google', () => {
       res
     );
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid OAuth state - possible CSRF attack' });
+    expect(mockSendOAuthError).toHaveBeenCalledWith(
+      res,
+      400,
+      'Invalid OAuth state - possible CSRF attack'
+    );
   });
 
   test('callback handler responds 500 when token exchange fails', async () => {
@@ -240,8 +247,7 @@ describe('auth/providers/google', () => {
       res
     );
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Authentication failed' });
+    expect(mockSendOAuthError).toHaveBeenCalledWith(res, 500, 'Authentication failed');
     consoleError.mockRestore();
   });
 });

--- a/packages/modelence/src/auth/providers/google.ts
+++ b/packages/modelence/src/auth/providers/google.ts
@@ -16,6 +16,7 @@ import {
   type OAuthUserData,
   clearOAuthLinkCookie,
   validateOAuthStateAndGetMode,
+  sendOAuthError,
 } from './oauth-common';
 
 interface GoogleTokenResponse {
@@ -81,7 +82,7 @@ async function handleGoogleAuthenticationCallback(req: Request, res: Response) {
   const code = validateOAuthCode(req.query.code);
 
   if (!code) {
-    res.status(400).json({ error: 'Missing authorization code' });
+    sendOAuthError(res, 400, 'Missing authorization code');
     return;
   }
 
@@ -123,7 +124,7 @@ async function handleGoogleAuthenticationCallback(req: Request, res: Response) {
     if (mode === 'link') {
       clearOAuthLinkCookie(res);
     }
-    res.status(500).json({ error: 'Authentication failed' });
+    sendOAuthError(res, 500, 'Authentication failed');
   }
 }
 
@@ -137,7 +138,7 @@ function getRouter(): ExpressRouter {
     const googleClientSecret = String(getConfig('_system.user.auth.google.clientSecret'));
 
     if (!googleEnabled || !googleClientId || !googleClientSecret) {
-      res.status(503).json({ error: 'Google authentication is not configured' });
+      sendOAuthError(res, 503, 'Google authentication is not configured');
       return;
     }
 

--- a/packages/modelence/src/auth/providers/oauth-common.test.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.test.ts
@@ -1000,5 +1000,22 @@ describe('auth/providers/oauth-common', () => {
       expect(res.status).toHaveBeenCalledWith(403);
       expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
     });
+    test('falls back to JSON when errorComponent throws', () => {
+      const mockErrorComponent = jest.fn().mockImplementation(() => {
+        throw new Error('render failed');
+      });
+
+      mockGetAuthConfig.mockReturnValue({ errorComponent: mockErrorComponent });
+
+      moduleExports.sendOAuthError(res, 500, 'Server error');
+
+      expect(mockErrorComponent).toHaveBeenCalledWith({
+        error: 'Server error',
+        statusCode: 500,
+      });
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    });
   });
 });

--- a/packages/modelence/src/auth/providers/oauth-common.test.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.test.ts
@@ -47,6 +47,7 @@ describe('auth/providers/oauth-common', () => {
     status: jest.fn().mockReturnThis(),
     redirect: jest.fn(),
     json: jest.fn(),
+    send: jest.fn(),
   } as unknown as Response;
 
   const req = {} as Request;
@@ -964,6 +965,40 @@ describe('auth/providers/oauth-common', () => {
           error: dbError,
         })
       );
+    });
+  });
+  describe('sendOAuthError', () => {
+    test('returns JSON error when no errorComponent is configured', () => {
+      mockGetAuthConfig.mockReturnValue({});
+
+      moduleExports.sendOAuthError(res, 400, 'Something went wrong');
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Something went wrong' });
+    });
+
+    test('returns HTML when errorComponent is configured', () => {
+      const mockErrorComponent = jest.fn().mockReturnValue('<html><body>Error</body></html>');
+      mockGetAuthConfig.mockReturnValue({ errorComponent: mockErrorComponent });
+      (res as any).send = jest.fn();
+
+      moduleExports.sendOAuthError(res, 500, 'Auth failed');
+
+      expect(mockErrorComponent).toHaveBeenCalledWith({ error: 'Auth failed', statusCode: 500 });
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect((res as any).send).toHaveBeenCalledWith('<html><body>Error</body></html>');
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
+    test('falls back to JSON when errorComponent returns falsy', () => {
+      const mockErrorComponent = jest.fn().mockReturnValue(null);
+      mockGetAuthConfig.mockReturnValue({ errorComponent: mockErrorComponent });
+
+      moduleExports.sendOAuthError(res, 403, 'Forbidden');
+
+      expect(mockErrorComponent).toHaveBeenCalledWith({ error: 'Forbidden', statusCode: 403 });
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
     });
   });
 });

--- a/packages/modelence/src/auth/providers/oauth-common.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.ts
@@ -27,8 +27,12 @@ export function sendOAuthError(res: Response, statusCode: number, errorMessage: 
   const authConfig = getAuthConfig();
   const response = res.status(statusCode);
   if (authConfig.errorComponent) {
-    const html = authConfig.errorComponent({ error: errorMessage, statusCode });
-    if (html) return response.send(html);
+    try {
+      const html = authConfig.errorComponent({ error: errorMessage, statusCode });
+      if (html) return response.send(html);
+    } catch (err) {
+      console.error('Unhandled error in authConfig.errorComponent:', err);
+    }
   }
   return response.json({ error: errorMessage });
 }

--- a/packages/modelence/src/auth/providers/oauth-common.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.ts
@@ -18,6 +18,20 @@ export interface OAuthUserData {
   lastName?: string;
   avatarUrl?: string;
 }
+/*
+ * Sends OAuth error response.
+ * If `errorComponent` is configured, renders HTML.
+ * Otherwise falls back to JSON.
+ */
+export function sendOAuthError(res: Response, statusCode: number, errorMessage: string) {
+  const authConfig = getAuthConfig();
+  const response = res.status(statusCode);
+  if (authConfig.errorComponent) {
+    const html = authConfig.errorComponent({ error: errorMessage, statusCode });
+    if (html) return response.send(html);
+  }
+  return response.json({ error: errorMessage });
+}
 
 export async function authenticateUser(res: Response, userId: ObjectId) {
   const { authToken } = await createSession(userId);
@@ -43,9 +57,7 @@ async function handleExistingProviderLogin(
 
   try {
     if (existingUser.status === 'disabled' || existingUser.status === 'deleted') {
-      res.status(400).json({
-        error: 'User account is not active.',
-      });
+      sendOAuthError(res, 400, 'User account is not active.');
       return;
     }
 
@@ -104,9 +116,7 @@ async function handleExistingEmailLogin(
 
   if (linkingMode === 'auto' && userData.emailVerified) {
     if (existingUserByEmail.status === 'disabled' || existingUserByEmail.status === 'deleted') {
-      res.status(400).json({
-        error: 'User account is not active.',
-      });
+      sendOAuthError(res, 400, 'User account is not active.');
       return;
     }
 
@@ -116,9 +126,7 @@ async function handleExistingEmailLogin(
 
     // Prevent pre-registration takeover by requiring local ownership verification too.
     if (!matchedEmail?.verified) {
-      res.status(400).json({
-        error: 'User with this email already exists. Please log in instead.',
-      });
+      sendOAuthError(res, 400, 'User with this email already exists. Please log in instead.');
       return;
     }
 
@@ -155,9 +163,7 @@ async function handleExistingEmailLogin(
 
       if (!autoLinkSuccessful) {
         // User was deleted/disabled between findOne and updateOne, or linked to a *different* ID
-        res.status(400).json({
-          error: 'User with this email already exists. Please log in instead.',
-        });
+        sendOAuthError(res, 400, 'User with this email already exists. Please log in instead.');
         return;
       }
 
@@ -200,10 +206,7 @@ async function handleExistingEmailLogin(
   }
 
   // Manual mode (default) or unverified email — reject
-  // TODO: handle case with an HTML page
-  res.status(400).json({
-    error: 'User with this email already exists. Please log in instead.',
-  });
+  sendOAuthError(res, 400, 'User with this email already exists. Please log in instead.');
   return;
 }
 
@@ -308,9 +311,11 @@ export async function handleOAuthUserAuthentication(
 
   // 2. Validate Email is provided by Provider
   if (!userData.email) {
-    res.status(400).json({
-      error: `Email address is required for ${userData.providerName} authentication.`,
-    });
+    sendOAuthError(
+      res,
+      400,
+      `Email address is required for ${userData.providerName} authentication.`
+    );
     return;
   }
 
@@ -378,7 +383,7 @@ export function validateOAuthStateAndGetMode(
   const [storedStateValue, storedMode] = (storedState || '').split(':');
 
   if (!state || !storedState || state !== storedStateValue) {
-    res.status(400).json({ error: 'Invalid OAuth state - possible CSRF attack' });
+    sendOAuthError(res, 400, 'Invalid OAuth state - possible CSRF attack');
     return null;
   }
 
@@ -396,9 +401,7 @@ export async function handleOAuthProviderLink(
 
   if (!session?.userId) {
     clearOAuthLinkCookie(res);
-    res.status(401).json({
-      error: 'You must be signed in to link a provider.',
-    });
+    sendOAuthError(res, 401, 'You must be signed in to link a provider.');
     return;
   }
 
@@ -439,7 +442,7 @@ export async function handleOAuthProviderLink(
 
         clearOAuthLinkCookie(res);
 
-        res.status(400).json({ error: 'User account is not active.' });
+        sendOAuthError(res, 400, 'User account is not active.');
         return;
       }
 
@@ -460,10 +463,11 @@ export async function handleOAuthProviderLink(
 
         clearOAuthLinkCookie(res);
 
-        res.status(400).json({
-          error: `You have already linked a different ${userData.providerName} account.`,
-        });
-
+        sendOAuthError(
+          res,
+          400,
+          `You have already linked a different ${userData.providerName} account.`
+        );
         return;
       }
 
@@ -479,10 +483,7 @@ export async function handleOAuthProviderLink(
 
       clearOAuthLinkCookie(res);
 
-      res.status(400).json({
-        error: `Unable to link ${userData.providerName} account.`,
-      });
-
+      sendOAuthError(res, 400, `Unable to link ${userData.providerName} account.`);
       return;
     }
 
@@ -519,10 +520,11 @@ export async function handleOAuthProviderLink(
 
       clearOAuthLinkCookie(res);
 
-      res.status(400).json({
-        error: `This ${userData.providerName} account is already linked to a different user.`,
-      });
-
+      sendOAuthError(
+        res,
+        400,
+        `This ${userData.providerName} account is already linked to a different user.`
+      );
       return;
     }
 

--- a/packages/modelence/src/auth/types.ts
+++ b/packages/modelence/src/auth/types.ts
@@ -110,3 +110,8 @@ export type AuthErrorProps = {
   session: Session | null;
   connectionInfo: ConnectionInfo;
 };
+
+export type OAuthErrorInfo = {
+  error: string;
+  statusCode: number;
+};


### PR DESCRIPTION
# Add errorComponent support for OAuth error rendering

## Summary

This PR introduces support for a customizable `errorComponent` in `AuthConfig` to improve how OAuth errors are rendered.

Previously, all OAuth errors were returned as raw JSON responses, which resulted in poor user experience when viewed in a browser.

With this change, developers can optionally provide an `errorComponent` function to render user-friendly HTML for OAuth errors.

------------------------------------------------------------------------

## Changes

-   Added `errorComponent` to `AuthConfig`:

    ``` ts
    errorComponent?: (props: { error: string; statusCode: number }) => string;
    ```

-   Implemented `sendOAuthError` helper:

    -   Renders HTML using `errorComponent` if provided
    -   Falls back to JSON response otherwise (backward compatible)

-   Replaced all OAuth error responses:

    -   `google.ts`
    -   `github.ts`
    -   `oauth-common.ts`

-   Removed outdated TODO related to HTML error handling

------------------------------------------------------------------------

## Behavior

### Without `errorComponent`

``` json
{ "error": "Authentication failed" }
```

### With `errorComponent`

Custom HTML response:

``` html
<html>
  <body>
    <h1>Error 500</h1>
    <p>Authentication failed</p>
  </body>
</html>
```

------------------------------------------------------------------------

## Example Usage

``` ts
startApp({
  auth: {
    errorComponent: ({ error, statusCode }) => `
      <html>
        <body>
          <h1>Error ${statusCode}</h1>
          <p>${error}</p>
        </body>
      </html>
    `,
  },
});
```

------------------------------------------------------------------------

## Tests

Added unit tests for `sendOAuthError`: - JSON fallback when `errorComponent` is not provided - HTML rendering when `errorComponent` is provided - Fallback when `errorComponent` returns falsy value

All existing tests pass without modification.

------------------------------------------------------------------------

## Backward Compatibility

This change is fully backward compatible: - If `errorComponent` is not provided, existing JSON error responses remain unchanged.

------------------------------------------------------------------------

## Notes

-   `errorComponent` is responsible for safely rendering or escaping the
    error message to prevent XSS vulnerabilities.

Closes #199 

Would be grateful if the team could look at this.
Thank you 😊
@artahian @omegascorp @eduard-piliposyan


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth/authentication error-handling paths and changes response format from JSON to optional HTML, which could affect clients and introduces potential XSS risk if custom renderers don’t escape input.
> 
> **Overview**
> **OAuth error responses are now customizable.** `AuthConfig` gains an optional `errorComponent` (taking `OAuthErrorInfo`) to render OAuth errors as HTML instead of always returning JSON.
> 
> A new `sendOAuthError` helper in `oauth-common` centralizes OAuth error responses (HTML when configured; JSON fallback on missing/falsy/throwing renderer), and GitHub/Google provider routes plus shared OAuth flows now use it for all error cases. Tests were updated and expanded to cover the new helper and to assert providers call `sendOAuthError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a39b298b1406bad222ba9aec5dcf318df51ce21b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->