### PR TITLE
fix(db): types in dot notation queries

### DIFF
--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@socket.io/mongo-adapter": "^0.4.0",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/data/store.test.ts
+++ b/packages/modelence/src/data/store.test.ts
@@ -50,6 +50,57 @@ function assertFetchOptionTypeSafety() {
 }
 void assertFetchOptionTypeSafety;
 
+function assertExtendedStoreDotNotationTypeSafety() {
+  const baseStore = new Store('baseStore', {
+    schema: {
+      name: schema.string(),
+      meta: schema
+        .object({
+          active: schema.boolean(),
+        })
+        .optional(),
+    },
+    indexes: [],
+    methods: undefined,
+  });
+
+  const extendedStore = baseStore.extend({
+    schema: {
+      integrations: schema
+        .object({
+          resend: schema
+            .object({
+              id: schema.string().optional(),
+              syncStatus: schema.enum(['success', 'error']),
+              syncedAt: schema.date(),
+            })
+            .optional(),
+        })
+        .optional(),
+    },
+  });
+
+  // Dot-notation paths must be accepted in filter queries on extended stores
+  extendedStore.findOne({ 'integrations.resend.syncStatus': 'success' });
+  extendedStore.fetch({
+    'integrations.resend.syncStatus': 'error',
+    $or: [
+      { 'integrations.resend.id': { $exists: false } },
+      { 'integrations.resend.syncedAt': { $lte: new Date() } },
+    ],
+  });
+
+  // Dot-notation paths must be accepted in $set updates on extended stores
+  extendedStore.updateOne('someId', {
+    $set: {
+      'integrations.resend.id': 'abc',
+      'integrations.resend.syncStatus': 'success',
+      'integrations.resend.syncedAt': new Date(),
+    },
+  });
+}
+void assertExtendedStoreDotNotationTypeSafety;
+
 describe('data/store', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/modelence/src/data/store.ts
+++ b/packages/modelence/src/data/store.ts
@@ -514,12 +514,8 @@ export class Store<
     /** Whether index creation should block startup or run in background */
     indexCreationMode?: IndexCreationMode;
   }): Store<
-    TSchema & TExtendedSchema & Record<string, unknown>,
-    PreserveMethodsForExtendedSchema<
-      TMethods,
-      TSchema & TExtendedSchema & Record<string, unknown>
-    > &
-      TExtendedMethods
+    TSchema & TExtendedSchema,
+    PreserveMethodsForExtendedSchema<TMethods, TSchema & TExtendedSchema> & TExtendedMethods
   > {
     // Follow chain to the tail – extending always appends to the end
     const tail: AnyStore = this.getChainTail();
@@ -530,18 +526,17 @@ export class Store<
       );
     }
 
+    type ExtendedSchema = TSchema & TExtendedSchema;
+
     const extendedSchema = {
       ...tail.schema,
       ...(config.schema || {}),
-    } as TSchema & TExtendedSchema & Record<string, unknown>;
+    } as ExtendedSchema;
 
     const extendedIndexes = [...tail.indexes, ...(config.indexes || [])];
     const extendedSearchIndexes = [...tail.searchIndexes, ...(config.searchIndexes || [])];
 
-    type CombinedMethods = PreserveMethodsForExtendedSchema<
-      TMethods,
-      TSchema & TExtendedSchema & Record<string, unknown>
-    > &
+    type CombinedMethods = PreserveMethodsForExtendedSchema<TMethods, ExtendedSchema> &
       TExtendedMethods;
 
     const combinedMethods = {
@@ -549,10 +544,7 @@ export class Store<
       ...(config.methods || {}),
     } as CombinedMethods | undefined;
 
-    const extendedStore = new Store<
-      TSchema & TExtendedSchema & Record<string, unknown>,
-      CombinedMethods
-    >(this.name, {
+    const extendedStore = new Store<ExtendedSchema, CombinedMethods>(this.name, {
       schema: extendedSchema,
       methods: combinedMethods as unknown as CombinedMethods | undefined,
       indexes: extendedIndexes,


### PR DESCRIPTION
* fix types in dot notation queries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes to `Store.extend()`’s generics could affect downstream TypeScript inference/compilation, but there is no runtime behavior change and coverage is added via type-level tests.
> 
> **Overview**
> Fixes TypeScript typing for dot-notation queries/updates on `Store` instances created via `store.extend()` by tightening the extended schema type (removing the extra `Record<string, unknown>` widening).
> 
> Adds compile-time type assertions in `store.test.ts` to ensure extended stores accept dot-notation paths in filters and `$set` updates.
> 
> Bumps the `modelence` package version to `0.15.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b42cffaf5f7100b0e176098037bafb605274ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->