### PR TITLE
docs: sync api reference navigation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,9 +42,18 @@ jobs:
         working-directory: ./docs/gen
         run: npm ci
 
-      - name: Generate TypeDoc
+      - name: Generate TypeDoc and sync API Reference nav
         working-directory: ./docs/gen
         run: npm run docs
+
+      - name: Verify docs.json API Reference nav is in sync
+        run: |
+          if ! git diff --quiet -- docs/web/docs.json; then
+            echo "::error::docs/web/docs.json is out of sync with the generated API Reference tree."
+            echo "Run 'npm run docs' in docs/gen and commit the updated docs/web/docs.json."
+            git diff -- docs/web/docs.json
+            exit 1
+          fi
 
       - name: Check internal documentation links
         run: ./packages/modelence/node_modules/.bin/tsx docs/scripts/check-internal-links.ts

--- a/docs/gen/package-lock.json
+++ b/docs/gen/package-lock.json
@@ -10,9 +10,452 @@
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "remark-mdx": "^3.1.0",
+        "tsx": "^4.19.3",
         "typedoc": "^0.28.1",
         "typedoc-plugin-frontmatter": "^1.3.0",
         "typedoc-plugin-markdown": "^4.6.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
@@ -310,6 +753,48 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
@@ -334,6 +819,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/is-alphabetical": {
@@ -1293,6 +1806,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -1306,6 +1829,26 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typedoc": {

--- a/docs/gen/package.json
+++ b/docs/gen/package.json
@@ -4,12 +4,14 @@
   "description": "",
   "main": " ",
   "scripts": {
-    "docs": "typedoc"
+    "docs": "typedoc && npm run sync-nav",
+    "sync-nav": "tsx ../scripts/sync-api-reference-nav.ts"
   },
   "author": "",
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
     "remark-mdx": "^3.1.0",
+    "tsx": "^4.19.3",
     "typedoc": "^0.28.1",
     "typedoc-plugin-frontmatter": "^1.3.0",
     "typedoc-plugin-markdown": "^4.6.0"

