### PR TITLE
chore: bump version to 0.16

### DIFF
--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.15.3",
+      "version": "0.16.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@socket.io/mongo-adapter": "^0.4.0",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.15.4",
+  "version": "0.16.0",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the `modelence` package version in `package.json` and `package-lock.json` with no code or dependency changes.
> 
> **Overview**
> Bumps the `modelence` package version to `0.16.0` by updating `packages/modelence/package.json` and syncing `packages/modelence/package-lock.json` to the same version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b24d3c1984df070a8eee44ff821d7c3ae4473d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->