### PR TITLE
docs: fix examples with _id

### DIFF
--- a/docs/web/core-concepts/modules.mdx
+++ b/docs/web/core-concepts/modules.mdx
@@ -103,7 +103,7 @@ export default new Module('todo', {
         }
       },
       async handler({ id }) {
-        return await dbTodos.deleteOne({ id });
+        return await dbTodos.deleteOne({ _id: new ObjectId(id) });
       }
     }
   }
@@ -219,7 +219,7 @@ mutations: {
       throw new Error('Not authorized to delete this todo');
     }
 
-    return await dbTodos.deleteOne({ id });
+    return await dbTodos.deleteOne({ _id: new ObjectId(id) });
   }
 }
 ```
@@ -240,7 +240,7 @@ export default new Module('todo', {
         throw new Error('Todo is already completed');
       }
 
-      await dbTodos.updateOne({ id }, {
+      await dbTodos.updateOne(id, {
         $set: {
           isCompleted: true,
           completedAt: new Date()

--- a/docs/web/core-concepts/mutations.mdx
+++ b/docs/web/core-concepts/mutations.mdx
@@ -18,7 +18,7 @@ Typed client modules for mutations require:
 Define mutations inside a module's `mutations` object:
 
 ```typescript
-import { Module } from 'modelence/server';
+import { Module, ObjectId } from 'modelence/server';
 import { dbTodos } from './db';
 
 export default new Module('todo', {
@@ -38,14 +38,14 @@ export default new Module('todo', {
     // Update a todo
     async update({ id, title, isCompleted }) {
       return await dbTodos.updateOne(
-        { id },
+        id,
         { $set: { title, isCompleted } }
       );
     },
 
     // Delete a todo
     async delete({ id }) {
-      return await dbTodos.deleteOne({ id });
+      return await dbTodos.deleteOne({ _id: new ObjectId(id) });
     },
   },
 });

--- a/docs/web/stores.mdx
+++ b/docs/web/stores.mdx
@@ -173,7 +173,7 @@ const result = await dbTodos.insertMany([
 ```typescript
 // Update one
 await dbTodos.updateOne(
-  { id: todoId },
+  { _id: new ObjectId(todoId) },
   { $set: { isCompleted: true } }
 );
 
@@ -200,7 +200,7 @@ await dbTodos.updateMany(
 
 ```typescript
 // Delete one
-await dbTodos.deleteOne({ id: todoId });
+await dbTodos.deleteOne({ _id: new ObjectId(todoId) });
 
 // Delete many
 await dbTodos.deleteMany({ isCompleted: true });
@@ -221,8 +221,8 @@ const stats = await dbTodos.aggregate([
 // Bulk write operations
 await dbTodos.bulkWrite([
   { insertOne: { document: { title: 'New task', /* ... */ } } },
-  { updateOne: { filter: { id: todoId }, update: { $set: { isCompleted: true } } } },
-  { deleteOne: { filter: { id: oldTodoId } } }
+  { updateOne: { filter: { _id: new ObjectId(todoId) }, update: { $set: { isCompleted: true } } } },
+  { deleteOne: { filter: { _id: new ObjectId(oldTodoId) } } }
 ]);
 ```
 

--- a/docs/web/tutorial.mdx
+++ b/docs/web/tutorial.mdx
@@ -90,7 +90,7 @@ Modules are the core building blocks of a Modelence application. They help you o
 Create a new file at `src/server/todo/index.ts`:
 
 ```typescript title="src/server/todo/index.ts"
-import { Module } from 'modelence/server';
+import { Module, ObjectId } from 'modelence/server';
 import { dbTodos } from './db';
 
 export default new Module('todo', {
@@ -125,7 +125,7 @@ export default new Module('todo', {
       return insertedId;
     },
     async update({ id, title, dueDate, isCompleted }) {
-      return await dbTodos.updateOne({ id }, {
+      return await dbTodos.updateOne(id, {
         $set: {
           title,
           dueDate,
@@ -134,7 +134,7 @@ export default new Module('todo', {
       });
     },
     async delete({ id }) {
-      return await dbTodos.deleteOne({ id });
+      return await dbTodos.deleteOne({ _id: new ObjectId(id) });
     }
   },
 });

--- a/docs/web/voyage-ai.mdx
+++ b/docs/web/voyage-ai.mdx
@@ -180,7 +180,7 @@ export async function rerank<T extends Record<string, any>>(
 Create an `index.ts` file to tie everything together:
 
 ```typescript title="src/server/voyage/index.ts"
-import { Module } from 'modelence/server';
+import { Module, ObjectId } from 'modelence/server';
 import { z } from 'zod';
 import { dbDocuments } from './db';
 import { generateEmbedding, rerank } from './voyage';
@@ -254,7 +254,7 @@ export default new Module('voyage', {
         id: z.string(),
       }).parse(args);
 
-      await dbDocuments.deleteOne({ id });
+      await dbDocuments.deleteOne({ _id: new ObjectId(id) });
       return { success: true };
     },
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that adjust code samples to match MongoDB `_id` semantics and Modelence store helper signatures.
> 
> **Overview**
> Updates multiple docs code samples to use MongoDB `_id` + `new ObjectId(id)` for deletes/filters (and imports `ObjectId` where needed), replacing incorrect `{ id }` selectors.
> 
> Also updates update examples to use the `updateOne(id, update)` convenience signature (and fixes bulkWrite filters) so the docs align with the actual store API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1f1f73fd7221e5840a4d8d5ca4ac83dd6479586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->