### PR TITLE
docs: rename api-reference to sdk

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
       - '!dist/**'
       - '!.modelence/**'
       - '!**/node_modules/**'
-      - '!docs/web/api-reference/**'
+      - '!docs/web/sdk/**'
       - '!.git/**'
 
 jobs:

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,1 @@
-web/api-reference
+web/sdk

--- a/docs/gen/scripts/custom-frontmatter.mjs
+++ b/docs/gen/scripts/custom-frontmatter.mjs
@@ -39,7 +39,7 @@ export function load(app) {
       // Replace occurrences like "(path.mdx" or "path.mdx#" but keep anchors and closing characters
       page.contents = page.contents.replace(/\.mdx(?=[)#])/g, "");
 
-      const baseUrl = ['api-reference', ...page.url.split('/').slice(0, -1).filter(Boolean)].join('/');
+      const baseUrl = ['sdk', ...page.url.split('/').slice(0, -1).filter(Boolean)].join('/');
 
       // Add a leading dot to internal links to avoid target="_blank"
       page.contents = page.contents.replace(/\]\(([^/)][^)#]*[^/])\)/g, (match, linkPath) => {

--- a/docs/gen/typedoc.json
+++ b/docs/gen/typedoc.json
@@ -11,7 +11,7 @@
     "../../packages/resend",
     "../../packages/aws-ses"
   ],
-  "out": "../web/api-reference",
+  "out": "../web/sdk",
   "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter", "./scripts/custom-frontmatter.mjs"],
   "excludePrivate": true,
   "excludeInternal": true,

--- a/docs/web/authentication/hooks.mdx
+++ b/docs/web/authentication/hooks.mdx
@@ -2,7 +2,7 @@
 title: 'Auth Hooks'
 ---
 
-The [AuthConfig](/api-reference/modelence/server/type-aliases/AuthConfig) type provides hooks for authentication events. Configure these in your `startApp` call:
+The [AuthConfig](/sdk/modelence/server/type-aliases/AuthConfig) type provides hooks for authentication events. Configure these in your `startApp` call:
 
 ## Validation Hooks
 

--- a/docs/web/authentication/index.mdx
+++ b/docs/web/authentication/index.mdx
@@ -160,23 +160,23 @@ function MyComponent() {
 
 ### Client Functions
 
-- [signupWithPassword](/api-reference/modelence/client/functions/signupWithPassword) - Sign up with email and password
-- [loginWithPassword](/api-reference/modelence/client/functions/loginWithPassword) - Log in with email and password
-- [logout](/api-reference/modelence/client/functions/logout) - Log out current user
-- [useSession](/api-reference/modelence/client/functions/useSession) - Access current user session
-- [verifyEmail](/api-reference/modelence/client/functions/verifyEmail) - Verify email with token
-- [sendResetPasswordToken](/api-reference/modelence/client/functions/sendResetPasswordToken) - Request password reset
-- [resetPassword](/api-reference/modelence/client/functions/resetPassword) - Reset password with token
+- [signupWithPassword](/sdk/modelence/client/functions/signupWithPassword) - Sign up with email and password
+- [loginWithPassword](/sdk/modelence/client/functions/loginWithPassword) - Log in with email and password
+- [logout](/sdk/modelence/client/functions/logout) - Log out current user
+- [useSession](/sdk/modelence/client/functions/useSession) - Access current user session
+- [verifyEmail](/sdk/modelence/client/functions/verifyEmail) - Verify email with token
+- [sendResetPasswordToken](/sdk/modelence/client/functions/sendResetPasswordToken) - Request password reset
+- [resetPassword](/sdk/modelence/client/functions/resetPassword) - Reset password with token
 
 ### Server Types
 
-- [AuthConfig](/api-reference/modelence/server/type-aliases/AuthConfig) - Authentication configuration
-- [UserInfo](/api-reference/modelence/server/type-aliases/UserInfo) - User information type
-- [dbUsers](/api-reference/modelence/server/variables/dbUsers) - User database collection
+- [AuthConfig](/sdk/modelence/server/type-aliases/AuthConfig) - Authentication configuration
+- [UserInfo](/sdk/modelence/server/type-aliases/UserInfo) - User information type
+- [dbUsers](/sdk/modelence/server/variables/dbUsers) - User database collection
 
 ### Error Types
 
-- [AuthError](/api-reference/modelence/index/classes/AuthError) - Authentication errors
-- [ValidationError](/api-reference/modelence/index/classes/ValidationError) - Validation errors
-- [RateLimitError](/api-reference/modelence/index/classes/RateLimitError) - Rate limit errors
+- [AuthError](/sdk/modelence/index/classes/AuthError) - Authentication errors
+- [ValidationError](/sdk/modelence/index/classes/ValidationError) - Validation errors
+- [RateLimitError](/sdk/modelence/index/classes/RateLimitError) - Rate limit errors
 

--- a/docs/web/authentication/rate-limiting.mdx
+++ b/docs/web/authentication/rate-limiting.mdx
@@ -10,7 +10,7 @@ Modelence includes built-in rate limiting on all authentication endpoints to pro
 - **Login**: 50 attempts per 15 minutes, 500 per day (per IP)
 - **Email Verification**: 1 per 60 seconds, 10 per day (per user)
 
-These limits are automatically enforced and will throw a [RateLimitError](/api-reference/modelence/index/classes/RateLimitError) when exceeded.
+These limits are automatically enforced and will throw a [RateLimitError](/sdk/modelence/index/classes/RateLimitError) when exceeded.
 
 ## Handling Rate Limit Errors
 

--- a/docs/web/configuration.mdx
+++ b/docs/web/configuration.mdx
@@ -285,7 +285,7 @@ function Header() {
 
 See the full API reference for config types:
 
-- [`ConfigSchema`](/api-reference/modelence/server/type-aliases/ConfigSchema) — The schema object passed to a module
-- [`ConfigType`](/api-reference/modelence/server/type-aliases/ConfigType) — The union of allowed type values
-- [`getConfig` (server)](/api-reference/modelence/server/functions/getConfig) — Read config on the server (untyped, for dynamic keys)
-- [`getConfig` (client)](/api-reference/modelence/client/functions/getConfig) — Read config on the client (untyped, for dynamic keys)
+- [`ConfigSchema`](/sdk/modelence/server/type-aliases/ConfigSchema) — The schema object passed to a module
+- [`ConfigType`](/sdk/modelence/server/type-aliases/ConfigType) — The union of allowed type values
+- [`getConfig` (server)](/sdk/modelence/server/functions/getConfig) — Read config on the server (untyped, for dynamic keys)
+- [`getConfig` (client)](/sdk/modelence/client/functions/getConfig) — Read config on the client (untyped, for dynamic keys)

--- a/docs/web/data-api.mdx
+++ b/docs/web/data-api.mdx
@@ -1141,6 +1141,6 @@ Want to see the full working code? Check it out on GitHub:
 
 ## Next Steps
 
-- Explore the [Store API Reference](../../api-reference/store) for advanced MongoDB operations
+- Explore the [Store API Reference](../../sdk/store) for advanced MongoDB operations
 - Learn about [Authentication](/auth) for more secure authentication methods
 - Check out the [Modules Guide](/modules) to understand how to organize your application

--- a/docs/web/docs.json
+++ b/docs/web/docs.json
@@ -176,6 +176,10 @@
   },
   "redirects": [
     {
+      "source": "/api-reference/intro",
+      "destination": "/sdk/modelence"
+    },
+    {
       "source": "/api-reference/:slug*",
       "destination": "/sdk/:slug*"
     },

--- a/docs/web/docs.json
+++ b/docs/web/docs.json
@@ -72,75 +72,75 @@
         ]
       },
       {
-        "tab": "API Reference",
+        "tab": "SDK Reference",
         "groups": [
           {
             "group": "Overview",
             "pages": [
-              "api-reference/modelence/index",
-              "api-reference/@modelence/react-query/index",
-              "api-reference/@modelence/ai/index",
-              "api-reference/@modelence/next/index",
-              "api-reference/@modelence/auth-ui/index"
+              "sdk/modelence/index",
+              "sdk/@modelence/react-query/index",
+              "sdk/@modelence/ai/index",
+              "sdk/@modelence/next/index",
+              "sdk/@modelence/auth-ui/index"
             ]
           },
           {
             "group": "Core",
             "pages": [
-              "api-reference/modelence/server/functions/startApp",
-              "api-reference/modelence/server/classes/Module",
-              "api-reference/modelence/client/functions/callMethod"
+              "sdk/modelence/server/functions/startApp",
+              "sdk/modelence/server/classes/Module",
+              "sdk/modelence/client/functions/callMethod"
             ]
           },
           {
             "group": "Authentication",
             "pages": [
-              "api-reference/modelence/client/functions/signupWithPassword",
-              "api-reference/modelence/client/functions/loginWithPassword",
-              "api-reference/modelence/client/functions/logout",
-              "api-reference/modelence/client/functions/useSession",
-              "api-reference/modelence/server/variables/dbUsers"
+              "sdk/modelence/client/functions/signupWithPassword",
+              "sdk/modelence/client/functions/loginWithPassword",
+              "sdk/modelence/client/functions/logout",
+              "sdk/modelence/client/functions/useSession",
+              "sdk/modelence/server/variables/dbUsers"
             ]
           },
           {
             "group": "Database",
             "pages": [
-              "api-reference/modelence/server/classes/Store",
-              "api-reference/modelence/server/variables/schema"
+              "sdk/modelence/server/classes/Store",
+              "sdk/modelence/server/variables/schema"
             ]
           },
           {
             "group": "Config",
             "pages": [
-              "api-reference/modelence/server/functions/getConfig",
-              "api-reference/modelence/client/functions/getConfig",
-              "api-reference/modelence/server/type-aliases/ConfigSchema",
-              "api-reference/modelence/server/type-aliases/ConfigType"
+              "sdk/modelence/server/functions/getConfig",
+              "sdk/modelence/client/functions/getConfig",
+              "sdk/modelence/server/type-aliases/ConfigSchema",
+              "sdk/modelence/server/type-aliases/ConfigType"
             ]
           },
           {
             "group": "Rate Limits",
             "pages": [
-              "api-reference/modelence/server/type-aliases/RateLimitRule",
-              "api-reference/modelence/server/functions/consumeRateLimit"
+              "sdk/modelence/server/type-aliases/RateLimitRule",
+              "sdk/modelence/server/functions/consumeRateLimit"
             ]
           },
           {
             "group": "Email",
             "pages": [
-              "api-reference/@modelence/smtp/index",
-              "api-reference/@modelence/resend/index",
-              "api-reference/@modelence/aws-ses/index"
+              "sdk/@modelence/smtp/index",
+              "sdk/@modelence/resend/index",
+              "sdk/@modelence/aws-ses/index"
             ]
           },
           {
             "group": "Files",
             "pages": [
-              "api-reference/modelence/server/functions/uploadFile",
-              "api-reference/modelence/server/functions/getUploadUrl",
-              "api-reference/modelence/server/functions/getFileUrl",
-              "api-reference/modelence/server/functions/downloadFile",
-              "api-reference/modelence/server/functions/deleteFile"
+              "sdk/modelence/server/functions/uploadFile",
+              "sdk/modelence/server/functions/getUploadUrl",
+              "sdk/modelence/server/functions/getFileUrl",
+              "sdk/modelence/server/functions/downloadFile",
+              "sdk/modelence/server/functions/deleteFile"
             ]
           }
         ]
@@ -176,8 +176,8 @@
   },
   "redirects": [
     {
-      "source": "/api-reference/intro",
-      "destination": "/api-reference"
+      "source": "/api-reference/:slug*",
+      "destination": "/sdk/:slug*"
     },
     {
       "source": "/quick-start/intro",

--- a/docs/web/email.mdx
+++ b/docs/web/email.mdx
@@ -10,9 +10,9 @@ Modelence supports multiple email providers for sending transactional emails suc
 
 Modelence supports the following email providers:
 
-- **[Resend](/api-reference/@modelence/resend/index)** - Modern email API service
-- **[Amazon SES](/api-reference/@modelence/aws-ses/index)** - AWS Simple Email Service
-- **[SMTP](/api-reference/@modelence/smtp/index)** - Any SMTP-compatible email service
+- **[Resend](/sdk/@modelence/resend/index)** - Modern email API service
+- **[Amazon SES](/sdk/@modelence/aws-ses/index)** - AWS Simple Email Service
+- **[SMTP](/sdk/@modelence/smtp/index)** - Any SMTP-compatible email service
 
 ## Configuration Steps
 
@@ -237,4 +237,4 @@ If you're in the AWS SES sandbox:
 
 - Learn about [Authentication](/docs/authentication) to understand how email verification works
 - Explore [User Management](/docs/user-management) features
-- Review the [API Reference](/docs/api-reference) for more details on email functions
+- Review the [API Reference](/docs/sdk) for more details on email functions

--- a/docs/web/index.mdx
+++ b/docs/web/index.mdx
@@ -42,7 +42,7 @@ That's it. No setup, no CLI, no configuration required.
   <Card
     title="API Reference"
     icon="code"
-    href="/api-reference"
+    href="/sdk"
   >
     Full API reference for the Modelence framework
   </Card>

--- a/docs/web/live-queries.mdx
+++ b/docs/web/live-queries.mdx
@@ -372,6 +372,6 @@ watch: ({ publish }) => {
 
 ## API Reference
 
-- [modelenceQuery](/api-reference/@modelence/react-query/functions/modelenceQuery) - Standard (non-live) query helper
-- [modelenceMutation](/api-reference/@modelence/react-query/functions/modelenceMutation) - Mutation helper
-- [Store](/api-reference/modelence/server/classes/Store) - Database store with `watch()` support
+- [modelenceQuery](/sdk/@modelence/react-query/functions/modelenceQuery) - Standard (non-live) query helper
+- [modelenceMutation](/sdk/@modelence/react-query/functions/modelenceMutation) - Mutation helper
+- [Store](/sdk/modelence/server/classes/Store) - Database store with `watch()` support

--- a/docs/web/rate-limiting.mdx
+++ b/docs/web/rate-limiting.mdx
@@ -7,7 +7,7 @@ Modelence provides a built-in rate limiting system you can use to protect any mu
 
 ## Defining Rate Limits
 
-You can define your own rate limits by adding a `rateLimits` array to a [Module](/api-reference/modelence/server/classes/Module). Each rule specifies a bucket name, the type of actor being limited (`ip` or `user`), a time window, and a maximum number of allowed calls within that window.
+You can define your own rate limits by adding a `rateLimits` array to a [Module](/sdk/modelence/server/classes/Module). Each rule specifies a bucket name, the type of actor being limited (`ip` or `user`), a time window, and a maximum number of allowed calls within that window.
 
 ```typescript
 import { Module } from 'modelence/server';
@@ -38,7 +38,7 @@ rateLimits: [
 
 ### Consuming a Rate Limit
 
-Call [`consumeRateLimit`](/api-reference/modelence/server/functions/consumeRateLimit) inside a mutation or query handler to check and increment the rate limit counter. It throws a [RateLimitError](/api-reference/modelence/index/classes/RateLimitError) automatically when any matching rule is exceeded:
+Call [`consumeRateLimit`](/sdk/modelence/server/functions/consumeRateLimit) inside a mutation or query handler to check and increment the rate limit counter. It throws a [RateLimitError](/sdk/modelence/index/classes/RateLimitError) automatically when any matching rule is exceeded:
 
 ```typescript
 import { consumeRateLimit } from 'modelence/server';

--- a/docs/web/stores.mdx
+++ b/docs/web/stores.mdx
@@ -302,4 +302,4 @@ The `extend()` method creates a new Store instance with merged schema, methods, 
 
 ## API Reference
 
-For a complete list of available methods and detailed API documentation, see the [Store API Reference](/api-reference/modelence/server/classes/Store).
+For a complete list of available methods and detailed API documentation, see the [Store API Reference](/sdk/modelence/server/classes/Store).

--- a/docs/web/tutorial.mdx
+++ b/docs/web/tutorial.mdx
@@ -77,7 +77,7 @@ console.log(todo.isOverdue());
 
 Stores provide a comprehensive set of methods for working with MongoDB documents, including finding, inserting, updating, and deleting records. All methods are fully typed with TypeScript.
 
-See the [Store API Reference](../../api-reference/store) for a complete list of available methods and their usage.
+See the [Store API Reference](../../sdk/store) for a complete list of available methods and their usage.
 
 <Tip>
 Stores automatically handle MongoDB connection management, collection provisioning and index creation. Just define your Store and start using it - Modelence takes care of the rest.

--- a/docs/web/voyage-ai.mdx
+++ b/docs/web/voyage-ai.mdx
@@ -501,4 +501,4 @@ Want to see the full working code? Check out the complete example:
 
 - Explore [MongoDB Vector Search documentation](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-overview/)
 - Learn about [Voyage AI's models and capabilities](https://docs.voyageai.com/)
-- Read about [Store API Reference](/api-reference/modelence/server/classes/Store) for more vector search options
+- Read about [Store API Reference](/sdk/modelence/server/classes/Store) for more vector search options

--- a/docs/web/websockets.mdx
+++ b/docs/web/websockets.mdx
@@ -677,4 +677,4 @@ const gameChannel = new ServerChannel<GameState>('game');
 - Explore the [Authentication](/authentication) docs for securing WebSocket connections
 - Check out the [Tutorial](/tutorial) for complete application examples
 - Review [Stores](/stores) documentation for persisting real-time data
-- Learn about [Modules](/api-reference/modelence/server/classes/Module) for organizing your application
+- Learn about [Modules](/sdk/modelence/server/classes/Module) for organizing your application

--- a/packages/modelence/README.md
+++ b/packages/modelence/README.md
@@ -10,7 +10,7 @@
   <img alt="Y Combinator S25" src="https://img.shields.io/badge/Combinator-S25-orange?logo=ycombinator&labelColor=white" />
   </h1>
   
-  [Website](https://modelence.com) | [Documentation](https://docs.modelence.com) | [API Reference](https://docs.modelence.com/api-reference) | [Modelence Cloud](https://cloud.modelence.com)
+  [Website](https://modelence.com) | [Documentation](https://docs.modelence.com) | [API Reference](https://docs.modelence.com/sdk) | [Modelence Cloud](https://cloud.modelence.com)
 
   ![Build Status](https://github.com/modelence/modelence/actions/workflows/build.yml/badge.svg)
   <a href="https://www.npmjs.com/package/modelence"><img alt="NPM version" src="https://img.shields.io/npm/v/modelence.svg" /></a>


### PR DESCRIPTION
openapi.json is added to llms.txt automatically. My best clue is that it's automatically generated because we named the folder `api-reference` since it's targeting an API (REST API). Our docs SDK docs, so I've ranamed api-reference to sdk

Task: MOD-389

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that renames the generated reference docs output path and updates internal links/redirects; main risk is broken docs navigation if any remaining `/api-reference` URLs weren’t migrated.
> 
> **Overview**
> Renames the generated reference docs from `api-reference` to `sdk` by updating TypeDoc output (`docs/gen/typedoc.json`) and the markdown link rewriting logic (`custom-frontmatter.mjs`).
> 
> Updates Mintlify navigation/tab naming, internal guide links, homepage CTA, and adds redirects so old `/api-reference/*` URLs forward to `/sdk/*`. Also adjusts CI/docs workflow path filters and docs `.gitignore` to target the new `docs/web/sdk` output directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8f591301b5791c4cbe81e03fafae7745f9c0cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->