### PR TITLE
Add max length validation for email addresses

### DIFF
--- a/packages/modelence/src/auth/validators.test.ts
+++ b/packages/modelence/src/auth/validators.test.ts
@@ -3,6 +3,7 @@ import {
   validatePassword,
   validateHandle,
   validateProfileFields,
+  MAX_EMAIL_LENGTH,
 } from './validators';
 
 describe('auth/validators', () => {
@@ -45,6 +46,28 @@ describe('auth/validators', () => {
 
     test('should handle edge cases', () => {
       expect(validateEmail('a@b.co')).toBe('a@b.co');
+    });
+
+    test('should accept email at exactly max length', () => {
+      // Build an email that is exactly MAX_EMAIL_LENGTH (254) characters
+      // Format: <local>@<domain>.com — domain part needs to be valid
+      const domain = 'example.com';
+      const atAndDomain = `@${domain}`;
+      const localPart = 'a'.repeat(MAX_EMAIL_LENGTH - atAndDomain.length);
+      const email = `${localPart}${atAndDomain}`;
+      expect(email.length).toBe(MAX_EMAIL_LENGTH);
+      expect(validateEmail(email)).toBe(email);
+    });
+
+    test('should throw error for email exceeding max length', () => {
+      const domain = 'example.com';
+      const atAndDomain = `@${domain}`;
+      const localPart = 'a'.repeat(MAX_EMAIL_LENGTH - atAndDomain.length + 1);
+      const email = `${localPart}${atAndDomain}`;
+      expect(email.length).toBe(MAX_EMAIL_LENGTH + 1);
+      expect(() => validateEmail(email)).toThrow(
+        `Email must be at most ${MAX_EMAIL_LENGTH} characters`
+      );
     });
   });
 

--- a/packages/modelence/src/auth/validators.ts
+++ b/packages/modelence/src/auth/validators.ts
@@ -7,6 +7,8 @@ export const MAX_HANDLE_LENGTH = 50;
 export const MIN_PASSWORD_LENGTH = 8;
 export const MAX_PASSWORD_LENGTH = 128;
 
+export const MAX_EMAIL_LENGTH = 254;
+
 // Reusable string validators
 const trimmedNonEmptyString = (opts: { min?: number; max: number }) =>
   z
@@ -71,7 +73,14 @@ export function validatePassword(value: string) {
 }
 
 export function validateEmail(value: string) {
-  return z.string().email({ message: 'Invalid email address' }).parse(value).toLowerCase();
+  return z
+    .string()
+    .max(MAX_EMAIL_LENGTH, {
+      message: `Email must be at most ${MAX_EMAIL_LENGTH} characters`,
+    })
+    .email({ message: 'Invalid email address' })
+    .parse(value)
+    .toLowerCase();
 }
 
 export function validateHandle(value: string) {


### PR DESCRIPTION
## Summary

The `validateEmail` function in `validators.ts` only checked email format via Zod's `.email()` but had **no max length constraint**, allowing arbitrarily long strings to pass validation. This affects signup, login, and password reset flows.

## Changes

**`validators.ts`**
- Added `MAX_EMAIL_LENGTH = 254` constant (per RFC 5321 max email address length)
- Chained `.max(MAX_EMAIL_LENGTH)` before `.email()` in `validateEmail`

**`validators.test.ts`**
- Added test for email at exactly 254 characters (boundary, should pass)
- Added test for email at 255 characters (should reject with clear error message)
- Imported `MAX_EMAIL_LENGTH` to keep tests in sync with the constant

## Context

This is the same class of issue as the password max-length fix in PR #241 — missing upper-bound validation on user input that gets stored in the database. The 254-character limit is the standard defined by RFC 5321 for a complete email address (64 local + 1 `@` + 253 domain, but the total path must not exceed 254).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple length constraint to `validateEmail` plus boundary tests; main impact is rejecting previously-accepted overlong emails during auth flows.
> 
> **Overview**
> Adds a **254-character maximum** to `validateEmail` via new `MAX_EMAIL_LENGTH`, returning a clear error when exceeded.
> 
> Updates `validators.test.ts` to import `MAX_EMAIL_LENGTH` and adds boundary tests to ensure emails at the limit pass and emails over the limit fail with the expected message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b95439ea104a4d39e324020c41ff4782d6be3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->