### PR TITLE
feat(auth): make authentication rate limits configurable via AuthConfig

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/usr/bin/env sh
 cd packages/modelence && npx lint-staged

--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -1,6 +1,63 @@
 import { AuthErrorProps, AuthSuccessProps, User } from '@/auth/types';
 import { UpdateProfileProps, SignupProps } from '@/methods/types';
 
+/**
+ * Per-action rate limit overrides for authentication endpoints.
+ * Every field is optional — omitting it keeps the built-in default.
+ *
+ * @example
+ * ```typescript
+ * startApp({
+ *   auth: {
+ *     rateLimits: {
+ *       signup: { perIp15Minutes: 5, perIpPerDay: 50 },
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export type AuthRateLimitsConfig = {
+  /** Per-IP limits for the signup endpoint (successful signups only). */
+  signup?: {
+    /** Max signups per IP in a 15-minute window. @default 20 */
+    perIp15Minutes?: number;
+    /** Max signups per IP per day. @default 200 */
+    perIpPerDay?: number;
+  };
+  /** Per-IP limits for signup attempts (checked before duplicate detection). */
+  signupAttempt?: {
+    /** Max signup attempts per IP in a 15-minute window. @default 50 */
+    perIp15Minutes?: number;
+    /** Max signup attempts per IP per day. @default 500 */
+    perIpPerDay?: number;
+  };
+  /** Per-IP limits for login attempts. */
+  signin?: {
+    /** Max login attempts per IP in a 15-minute window. @default 50 */
+    perIp15Minutes?: number;
+    /** Max login attempts per IP per day. @default 500 */
+    perIpPerDay?: number;
+  };
+  /** Per-user limits for email verification requests. */
+  verification?: {
+    /** Max verification emails per user per minute. @default 1 */
+    perUserPerMinute?: number;
+    /** Max verification emails per user per day. @default 10 */
+    perUserPerDay?: number;
+  };
+  /** Rate limits for password reset requests. */
+  passwordReset?: {
+    /** Max password reset requests per IP in a 15-minute window. @default 10 */
+    perIp15Minutes?: number;
+    /** Max password reset requests per IP per day. @default 100 */
+    perIpPerDay?: number;
+    /** Max password reset requests per email address per hour. @default 5 */
+    perEmailPerHour?: number;
+    /** Max password reset requests per email address per day. @default 10 */
+    perEmailPerDay?: number;
+  };
+};
+
 type GenerateHandleProps = {
   email: string;
   firstName?: string;
@@ -87,6 +144,12 @@ export type AuthConfig = {
    *   if the provider email is verified.
    */
   oauthAccountLinking?: 'auto' | 'manual';
+
+  /**
+   * Overrides the built-in rate limits for authentication endpoints.
+   * Only the fields you specify are overridden; all others keep their defaults.
+   */
+  rateLimits?: AuthRateLimitsConfig;
 };
 
 let authConfig: AuthConfig = Object.freeze({});

--- a/packages/modelence/src/app/index.test.ts
+++ b/packages/modelence/src/app/index.test.ts
@@ -164,6 +164,7 @@ jest.unstable_mockModule('@/websocket/socketio/server', () => ({
 }));
 
 jest.unstable_mockModule('../auth/user', () => ({
+  buildAuthRateLimits: jest.fn(() => []),
   default: {
     name: '_system.user',
     queries: {},

--- a/packages/modelence/src/app/index.test.ts
+++ b/packages/modelence/src/app/index.test.ts
@@ -4,6 +4,7 @@ import type { MigrationScript } from '../migration';
 import type { ModelSchema } from '../data/types';
 import type { Store } from '../data/store';
 import type { RateLimitRule } from '../rate-limit/types';
+import type { AuthRateLimitsConfig } from './authConfig';
 import { ServerChannel } from '@/websocket/serverChannel';
 import type { WebsocketServerProvider } from '@/websocket/types';
 
@@ -61,6 +62,20 @@ const expectedMigrationsLockOptions = {
 
 const mockResolveStores =
   jest.fn<(stores: unknown[]) => { storesToInit: unknown[]; effectiveStores: unknown[] }>();
+
+const mockBuildAuthRateLimits = jest.fn<(config?: AuthRateLimitsConfig) => RateLimitRule[]>(
+  () => []
+);
+const mockUserModule = {
+  name: '_system.user',
+  queries: {},
+  mutations: {},
+  stores: [],
+  channels: [],
+  rateLimits: [] as RateLimitRule[],
+  cronJobs: {},
+  configSchema: {},
+};
 
 jest.unstable_mockModule('dotenv', () => ({
   default: { config: mockDotenvConfig },
@@ -164,17 +179,8 @@ jest.unstable_mockModule('@/websocket/socketio/server', () => ({
 }));
 
 jest.unstable_mockModule('../auth/user', () => ({
-  buildAuthRateLimits: jest.fn(() => []),
-  default: {
-    name: '_system.user',
-    queries: {},
-    mutations: {},
-    stores: [],
-    channels: [],
-    rateLimits: [],
-    cronJobs: {},
-    configSchema: {},
-  },
+  buildAuthRateLimits: mockBuildAuthRateLimits,
+  default: mockUserModule,
 }));
 
 jest.unstable_mockModule('../auth/session', () => ({
@@ -469,6 +475,28 @@ describe('app/index', () => {
     });
 
     expect(mockInitRateLimits).toHaveBeenCalledWith([rateLimit1, rateLimit2]);
+  });
+
+  test('writes auth rate limit overrides onto the user module before collection', async () => {
+    const authRules: RateLimitRule[] = [
+      { bucket: 'signup', type: 'ip', window: 900_000, limit: 5 },
+    ];
+    mockBuildAuthRateLimits.mockReturnValueOnce(authRules);
+
+    await startApp({
+      auth: {
+        rateLimits: { signup: { perIp15Minutes: 5 } },
+      },
+    });
+
+    // The builder receives the user-supplied overrides
+    expect(mockBuildAuthRateLimits).toHaveBeenCalledWith({ signup: { perIp15Minutes: 5 } });
+
+    // Effective limits land on the user module (so Modelence Cloud can read them)
+    expect(mockUserModule.rateLimits).toEqual(authRules);
+
+    // And feed into initRateLimits via getRateLimits()
+    expect(mockInitRateLimits).toHaveBeenCalledWith(expect.arrayContaining(authRules));
   });
 
   test('defines cron jobs from modules', async () => {

--- a/packages/modelence/src/app/index.ts
+++ b/packages/modelence/src/app/index.ts
@@ -40,6 +40,7 @@ import { EmailConfig, setEmailConfig } from './emailConfig';
 import { AuthConfig, setAuthConfig } from './authConfig';
 import { SecurityConfig, setSecurityConfig } from './securityConfig';
 import { WebsocketConfig, setWebsocketConfig } from './websocketConfig';
+import { buildAuthRateLimits } from '../auth/user';
 
 export type AppOptions = {
   modules?: Module[];
@@ -122,7 +123,7 @@ export async function startApp({
 
   defineCronJobs(combinedModules);
 
-  const rateLimits = getRateLimits(combinedModules);
+  const rateLimits = [...getRateLimits(combinedModules), ...buildAuthRateLimits(auth.rateLimits)];
   initRateLimits(rateLimits);
 
   const { storesToInit, effectiveStores } = resolveStores(rawStores) as {

--- a/packages/modelence/src/app/index.ts
+++ b/packages/modelence/src/app/index.ts
@@ -123,7 +123,12 @@ export async function startApp({
 
   defineCronJobs(combinedModules);
 
-  const rateLimits = [...getRateLimits(combinedModules), ...buildAuthRateLimits(auth.rateLimits)];
+  // Apply user-provided auth rate limit overrides directly onto the user
+  // module so its `rateLimits` array reflects the effective configuration
+  // (the Modelence Cloud reads these from modules for display).
+  userModule.rateLimits = buildAuthRateLimits(auth.rateLimits);
+
+  const rateLimits = getRateLimits(combinedModules);
   initRateLimits(rateLimits);
 
   const { storesToInit, effectiveStores } = resolveStores(rawStores) as {

--- a/packages/modelence/src/app/module.ts
+++ b/packages/modelence/src/app/module.ts
@@ -68,7 +68,7 @@ export class Module<
   public readonly configSchema: TSchema;
 
   /** @internal */
-  public readonly rateLimits: RateLimitRule[];
+  public rateLimits: RateLimitRule[];
 
   /** @internal */
   public readonly channels: ServerChannel[];

--- a/packages/modelence/src/auth/user.test.ts
+++ b/packages/modelence/src/auth/user.test.ts
@@ -85,7 +85,7 @@ jest.unstable_mockModule('../app/module', () => ({
   Module: ModuleMock,
 }));
 
-const { createGuestUser, default: userModule } = await import('./user');
+const { createGuestUser, buildAuthRateLimits, default: userModule } = await import('./user');
 
 describe('auth/user', () => {
   beforeEach(() => {
@@ -149,9 +149,109 @@ describe('auth/user', () => {
         ],
       })
     );
+  });
 
-    expect(mockTime.minutes).toHaveBeenCalledWith(15);
-    expect(mockTime.hours).toHaveBeenCalledWith(1);
-    expect(mockTime.days).toHaveBeenCalledWith(1);
+  describe('buildAuthRateLimits', () => {
+    beforeEach(() => {
+      mockTime.seconds.mockClear();
+      mockTime.minutes.mockClear();
+      mockTime.hours.mockClear();
+      mockTime.days.mockClear();
+    });
+
+    test('returns default limits when called with no config', () => {
+      const rules = buildAuthRateLimits();
+
+      const signup15m = rules.find((r) => r.bucket === 'signup' && r.window === 15 * 60 * 1000);
+      const signupDay = rules.find(
+        (r) => r.bucket === 'signup' && r.window === 24 * 60 * 60 * 1000
+      );
+      expect(signup15m?.limit).toBe(20);
+      expect(signupDay?.limit).toBe(200);
+
+      const attempt15m = rules.find(
+        (r) => r.bucket === 'signupAttempt' && r.window === 15 * 60 * 1000
+      );
+      const attemptDay = rules.find(
+        (r) => r.bucket === 'signupAttempt' && r.window === 24 * 60 * 60 * 1000
+      );
+      expect(attempt15m?.limit).toBe(50);
+      expect(attemptDay?.limit).toBe(500);
+
+      expect(mockTime.seconds).toHaveBeenCalledWith(60);
+      expect(mockTime.minutes).toHaveBeenCalledWith(15);
+      expect(mockTime.hours).toHaveBeenCalledWith(1);
+      expect(mockTime.days).toHaveBeenCalledWith(1);
+    });
+
+    test('applies signup limit overrides', () => {
+      const rules = buildAuthRateLimits({
+        signup: { perIp15Minutes: 5, perIpPerDay: 50 },
+      });
+
+      const signup15m = rules.find((r) => r.bucket === 'signup' && r.window === 15 * 60 * 1000);
+      const signupDay = rules.find(
+        (r) => r.bucket === 'signup' && r.window === 24 * 60 * 60 * 1000
+      );
+      expect(signup15m?.limit).toBe(5);
+      expect(signupDay?.limit).toBe(50);
+
+      // Unrelated buckets keep their defaults
+      const signin15m = rules.find((r) => r.bucket === 'signin' && r.window === 15 * 60 * 1000);
+      expect(signin15m?.limit).toBe(50);
+    });
+
+    test('applies partial overrides — unspecified fields keep defaults', () => {
+      const rules = buildAuthRateLimits({
+        signup: { perIp15Minutes: 3 },
+      });
+
+      const signup15m = rules.find((r) => r.bucket === 'signup' && r.window === 15 * 60 * 1000);
+      const signupDay = rules.find(
+        (r) => r.bucket === 'signup' && r.window === 24 * 60 * 60 * 1000
+      );
+      expect(signup15m?.limit).toBe(3);
+      expect(signupDay?.limit).toBe(200); // default preserved
+    });
+
+    test('applies overrides across multiple buckets', () => {
+      const rules = buildAuthRateLimits({
+        signup: { perIpPerDay: 10 },
+        signin: { perIp15Minutes: 5, perIpPerDay: 20 },
+        passwordReset: { perEmailPerHour: 2, perEmailPerDay: 3 },
+      });
+
+      const signupDay = rules.find(
+        (r) => r.bucket === 'signup' && r.window === 24 * 60 * 60 * 1000
+      );
+      expect(signupDay?.limit).toBe(10);
+
+      const signin15m = rules.find((r) => r.bucket === 'signin' && r.window === 15 * 60 * 1000);
+      const signinDay = rules.find(
+        (r) => r.bucket === 'signin' && r.window === 24 * 60 * 60 * 1000
+      );
+      expect(signin15m?.limit).toBe(5);
+      expect(signinDay?.limit).toBe(20);
+
+      const pwResetEmailHour = rules.find(
+        (r) => r.bucket === 'passwordReset' && r.type === 'email' && r.window === 60 * 60 * 1000
+      );
+      const pwResetEmailDay = rules.find(
+        (r) =>
+          r.bucket === 'passwordReset' && r.type === 'email' && r.window === 24 * 60 * 60 * 1000
+      );
+      expect(pwResetEmailHour?.limit).toBe(2);
+      expect(pwResetEmailDay?.limit).toBe(3);
+    });
+
+    test('produces exactly 12 rules covering all auth buckets', () => {
+      const rules = buildAuthRateLimits();
+      expect(rules).toHaveLength(12);
+
+      const buckets = new Set(rules.map((r) => r.bucket));
+      expect(buckets).toEqual(
+        new Set(['signup', 'signupAttempt', 'signin', 'verification', 'passwordReset'])
+      );
+    });
   });
 });

--- a/packages/modelence/src/auth/user.test.ts
+++ b/packages/modelence/src/auth/user.test.ts
@@ -139,6 +139,13 @@ describe('auth/user', () => {
         cronJobs: {
           updateDisposableEmailList: mockUpdateDisposableEmailListCron,
         },
+        rateLimits: expect.arrayContaining([
+          expect.objectContaining({ bucket: 'signup', limit: 20 }),
+          expect.objectContaining({ bucket: 'signupAttempt', limit: 50 }),
+          expect.objectContaining({ bucket: 'signin', limit: 50 }),
+          expect.objectContaining({ bucket: 'verification', limit: 1 }),
+          expect.objectContaining({ bucket: 'passwordReset', limit: 10 }),
+        ]),
         routes: [
           {
             path: '/api/_internal/auth/verify-email',

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from 'crypto';
 
+import type { AuthRateLimitsConfig } from '../app/authConfig';
 import { Module } from '../app/module';
+import { RateLimitRule } from '../rate-limit/types';
 import { time } from '../time';
 import {
   dbDisposableEmailDomains,
@@ -15,6 +17,90 @@ import { handleUnlinkOAuthProvider } from './unlinkOAuthProvider';
 import { handleSignupWithPassword } from './signup';
 import { handleVerifyEmail, handleResendEmailVerification } from './verification';
 import { handleResetPassword, handleSendResetPasswordToken } from './resetPassword';
+
+/**
+ * Builds the rate limit rules for all authentication endpoints, merging any
+ * caller-supplied overrides with the built-in defaults.
+ *
+ * Exposed so that `startApp` can pass user-configured limits at startup rather
+ * than relying on static values baked into the Module constructor.
+ */
+export function buildAuthRateLimits(config: AuthRateLimitsConfig = {}): RateLimitRule[] {
+  return [
+    {
+      bucket: 'signup',
+      type: 'ip',
+      window: time.minutes(15),
+      limit: config.signup?.perIp15Minutes ?? 20,
+    },
+    {
+      bucket: 'signup',
+      type: 'ip',
+      window: time.days(1),
+      limit: config.signup?.perIpPerDay ?? 200,
+    },
+    {
+      bucket: 'signupAttempt',
+      type: 'ip',
+      window: time.minutes(15),
+      limit: config.signupAttempt?.perIp15Minutes ?? 50,
+    },
+    {
+      bucket: 'signupAttempt',
+      type: 'ip',
+      window: time.days(1),
+      limit: config.signupAttempt?.perIpPerDay ?? 500,
+    },
+    {
+      bucket: 'signin',
+      type: 'ip',
+      window: time.minutes(15),
+      limit: config.signin?.perIp15Minutes ?? 50,
+    },
+    {
+      bucket: 'signin',
+      type: 'ip',
+      window: time.days(1),
+      limit: config.signin?.perIpPerDay ?? 500,
+    },
+    {
+      bucket: 'verification',
+      type: 'user',
+      window: time.seconds(60),
+      limit: config.verification?.perUserPerMinute ?? 1,
+    },
+    {
+      bucket: 'verification',
+      type: 'user',
+      window: time.days(1),
+      limit: config.verification?.perUserPerDay ?? 10,
+    },
+    {
+      bucket: 'passwordReset',
+      type: 'ip',
+      window: time.minutes(15),
+      limit: config.passwordReset?.perIp15Minutes ?? 10,
+    },
+    {
+      bucket: 'passwordReset',
+      type: 'ip',
+      window: time.days(1),
+      limit: config.passwordReset?.perIpPerDay ?? 100,
+    },
+    {
+      bucket: 'passwordReset',
+      type: 'email',
+      window: time.hours(1),
+      limit: config.passwordReset?.perEmailPerHour ?? 5,
+    },
+    {
+      bucket: 'passwordReset',
+      type: 'email',
+      window: time.days(1),
+      limit: config.passwordReset?.perEmailPerDay ?? 10,
+    },
+  ];
+}
 
 export async function createGuestUser() {
   // TODO: add rate-limiting and captcha handling
@@ -59,80 +145,6 @@ export default new Module('_system.user', {
   cronJobs: {
     updateDisposableEmailList: updateDisposableEmailListCron,
   },
-  rateLimits: [
-    {
-      bucket: 'signup',
-      type: 'ip',
-      window: time.minutes(15),
-      limit: 20,
-    },
-    {
-      bucket: 'signup',
-      type: 'ip',
-      window: time.days(1),
-      limit: 200,
-    },
-    {
-      bucket: 'signupAttempt',
-      type: 'ip',
-      window: time.minutes(15),
-      limit: 50,
-    },
-    {
-      bucket: 'signupAttempt',
-      type: 'ip',
-      window: time.days(1),
-      limit: 500,
-    },
-    {
-      bucket: 'signin',
-      type: 'ip',
-      window: time.minutes(15),
-      limit: 50,
-    },
-    {
-      bucket: 'signin',
-      type: 'ip',
-      window: time.days(1),
-      limit: 500,
-    },
-    {
-      bucket: 'verification',
-      type: 'user',
-      window: time.seconds(60),
-      limit: 1,
-    },
-    {
-      bucket: 'verification',
-      type: 'user',
-      window: time.days(1),
-      limit: 10,
-    },
-    {
-      bucket: 'passwordReset',
-      type: 'ip',
-      window: time.minutes(15),
-      limit: 10,
-    },
-    {
-      bucket: 'passwordReset',
-      type: 'ip',
-      window: time.days(1),
-      limit: 100,
-    },
-    {
-      bucket: 'passwordReset',
-      type: 'email',
-      window: time.hours(1),
-      limit: 5,
-    },
-    {
-      bucket: 'passwordReset',
-      type: 'email',
-      window: time.days(1),
-      limit: 10,
-    },
-  ],
   configSchema: {
     'auth.email.enabled': {
       type: 'boolean',

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -145,6 +145,10 @@ export default new Module('_system.user', {
   cronJobs: {
     updateDisposableEmailList: updateDisposableEmailListCron,
   },
+  // Default auth rate limits — replaced at startApp time with any user
+  // overrides from `auth.rateLimits`. Keeping the rules on the module makes
+  // them discoverable for module-level introspection (e.g. Modelence Cloud).
+  rateLimits: buildAuthRateLimits(),
   configSchema: {
     'auth.email.enabled': {
       type: 'boolean',

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -145,9 +145,6 @@ export default new Module('_system.user', {
   cronJobs: {
     updateDisposableEmailList: updateDisposableEmailListCron,
   },
-  // Default auth rate limits — replaced at startApp time with any user
-  // overrides from `auth.rateLimits`. Keeping the rules on the module makes
-  // them discoverable for module-level introspection (e.g. Modelence Cloud).
   rateLimits: buildAuthRateLimits(),
   configSchema: {
     'auth.email.enabled': {

--- a/packages/modelence/src/server.ts
+++ b/packages/modelence/src/server.ts
@@ -1,5 +1,5 @@
 export { startApp, type AppOptions } from './app';
-export type { AuthConfig, AuthOption } from './app/authConfig';
+export type { AuthConfig, AuthOption, AuthRateLimitsConfig } from './app/authConfig';
 export type { SecurityConfig } from './app/securityConfig';
 export { Module } from './app/module';
 export {


### PR DESCRIPTION
Closes #31

Previously, all auth rate limits (signup, signupAttempt, signin, verification, passwordReset) were hardcoded as static values inside the _system.user Module constructor, making them impossible to tune without forking the framework.

This change introduces AuthRateLimitsConfig — a typed, fully-documented config type that lets users override any per-action limit through the existing startApp auth config:

  startApp({
    auth: {
      rateLimits: {
        signup: { perIp15Minutes: 5, perIpPerDay: 50 },
        signin: { perIp15Minutes: 10 },
      },
    },
  });

Unspecified fields fall back to the original hardcoded defaults, so there is no behaviour change for existing apps.

Implementation notes:
- Auth rate limits are moved out of the Module constructor into an exported buildAuthRateLimits(config?) builder in auth/user.ts. This sidesteps the init-order issue: initRateLimits is called in startApp before setAuthConfig, so reading from getAuthConfig() at that point would return an empty object. Passing auth.rateLimits directly from the startApp parameter avoids the race entirely.
- AuthRateLimitsConfig is re-exported from modelence/server so consumers can type their config without reaching into internal paths.
- 5 new unit tests cover defaults, full overrides, partial overrides, multi-bucket overrides, and rule count invariant.
- fix: add shebang to .husky/pre-commit so Git can spawn it on Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication rate-limiting behavior and startup wiring; misconfiguration or merge bugs could weaken brute-force protection or change effective limits at runtime, though defaults remain unchanged when unset.
> 
> **Overview**
> Adds `AuthRateLimitsConfig` to `AuthConfig` so apps can override per-endpoint auth rate limits (signup/signin/verification/password reset) while preserving defaults for unspecified fields.
> 
> Refactors auth rate limits into an exported `buildAuthRateLimits()` in `auth/user.ts` and updates `startApp` to apply overrides by mutating `userModule.rateLimits` before rate-limit collection/initialization; `Module.rateLimits` is made mutable to support this. Updates tests to cover default/override behavior and ensures the effective rules are surfaced via the `_system.user` module, and re-exports `AuthRateLimitsConfig` from `server.ts`. Also fixes the `.husky/pre-commit` hook by adding a shebang.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eda501590426092d33495a974376eef699c0ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->