### PR TITLE
docs(auth): add errorComponent documentation for OAuth error rendering

### DIFF
--- a/docs/web/authentication/hooks.mdx
+++ b/docs/web/authentication/hooks.mdx
@@ -129,6 +129,34 @@ startApp({
 });
 ```
 
+## Error Rendering
+
+### `errorComponent`
+
+Use `errorComponent` to customize how OAuth authentication errors are rendered. 
+
+By default, OAuth errors are returned as JSON. Providing `errorComponent` allows you to return a custom HTML response instead. 
+
+This is useful when OAuth flows are triggered in a browser context.
+
+```typescript
+startApp({
+  auth: {
+    errorComponent: ({ error, statusCode }) => {
+      // ⚠️ Ensure proper escaping to avoid XSS vulnerabilities
+      return `
+        <html>
+          <body>
+            <h1>Error ${statusCode}</h1>
+            <p>${error}</p>
+          </body>
+        </html>
+      `;
+    },
+  },
+});
+```
+
 ## Full Example
 
 ```typescript
@@ -151,6 +179,9 @@ startApp({
         return `${firstName}-${lastName}`.toLowerCase();
       }
       return email.split('@')[0];
+    },
+    errorComponent: ({ error, statusCode }) => {
+      return `<html><body><h1>Error ${statusCode}</h1><p>${error}</p></body></html>`;
     },
     onAfterSignup: ({ user }) => {
       console.log('Welcome!', user.handle);

--- a/docs/web/authentication/hooks.mdx
+++ b/docs/web/authentication/hooks.mdx
@@ -144,14 +144,14 @@ startApp({
   auth: {
     errorComponent: ({ error, statusCode }) => {
       // Safely escape the error string to prevent XSS vulnerabilities
-      const escapeHtml = (str: string) => str.replace(/[&<>"']/g, m => ({
+      const escapeHtml = (str: string | number) => String(str).replace(/[&<>"']/g, m => ({
         '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;'
       })[m as any] || m);
 
       return `
         <html>
           <body>
-            <h1>Error ${statusCode}</h1>
+            <h1>Error ${escapeHtml(statusCode)}</h1>
             <p>${escapeHtml(error)}</p>
           </body>
         </html>
@@ -185,10 +185,10 @@ startApp({
       return email.split('@')[0];
     },
     errorComponent: ({ error, statusCode }) => {
-      const escapeHtml = (str: string) => str.replace(/[&<>"']/g, m => ({
+      const escapeHtml = (str: string | number) => String(str).replace(/[&<>"']/g, m => ({
         '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;'
       })[m as any] || m);
-      return `<html><body><h1>Error ${statusCode}</h1><p>${escapeHtml(error)}</p></body></html>`;
+      return `<html><body><h1>Error ${escapeHtml(statusCode)}</h1><p>${escapeHtml(error)}</p></body></html>`;
     },
     onAfterSignup: ({ user }) => {
       console.log('Welcome!', user.handle);

--- a/docs/web/authentication/hooks.mdx
+++ b/docs/web/authentication/hooks.mdx
@@ -143,12 +143,16 @@ This is useful when OAuth flows are triggered in a browser context.
 startApp({
   auth: {
     errorComponent: ({ error, statusCode }) => {
-      // ⚠️ Ensure proper escaping to avoid XSS vulnerabilities
+      // Safely escape the error string to prevent XSS vulnerabilities
+      const escapeHtml = (str: string) => str.replace(/[&<>"']/g, m => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;'
+      })[m as any] || m);
+
       return `
         <html>
           <body>
             <h1>Error ${statusCode}</h1>
-            <p>${error}</p>
+            <p>${escapeHtml(error)}</p>
           </body>
         </html>
       `;
@@ -181,7 +185,10 @@ startApp({
       return email.split('@')[0];
     },
     errorComponent: ({ error, statusCode }) => {
-      return `<html><body><h1>Error ${statusCode}</h1><p>${error}</p></body></html>`;
+      const escapeHtml = (str: string) => str.replace(/[&<>"']/g, m => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;'
+      })[m as any] || m);
+      return `<html><body><h1>Error ${statusCode}</h1><p>${escapeHtml(error)}</p></body></html>`;
     },
     onAfterSignup: ({ user }) => {
       console.log('Welcome!', user.handle);

--- a/docs/web/authentication/index.mdx
+++ b/docs/web/authentication/index.mdx
@@ -13,7 +13,7 @@ Modelence authentication includes:
 - **[User Management](/authentication/user-management)** - User profile and role management
 - **[Email Verification](/authentication/email-verification)** - Optional email verification for new signups
 - **[Password Reset](/authentication/password-reset)** - Secure password reset flow with email tokens
-- **[Hooks](/authentication/hooks)** - Add custom handlers that run after login or signup
+- **[Hooks](/authentication/hooks)** - Add custom handlers and error rendering components for your authentication flow
 - **[Rate Limiting](/authentication/rate-limiting)** - Built-in protection against brute force attacks
 - **[Google Sign-In](/authentication/google-sign-in)** - OAuth authentication with Google accounts
 


### PR DESCRIPTION
# docs(auth): add errorComponent documentation for OAuth error rendering

## Summary

Adds documentation for the `errorComponent` option introduced for customizing OAuth error rendering.

## Related

- Issue: https://github.com/modelence/modelence/issues/199
- Implementation PR: https://github.com/modelence/modelence/pull/232

## Changes

- Added `errorComponent` section under authentication hooks
- Included usage example demonstrating custom HTML rendering
- Documented props (`error`, `statusCode`)
- Updated full authentication example to include `errorComponent`
- Updated authentication overview to reflect error rendering support

## Why

By default, OAuth errors are returned as JSON. This change improves developer experience by allowing custom HTML rendering, especially useful in browser-based OAuth flows.

## Notes

- Includes guidance on safely escaping error content to prevent XSS vulnerabilities

Would be grateful if the team could look at this.
Thank you 😊
@artahian @omegascorp @eduard-piliposyan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior or APIs are modified in this PR.
> 
> **Overview**
> Adds a new **Error Rendering** section to `docs/web/authentication/hooks.mdx` documenting the `auth.errorComponent` hook for returning custom HTML when OAuth flows error, including an example that escapes error content to avoid XSS.
> 
> Updates the authentication overview (`docs/web/authentication/index.mdx`) to note that hooks can also be used for *error rendering*, and extends the full auth configuration example to include `errorComponent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ad074e08bbf7eaae1b3ce52c5df2b9ab4dc0709. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->