### PR TITLE
fix: add maximum password length to prevent DoS via large payloads

### DIFF
--- a/packages/modelence/src/auth/validators.ts
+++ b/packages/modelence/src/auth/validators.ts
@@ -61,8 +61,12 @@ export function validateProfileFields(
 export function validatePassword(value: string) {
   return z
     .string()
-    .min(MIN_PASSWORD_LENGTH, { message: `Password must contain at least ${MIN_PASSWORD_LENGTH} characters` })
-    .max(MAX_PASSWORD_LENGTH, { message: `Password must be at most ${MAX_PASSWORD_LENGTH} characters` })
+    .min(MIN_PASSWORD_LENGTH, {
+      message: `Password must contain at least ${MIN_PASSWORD_LENGTH} characters`,
+    })
+    .max(MAX_PASSWORD_LENGTH, {
+      message: `Password must be at most ${MAX_PASSWORD_LENGTH} characters`,
+    })
     .parse(value);
 }
 

--- a/packages/modelence/src/auth/validators.ts
+++ b/packages/modelence/src/auth/validators.ts
@@ -4,6 +4,9 @@ import { UpdateProfileProps } from '../methods/types';
 export const MIN_HANDLE_LENGTH = 3;
 export const MAX_HANDLE_LENGTH = 50;
 
+export const MIN_PASSWORD_LENGTH = 8;
+export const MAX_PASSWORD_LENGTH = 128;
+
 // Reusable string validators
 const trimmedNonEmptyString = (opts: { min?: number; max: number }) =>
   z
@@ -56,7 +59,11 @@ export function validateProfileFields(
 }
 
 export function validatePassword(value: string) {
-  return z.string().min(8, { message: 'Password must contain at least 8 characters' }).parse(value);
+  return z
+    .string()
+    .min(MIN_PASSWORD_LENGTH, { message: `Password must contain at least ${MIN_PASSWORD_LENGTH} characters` })
+    .max(MAX_PASSWORD_LENGTH, { message: `Password must be at most ${MAX_PASSWORD_LENGTH} characters` })
+    .parse(value);
 }
 
 export function validateEmail(value: string) {


### PR DESCRIPTION
## Summary

Adds a max password length of 128 characters to `validatePassword()` in `validators.ts`.

## Problem

The password validator only enforced a minimum of 8 characters with no upper bound. An attacker could submit an extremely large password to the reset-password or signup endpoints, forcing the server to buffer and process an oversized request body before it reaches bcrypt. While bcrypt itself truncates at 72 bytes, the memory/CPU cost of receiving and parsing the payload could be used for denial-of-service.

## Changes

- Added `MAX_PASSWORD_LENGTH = 128` constant
- Added `.max(MAX_PASSWORD_LENGTH)` to the zod schema in `validatePassword()`
- Exported both `MIN_PASSWORD_LENGTH` and `MAX_PASSWORD_LENGTH` constants for use by client-side validation

## Testing

Existing test coverage for `validatePassword` should be extended to cover the new max-length rejection.