### PR TITLE
fix: add id support to Store.deleteOne

### DIFF
--- a/packages/modelence/src/data/store.ts
+++ b/packages/modelence/src/data/store.ts
@@ -1007,10 +1007,10 @@ export class Store<
    * @returns The result of the delete operation
    */
   async deleteOne(
-    selector: TypedFilter<this['_type']>,
+    selector: TypedFilter<this['_type']> | string | ObjectId,
     options?: { session?: ClientSession }
   ): Promise<DeleteResult> {
-    return await this.requireCollection().deleteOne(selector as Filter<this['_type']>, options);
+    return await this.requireCollection().deleteOne(this.getSelector(selector), options);
   }
 
   /**


### PR DESCRIPTION
* added Store.deleteOne(id) and Store.deleteOne(new ObjectId(id)) support to align it with updateOne

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to selector handling for `Store.deleteOne`; main concern is behavior change for callers passing a raw string that previously would not be treated as an `_id`.
> 
> **Overview**
> `Store.deleteOne` now accepts a document id (`string` or `ObjectId`) in addition to a typed filter, and normalizes all inputs via `getSelector` so deletes by id work consistently with `updateOne`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f11f3874999c6a36700c973b8e73966eebf1bc38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->