--- a/docs/scripts/sync-api-reference-nav.ts
+++ b/docs/scripts/sync-api-reference-nav.ts
@@ -1,0 +1,235 @@
+#!/usr/bin/env tsx
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface DocsJson {
+  navigation: {
+    tabs: Array<{
+      tab: string;
+      groups: Array<{ group: string; pages: unknown[] }>;
+    }>;
+  };
+  [key: string]: unknown;
+}
+
+interface NavGroup {
+  group: string;
+  pages: Array<string | NavGroup>;
+}
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const apiReferenceDir = path.join(repoRoot, 'docs/web/api-reference');
+const docsConfigPath = path.join(repoRoot, 'docs/web/docs.json');
+
+const KIND_ORDER = ['classes', 'interfaces', 'functions', 'variables', 'type-aliases', 'namespaces'] as const;
+const KIND_LABEL: Record<string, string> = {
+  classes: 'Classes',
+  interfaces: 'Interfaces',
+  functions: 'Functions',
+  variables: 'Variables',
+  'type-aliases': 'Type Aliases',
+  namespaces: 'Namespaces',
+};
+
+function toPosix(p: string): string {
+  return p.split(path.sep).join('/');
+}
+
+function walkMdx(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkMdx(full));
+    } else if (entry.isFile() && entry.name.endsWith('.mdx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function pageIdFromPath(absPath: string): string {
+  const relFromDocsWeb = toPosix(path.relative(path.join(repoRoot, 'docs/web'), absPath));
+  return relFromDocsWeb.replace(/\.mdx$/, '');
+}
+
+interface PackageEntry {
+  pkg: string;
+  subpath: string | null;
+  kind: string | null;
+  pageId: string;
+  symbol: string;
+}
+
+function classify(pageId: string): PackageEntry | null {
+  const parts = pageId.split('/');
+  if (parts[0] !== 'api-reference') return null;
+
+  let cursor = 1;
+  let pkg: string;
+  if (parts[cursor] === '@modelence') {
+    pkg = `@modelence/${parts[cursor + 1]}`;
+    cursor += 2;
+  } else {
+    pkg = parts[cursor];
+    cursor += 1;
+  }
+
+  if (cursor >= parts.length) return null;
+
+  const remaining = parts.slice(cursor);
+
+  // Package overview: api-reference/<pkg>/index
+  if (remaining.length === 1 && remaining[0] === 'index') {
+    return { pkg, subpath: null, kind: null, pageId, symbol: 'index' };
+  }
+
+  // For `modelence` package, the first segment is always the subpath
+  // (server/client/index). For scoped packages (@modelence/*) there's no
+  // subpath level — kinds sit directly under the package.
+  let subpath: string | null = null;
+  let kindIndex = 0;
+  const isModelencePkg = pkg === 'modelence';
+  const firstIsKind = KIND_ORDER.includes(remaining[0] as (typeof KIND_ORDER)[number]);
+
+  if (isModelencePkg && !firstIsKind) {
+    subpath = remaining[0];
+    kindIndex = 1;
+  } else if (!isModelencePkg && !firstIsKind) {
+    return null;
+  }
+
+  if (kindIndex >= remaining.length) return null;
+  const kindOrIndex = remaining[kindIndex];
+  if (kindOrIndex === 'index') {
+    return { pkg, subpath, kind: null, pageId, symbol: 'index' };
+  }
+  if (!KIND_ORDER.includes(kindOrIndex as (typeof KIND_ORDER)[number])) {
+    return null;
+  }
+  const symbol = remaining.slice(kindIndex + 1).join('/').replace(/\/index$/, '');
+  return { pkg, subpath, kind: kindOrIndex, pageId, symbol };
+}
+
+function sortBy<T>(arr: T[], key: (t: T) => string): T[] {
+  return [...arr].sort((a, b) => key(a).localeCompare(key(b)));
+}
+
+function buildKindGroups(entries: PackageEntry[]): NavGroup[] {
+  const byKind = new Map<string, PackageEntry[]>();
+  for (const entry of entries) {
+    if (!entry.kind) continue;
+    if (!byKind.has(entry.kind)) byKind.set(entry.kind, []);
+    byKind.get(entry.kind)!.push(entry);
+  }
+  const groups: NavGroup[] = [];
+  for (const kind of KIND_ORDER) {
+    const items = byKind.get(kind);
+    if (!items || items.length === 0) continue;
+    groups.push({
+      group: KIND_LABEL[kind],
+      pages: sortBy(items, (e) => e.symbol).map((e) => e.pageId),
+    });
+  }
+  return groups;
+}
+
+function buildPackageGroup(pkg: string, entries: PackageEntry[]): NavGroup {
+  const pages: Array<string | NavGroup> = [];
+
+  const overview = entries.find((e) => e.subpath === null && e.symbol === 'index');
+  if (overview) pages.push(overview.pageId);
+
+  if (pkg === 'modelence') {
+    const subpaths = ['server', 'client', 'index'];
+    for (const sp of subpaths) {
+      const subEntries = entries.filter((e) => e.subpath === sp);
+      if (subEntries.length === 0) continue;
+      const subOverview = subEntries.find((e) => e.kind === null && e.symbol === 'index');
+      const subpathPages: Array<string | NavGroup> = [];
+      if (subOverview) subpathPages.push(subOverview.pageId);
+      subpathPages.push(...buildKindGroups(subEntries));
+      const label = sp === 'index' ? 'Shared' : sp === 'server' ? 'Server' : 'Client';
+      pages.push({ group: label, pages: subpathPages });
+    }
+  } else {
+    pages.push(...buildKindGroups(entries.filter((e) => e.subpath === null)));
+  }
+
+  return { group: pkg, pages };
+}
+
+function buildApiReferenceTab(): Array<{ group: string; pages: unknown[] }> {
+  const allFiles = walkMdx(apiReferenceDir);
+  const entries: PackageEntry[] = [];
+  for (const file of allFiles) {
+    const pageId = pageIdFromPath(file);
+    const entry = classify(pageId);
+    if (entry) entries.push(entry);
+  }
+
+  const byPkg = new Map<string, PackageEntry[]>();
+  for (const entry of entries) {
+    if (!byPkg.has(entry.pkg)) byPkg.set(entry.pkg, []);
+    byPkg.get(entry.pkg)!.push(entry);
+  }
+
+  const pkgOrder = [
+    'modelence',
+    '@modelence/react-query',
+    '@modelence/ai',
+    '@modelence/next',
+    '@modelence/auth-ui',
+    '@modelence/smtp',
+    '@modelence/resend',
+    '@modelence/aws-ses',
+  ];
+
+  const groups: Array<{ group: string; pages: unknown[] }> = [];
+  for (const pkg of pkgOrder) {
+    const pkgEntries = byPkg.get(pkg);
+    if (!pkgEntries || pkgEntries.length === 0) continue;
+    groups.push(buildPackageGroup(pkg, pkgEntries));
+  }
+
+  const knownPkgs = new Set(pkgOrder);
+  for (const [pkg, pkgEntries] of byPkg) {
+    if (knownPkgs.has(pkg)) continue;
+    groups.push(buildPackageGroup(pkg, pkgEntries));
+  }
+
+  return groups;
+}
+
+function main() {
+  const docsRaw = fs.readFileSync(docsConfigPath, 'utf8');
+  const docs: DocsJson = JSON.parse(docsRaw);
+  const tabs = docs.navigation.tabs;
+  const apiTabIndex = tabs.findIndex((t) => t.tab === 'API Reference');
+  if (apiTabIndex === -1) {
+    throw new Error('API Reference tab not found in docs.json');
+  }
+
+  const newGroups = buildApiReferenceTab();
+  tabs[apiTabIndex] = { tab: 'API Reference', groups: newGroups };
+
+  const updated = JSON.stringify(docs, null, 2) + '\n';
+  fs.writeFileSync(docsConfigPath, updated);
+
+  let pageCount = 0;
+  function count(pages: unknown[]): void {
+    for (const p of pages) {
+      if (typeof p === 'string') pageCount++;
+      else if (p && typeof p === 'object' && 'pages' in p) {
+        count((p as { pages: unknown[] }).pages);
+      }
+    }
+  }
+  for (const g of newGroups) count(g.pages);
+
+  console.log(`Updated API Reference tab: ${newGroups.length} top-level groups, ${pageCount} pages.`);
+}
+
+main();

--- a/docs/web/docs.json
+++ b/docs/web/docs.json
@@ -75,72 +75,323 @@
         "tab": "API Reference",
         "groups": [
           {
-            "group": "Overview",
+            "group": "modelence",
             "pages": [
               "api-reference/modelence/index",
+              {
+                "group": "Server",
+                "pages": [
+                  "api-reference/modelence/server/index",
+                  {
+                    "group": "Classes",
+                    "pages": [
+                      "api-reference/modelence/server/classes/LiveData",
+                      "api-reference/modelence/server/classes/Module",
+                      "api-reference/modelence/server/classes/ServerChannel",
+                      "api-reference/modelence/server/classes/Store"
+                    ]
+                  },
+                  {
+                    "group": "Interfaces",
+                    "pages": [
+                      "api-reference/modelence/server/interfaces/LiveDataConfig"
+                    ]
+                  },
+                  {
+                    "group": "Functions",
+                    "pages": [
+                      "api-reference/modelence/server/functions/authenticate",
+                      "api-reference/modelence/server/functions/consumeRateLimit",
+                      "api-reference/modelence/server/functions/createQuery",
+                      "api-reference/modelence/server/functions/deleteFile",
+                      "api-reference/modelence/server/functions/deleteUser",
+                      "api-reference/modelence/server/functions/disableUser",
+                      "api-reference/modelence/server/functions/downloadFile",
+                      "api-reference/modelence/server/functions/getConfig",
+                      "api-reference/modelence/server/functions/getFileUrl",
+                      "api-reference/modelence/server/functions/getUploadUrl",
+                      "api-reference/modelence/server/functions/sendEmail",
+                      "api-reference/modelence/server/functions/startApp"
+                    ]
+                  },
+                  {
+                    "group": "Variables",
+                    "pages": [
+                      "api-reference/modelence/server/variables/dbUsers",
+                      "api-reference/modelence/server/variables/schema"
+                    ]
+                  },
+                  {
+                    "group": "Type Aliases",
+                    "pages": [
+                      "api-reference/modelence/server/type-aliases/AppOptions",
+                      "api-reference/modelence/server/type-aliases/AuthConfig",
+                      "api-reference/modelence/server/type-aliases/AuthOption",
+                      "api-reference/modelence/server/type-aliases/AuthRateLimitsConfig",
+                      "api-reference/modelence/server/type-aliases/CloudBackendConnectResponse",
+                      "api-reference/modelence/server/type-aliases/ConfigType",
+                      "api-reference/modelence/server/type-aliases/CronJobInputParams",
+                      "api-reference/modelence/server/type-aliases/FileVisibility",
+                      "api-reference/modelence/server/type-aliases/HttpMethod",
+                      "api-reference/modelence/server/type-aliases/LiveQueryCleanup",
+                      "api-reference/modelence/server/type-aliases/LiveQueryPublish",
+                      "api-reference/modelence/server/type-aliases/LiveQueryWatch",
+                      "api-reference/modelence/server/type-aliases/RateLimitRule",
+                      "api-reference/modelence/server/type-aliases/RateLimitType",
+                      "api-reference/modelence/server/type-aliases/RoleDefinition",
+                      "api-reference/modelence/server/type-aliases/RouteDefinition",
+                      "api-reference/modelence/server/type-aliases/RouteHandler",
+                      "api-reference/modelence/server/type-aliases/RouteParams",
+                      "api-reference/modelence/server/type-aliases/RouteResponse",
+                      "api-reference/modelence/server/type-aliases/SecurityConfig",
+                      "api-reference/modelence/server/type-aliases/UserInfo",
+                      "api-reference/modelence/server/type-aliases/ValueType"
+                    ]
+                  },
+                  {
+                    "group": "Namespaces",
+                    "pages": [
+                      "api-reference/modelence/server/namespaces/schema/index",
+                      "api-reference/modelence/server/namespaces/schema/type-aliases/infer"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Client",
+                "pages": [
+                  "api-reference/modelence/client/index",
+                  {
+                    "group": "Classes",
+                    "pages": [
+                      "api-reference/modelence/client/classes/ClientChannel",
+                      "api-reference/modelence/client/classes/MethodError"
+                    ]
+                  },
+                  {
+                    "group": "Functions",
+                    "pages": [
+                      "api-reference/modelence/client/functions/callMethod",
+                      "api-reference/modelence/client/functions/createClientModule",
+                      "api-reference/modelence/client/functions/deleteFile",
+                      "api-reference/modelence/client/functions/downloadFile",
+                      "api-reference/modelence/client/functions/getConfig",
+                      "api-reference/modelence/client/functions/getFileUrl",
+                      "api-reference/modelence/client/functions/getLocalStorageSession",
+                      "api-reference/modelence/client/functions/getWebsocketClientProvider",
+                      "api-reference/modelence/client/functions/linkOAuthProvider",
+                      "api-reference/modelence/client/functions/loginWithPassword",
+                      "api-reference/modelence/client/functions/logout",
+                      "api-reference/modelence/client/functions/renderApp",
+                      "api-reference/modelence/client/functions/resendEmailVerification",
+                      "api-reference/modelence/client/functions/resetPassword",
+                      "api-reference/modelence/client/functions/sendResetPasswordToken",
+                      "api-reference/modelence/client/functions/setWebsocketClientProvider",
+                      "api-reference/modelence/client/functions/signupWithPassword",
+                      "api-reference/modelence/client/functions/startWebsockets",
+                      "api-reference/modelence/client/functions/subscribeLiveQuery",
+                      "api-reference/modelence/client/functions/unlinkOAuthProvider",
+                      "api-reference/modelence/client/functions/updateProfile",
+                      "api-reference/modelence/client/functions/uploadFile",
+                      "api-reference/modelence/client/functions/useSession",
+                      "api-reference/modelence/client/functions/verifyEmail"
+                    ]
+                  },
+                  {
+                    "group": "Variables",
+                    "pages": [
+                      "api-reference/modelence/client/variables/AppProvider",
+                      "api-reference/modelence/client/variables/systemConfig"
+                    ]
+                  },
+                  {
+                    "group": "Type Aliases",
+                    "pages": [
+                      "api-reference/modelence/client/type-aliases/MethodArgs",
+                      "api-reference/modelence/client/type-aliases/UserInfo"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Shared",
+                "pages": [
+                  "api-reference/modelence/index/index",
+                  {
+                    "group": "Classes",
+                    "pages": [
+                      "api-reference/modelence/index/classes/AuthError",
+                      "api-reference/modelence/index/classes/ModelenceError",
+                      "api-reference/modelence/index/classes/RateLimitError",
+                      "api-reference/modelence/index/classes/ValidationError"
+                    ]
+                  },
+                  {
+                    "group": "Interfaces",
+                    "pages": [
+                      "api-reference/modelence/index/interfaces/ModelenceConfig",
+                      "api-reference/modelence/index/interfaces/WebsocketClientProvider",
+                      "api-reference/modelence/index/interfaces/WebsocketServerProvider"
+                    ]
+                  },
+                  {
+                    "group": "Variables",
+                    "pages": [
+                      "api-reference/modelence/index/variables/time"
+                    ]
+                  },
+                  {
+                    "group": "Type Aliases",
+                    "pages": [
+                      "api-reference/modelence/index/type-aliases/ConfigSchema"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "group": "@modelence/react-query",
+            "pages": [
               "api-reference/@modelence/react-query/index",
+              {
+                "group": "Classes",
+                "pages": [
+                  "api-reference/@modelence/react-query/classes/ModelenceQueryClient"
+                ]
+              },
+              {
+                "group": "Functions",
+                "pages": [
+                  "api-reference/@modelence/react-query/functions/createQueryKey",
+                  "api-reference/@modelence/react-query/functions/modelenceLiveQuery",
+                  "api-reference/@modelence/react-query/functions/modelenceMutation",
+                  "api-reference/@modelence/react-query/functions/modelenceQuery"
+                ]
+              },
+              {
+                "group": "Type Aliases",
+                "pages": [
+                  "api-reference/@modelence/react-query/type-aliases/ModelenceQueryKey"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "@modelence/ai",
+            "pages": [
               "api-reference/@modelence/ai/index",
+              {
+                "group": "Functions",
+                "pages": [
+                  "api-reference/@modelence/ai/functions/generateText"
+                ]
+              },
+              {
+                "group": "Type Aliases",
+                "pages": [
+                  "api-reference/@modelence/ai/type-aliases/GenerateTextOptions"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "@modelence/next",
+            "pages": [
               "api-reference/@modelence/next/index",
+              {
+                "group": "Classes",
+                "pages": [
+                  "api-reference/@modelence/next/classes/NextServer"
+                ]
+              },
+              {
+                "group": "Variables",
+                "pages": [
+                  "api-reference/@modelence/next/variables/nextServer"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "@modelence/auth-ui",
+            "pages": [
               "api-reference/@modelence/auth-ui/index"
             ]
           },
           {
-            "group": "Core",
-            "pages": [
-              "api-reference/modelence/server/functions/startApp",
-              "api-reference/modelence/server/classes/Module",
-              "api-reference/modelence/client/functions/callMethod"
-            ]
-          },
-          {
-            "group": "Authentication",
-            "pages": [
-              "api-reference/modelence/client/functions/signupWithPassword",
-              "api-reference/modelence/client/functions/loginWithPassword",
-              "api-reference/modelence/client/functions/logout",
-              "api-reference/modelence/client/functions/useSession",
-              "api-reference/modelence/server/variables/dbUsers"
-            ]
-          },
-          {
-            "group": "Database",
-            "pages": [
-              "api-reference/modelence/server/classes/Store",
-              "api-reference/modelence/server/variables/schema"
-            ]
-          },
-          {
-            "group": "Config",
-            "pages": [
-              "api-reference/modelence/server/functions/getConfig",
-              "api-reference/modelence/client/functions/getConfig",
-              "api-reference/modelence/index/type-aliases/ConfigSchema",
-              "api-reference/modelence/server/type-aliases/ConfigType"
-            ]
-          },
-          {
-            "group": "Rate Limits",
-            "pages": [
-              "api-reference/modelence/server/type-aliases/RateLimitRule",
-              "api-reference/modelence/server/functions/consumeRateLimit"
-            ]
-          },
-          {
-            "group": "Email",
+            "group": "@modelence/smtp",
             "pages": [
               "api-reference/@modelence/smtp/index",
-              "api-reference/@modelence/resend/index",
-              "api-reference/@modelence/aws-ses/index"
+              {
+                "group": "Functions",
+                "pages": [
+                  "api-reference/@modelence/smtp/functions/sendEmail"
+                ]
+              },
+              {
+                "group": "Variables",
+                "pages": [
+                  "api-reference/@modelence/smtp/variables/default"
+                ]
+              },
+              {
+                "group": "Type Aliases",
+                "pages": [
+                  "api-reference/@modelence/smtp/type-aliases/EmailAttachment",
+                  "api-reference/@modelence/smtp/type-aliases/EmailPayload"
+                ]
+              }
             ]
           },
           {
-            "group": "Files",
+            "group": "@modelence/resend",
             "pages": [
-              "api-reference/modelence/client/functions/uploadFile",
-              "api-reference/modelence/server/functions/getUploadUrl",
-              "api-reference/modelence/server/functions/getFileUrl",
-              "api-reference/modelence/server/functions/downloadFile",
-              "api-reference/modelence/server/functions/deleteFile"
+              "api-reference/@modelence/resend/index",
+              {
+                "group": "Functions",
+                "pages": [
+                  "api-reference/@modelence/resend/functions/sendEmail"
+                ]
+              },
+              {
+                "group": "Variables",
+                "pages": [
+                  "api-reference/@modelence/resend/variables/default"
+                ]
+              },
+              {
+                "group": "Type Aliases",
+                "pages": [
+                  "api-reference/@modelence/resend/type-aliases/EmailAttachment",
+                  "api-reference/@modelence/resend/type-aliases/EmailPayload"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "@modelence/aws-ses",
+            "pages": [
+              "api-reference/@modelence/aws-ses/index",
+              {
+                "group": "Functions",
+                "pages": [
+                  "api-reference/@modelence/aws-ses/functions/sendEmail"
+                ]
+              },
+              {
+                "group": "Variables",
+                "pages": [
+                  "api-reference/@modelence/aws-ses/variables/default"
+                ]
+              },
+              {
+                "group": "Type Aliases",
+                "pages": [
+                  "api-reference/@modelence/aws-ses/type-aliases/EmailAttachment",
+                  "api-reference/@modelence/aws-ses/type-aliases/EmailPayload"
+                ]
+              }
             ]
           }
         ]


### PR DESCRIPTION
* script sync api reference navigation
* update CI to check api reference navigation is in sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docs generation/CI and a deterministic nav-sync script; primary risk is CI failures or unintended docs navigation reshuffles if the script misclassifies pages.
> 
> **Overview**
> Automatically regenerates and **syncs `docs/web/docs.json`’s `API Reference` tab** from the MDX files under `docs/web/api-reference` via a new `docs/scripts/sync-api-reference-nav.ts` script (grouped by package, and by kind like *Classes/Functions/Type Aliases*).
> 
> Updates `docs/gen` so `npm run docs` runs TypeDoc *and* the nav sync (adding `tsx`), and updates the docs GitHub Action to run this combined step and **fail the build if `docs.json` changes aren’t committed**. The committed `docs.json` reflects the new structured API nav (replacing the prior hand-curated groupings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 228ba15febf0e9e4217502392ec2849689b2ec5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->