### PR TITLE
fix: improve sanitization performance

### DIFF
--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint src --ext .ts,.tsx --fix",
     "lint:check": "eslint src --ext .ts,.tsx",
     "prepublishOnly": "npm run build",
+    "bench": "tsx src/bench/index.ts",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",

--- a/packages/modelence/src/bench/index.ts
+++ b/packages/modelence/src/bench/index.ts
@@ -1,0 +1,31 @@
+import { readdirSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const srcDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+function findBenchFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir).sort()) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...findBenchFiles(full));
+    } else if (entry.endsWith('.bench.ts')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const files = findBenchFiles(srcDir);
+
+if (files.length === 0) {
+  console.log('No *.bench.ts files found under src/.');
+  process.exit(0);
+}
+
+for (const file of files) {
+  const rel = file.slice(srcDir.length + 1);
+  console.log(`\n${'═'.repeat(72)}\n  ${rel}\n${'═'.repeat(72)}`);
+  await import(pathToFileURL(file).href);
+}

--- a/packages/modelence/src/methods/serialize.bench.ts
+++ b/packages/modelence/src/methods/serialize.bench.ts
@@ -65,17 +65,27 @@ console.log(
 
 section('1. Primitive array (1 000 numbers) — no ObjectId');
 bench('sanitizeResult', () => sanitizeResult(primitiveArray));
+bench('JSON.stringify', () => JSON.stringify(primitiveArray));
+bench('sanitizeResult + JSON.stringify', () => JSON.stringify(sanitizeResult(primitiveArray)));
 
 section('2. Array of 500 plain objects — no ObjectId');
 bench('sanitizeResult', () => sanitizeResult(plainObjectArray));
+bench('JSON.stringify', () => JSON.stringify(plainObjectArray));
+bench('sanitizeResult + JSON.stringify', () => JSON.stringify(sanitizeResult(plainObjectArray)));
 
 section('3. Array of 500 docs with ObjectId _id — must convert');
 bench('sanitizeResult', () => sanitizeResult(docArray));
+bench('JSON.stringify (relies on toJSON)', () => JSON.stringify(docArray));
+bench('sanitizeResult + JSON.stringify', () => JSON.stringify(sanitizeResult(docArray)));
 
 section('4. Deeply nested object (depth 10) — no ObjectId');
 bench('sanitizeResult', () => sanitizeResult(deepObject));
+bench('JSON.stringify', () => JSON.stringify(deepObject));
+bench('sanitizeResult + JSON.stringify', () => JSON.stringify(sanitizeResult(deepObject)));
 
 section('5. Realistic mixed document (ObjectIds + primitives)');
 bench('sanitizeResult', () => sanitizeResult(realisticDoc));
+bench('JSON.stringify (relies on toJSON)', () => JSON.stringify(realisticDoc));
+bench('sanitizeResult + JSON.stringify', () => JSON.stringify(sanitizeResult(realisticDoc)));
 
 console.log();

--- a/packages/modelence/src/methods/serialize.bench.ts
+++ b/packages/modelence/src/methods/serialize.bench.ts
@@ -1,0 +1,81 @@
+import { ObjectId } from 'mongodb';
+import { sanitizeResult } from './serialize.js';
+
+// ── Harness ───────────────────────────────────────────────────────────────────
+
+const WARMUP = 5_000;
+const ITERATIONS = 100_000;
+
+function bench(label: string, fn: () => void): void {
+  for (let i = 0; i < WARMUP; i++) fn();
+  const start = process.hrtime.bigint();
+  for (let i = 0; i < ITERATIONS; i++) fn();
+  const ms = Number(process.hrtime.bigint() - start) / 1e6;
+  const ops = Math.round((ITERATIONS / ms) * 1000);
+  console.log(
+    `  ${label.padEnd(44)} ${ms.toFixed(2).padStart(8)} ms   ${ops.toLocaleString().padStart(12)} ops/s`
+  );
+}
+
+function section(title: string) {
+  console.log(`\n${'─'.repeat(72)}\n  ${title}\n${'─'.repeat(72)}`);
+  console.log(`  ${'scenario'.padEnd(44)} ${'total ms'.padStart(8)}   ${'ops/sec'.padStart(12)}`);
+  console.log(`  ${'─'.repeat(68)}`);
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const primitiveArray = Array.from({ length: 1_000 }, (_, i) => i);
+
+const plainObjectArray = Array.from({ length: 500 }, (_, i) => ({
+  index: i,
+  name: `item-${i}`,
+  active: true,
+  score: Math.random(),
+}));
+
+const docArray = Array.from({ length: 500 }, () => ({
+  _id: new ObjectId(),
+  name: 'Alice',
+  score: 42,
+}));
+
+function makeDeep(depth: number): unknown {
+  if (depth === 0) return { value: 'leaf', num: 123, flag: true };
+  return { level: depth, child: makeDeep(depth - 1) };
+}
+const deepObject = makeDeep(10);
+
+const realisticDoc = {
+  _id: new ObjectId(),
+  title: 'Post title',
+  body: 'Some longer body text here.',
+  views: 9_001,
+  published: true,
+  tags: ['alpha', 'beta', 'gamma'],
+  author: { _id: new ObjectId(), name: 'Alice', email: 'alice@example.com' },
+  metadata: { createdAt: new Date(), source: 'web', revision: 3 },
+};
+
+// ── Run ───────────────────────────────────────────────────────────────────────
+
+console.log(
+  `\nwarm-up: ${WARMUP.toLocaleString()} iters   measured: ${ITERATIONS.toLocaleString()} iters`
+);
+
+section('1. Primitive array (1 000 numbers) — no ObjectId');
+bench('sanitizeResult', () => sanitizeResult(primitiveArray));
+
+section('2. Array of 500 plain objects — no ObjectId');
+bench('sanitizeResult', () => sanitizeResult(plainObjectArray));
+
+section('3. Array of 500 docs with ObjectId _id — must convert');
+bench('sanitizeResult', () => sanitizeResult(docArray));
+
+section('4. Deeply nested object (depth 10) — no ObjectId');
+bench('sanitizeResult', () => sanitizeResult(deepObject));
+
+section('5. Realistic mixed document (ObjectIds + primitives)');
+bench('sanitizeResult', () => sanitizeResult(realisticDoc));
+
+console.log();

--- a/packages/modelence/src/methods/serialize.test.ts
+++ b/packages/modelence/src/methods/serialize.test.ts
@@ -51,6 +51,57 @@ describe('serialize', () => {
       expect(sanitizeResult(null)).toBeNull();
       expect(sanitizeResult(undefined)).toBeUndefined();
     });
+
+    test('should return the same array reference when no ObjectId is present', () => {
+      const arr = [1, 'two', true, null];
+      expect(sanitizeResult(arr)).toBe(arr);
+    });
+
+    test('should return the same object reference when no ObjectId is present', () => {
+      const obj = { name: 'Alice', count: 3 };
+      expect(sanitizeResult(obj)).toBe(obj);
+    });
+
+    test('should return the same nested object reference when no ObjectId is present', () => {
+      const inner = { x: 1 };
+      const outer = { inner, label: 'test' };
+      const result = sanitizeResult(outer) as typeof outer;
+      expect(result).toBe(outer);
+      expect(result.inner).toBe(inner);
+    });
+
+    test('should return the same array reference for array of plain objects with no ObjectId', () => {
+      const arr = [{ a: 1 }, { b: 'two' }];
+      expect(sanitizeResult(arr)).toBe(arr);
+    });
+
+    test('should only replace the element containing the ObjectId (copy-on-write)', () => {
+      const id = new ObjectId('507f1f77bcf86cd799439011');
+      const unchanged = { name: 'Bob' };
+      const arr = [unchanged, { _id: id }];
+      const result = sanitizeResult(arr) as unknown[];
+      expect(result).not.toBe(arr);
+      expect(result[0]).toBe(unchanged);
+      expect((result[1] as Record<string, unknown>)._id).toBe('507f1f77bcf86cd799439011');
+    });
+
+    test('should only replace the changed key on an object (copy-on-write)', () => {
+      const id = new ObjectId('507f1f77bcf86cd799439011');
+      const nested = { ref: id };
+      const obj = { a: 1, nested };
+      const result = sanitizeResult(obj) as typeof obj;
+      expect(result).not.toBe(obj);
+      expect((result as Record<string, unknown>).a).toBe(1);
+      expect((result.nested as Record<string, unknown>).ref).toBe('507f1f77bcf86cd799439011');
+    });
+
+    test('should return the same Date reference inside an object with no ObjectId', () => {
+      const date = new Date('2024-06-01');
+      const obj = { createdAt: date };
+      const result = sanitizeResult(obj) as typeof obj;
+      expect(result).toBe(obj);
+      expect(result.createdAt).toBe(date);
+    });
   });
 
   describe('getResponseTypeMap', () => {

--- a/packages/modelence/src/methods/serialize.ts
+++ b/packages/modelence/src/methods/serialize.ts
@@ -10,6 +10,7 @@ function isObjectId(value: unknown): value is { toHexString(): string } {
 /**
  * Recursively converts all MongoDB ObjectId instances to hex strings.
  * Uses duck typing (checks for toHexString method) to avoid importing mongodb on the client.
+ * Returns the original input reference unchanged when no ObjectId is present (no allocation).
  */
 export function sanitizeResult(result: unknown): unknown {
   if (result == null || typeof result !== 'object') {
@@ -25,12 +26,43 @@ export function sanitizeResult(result: unknown): unknown {
   }
 
   if (Array.isArray(result)) {
-    return result.map(sanitizeResult);
+    let out: unknown[] | null = null;
+    for (let i = 0; i < result.length; i++) {
+      const item = result[i];
+      // Primitives and null can never contain an ObjectId — skip recursion.
+      if (item === null || typeof item !== 'object') {
+        if (out !== null) out.push(item);
+        continue;
+      }
+      const sanitized = sanitizeResult(item);
+      if (sanitized !== item) {
+        if (out === null) {
+          // Copy-on-first-write: preserve all preceding elements.
+          out = result.slice(0, i);
+        }
+        out.push(sanitized);
+      } else if (out !== null) {
+        out.push(item);
+      }
+    }
+    return out !== null ? out : result;
   }
 
-  return Object.fromEntries(
-    Object.entries(result).map(([key, value]) => [key, sanitizeResult(value)])
-  );
+  let out: Record<string, unknown> | null = null;
+  for (const [key, value] of Object.entries(result as Record<string, unknown>)) {
+    if (value === null || typeof value !== 'object') {
+      if (out !== null) out[key] = value;
+      continue;
+    }
+    const sanitized = sanitizeResult(value);
+    if (sanitized !== value) {
+      if (out === null) {
+        out = { ...(result as Record<string, unknown>) };
+      }
+      out[key] = sanitized;
+    }
+  }
+  return out !== null ? out : result;
 }
 
 export function getResponseTypeMap(result: unknown) {


### PR DESCRIPTION

Scenario | OLD | NEW | Speedup
-- | -- | -- | --
Primitive array (1 000 numbers, no ObjectId) | 161K ops/s | 2.75M ops/s | 17×
Array of 500 plain objects, no ObjectId | 4.5K ops/s | 11.4K ops/s | 2.5×
Array of 500 docs with ObjectId _id (real work) | 4.5K ops/s | 7.8K ops/s | 1.7×
Deeply nested object, depth 10, no ObjectId | 368K ops/s | 778K ops/s | 2.1×
Realistic mixed doc (some ObjectIds) | 587K ops/s | 1.05M ops/s | 1.8×


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core response sanitization used in method and live-query responses; while behavior should be equivalent, subtle edge cases in traversal/copying could affect returned data shapes or mutation expectations.
> 
> **Overview**
> Improves `sanitizeResult` performance by switching from always-deep-mapping to a **copy-on-write** traversal that returns the original array/object reference when no `ObjectId` conversions are needed.
> 
> Adds a small benchmark harness (`npm run bench`) plus a `serialize.bench.ts` suite to measure sanitization vs `JSON.stringify`, and extends tests to assert reference-preserving behavior and minimal copying when only some fields contain `ObjectId`s. Bumps `modelence` version to `0.15.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 273526970eb9d3e376f5cda0a6d1a64abe760801. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->