### PR TITLE
fix: string -> secret in VoyageAI docs

### DIFF
--- a/docs/web/voyage-ai.mdx
+++ b/docs/web/voyage-ai.mdx
@@ -259,9 +259,9 @@ export default new Module('voyage', {
     },
   },
   configSchema: {
+    // 'secret' values are always server-only and masked in the Cloud dashboard; isPublic is not allowed.
     apiKey: {
-      type: 'string',
-      isPublic: false,
+      type: 'secret',
       default: '',
     },
   },


### PR DESCRIPTION
* string -> secret in VoyageAI docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts an example config schema; no runtime code is affected.
> 
> **Overview**
> Updates the `docs/web/voyage-ai.mdx` tutorial to define the Voyage AI `apiKey` config as `type: 'secret'` (instead of a plain `string`) and removes the `isPublic` flag, clarifying that secrets are server-only and masked in the Cloud dashboard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 586642feb3f16d3d06d415a56016cc243d966e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->