### PR TITLE
docs: add call method description

### DIFF
--- a/packages/modelence/src/client.ts
+++ b/packages/modelence/src/client.ts
@@ -14,7 +14,7 @@ export const AppProvider =
     : OriginalAppProvider;
 
 export { renderApp } from './client/renderApp';
-export { callMethod, MethodError, type MethodArgs } from './client/method';
+export { callMethod, MethodError, type MethodArgs, type CallMethodOptions } from './client/method';
 export { useSession } from './client/session';
 export {
   signupWithPassword,

--- a/packages/modelence/src/client/method.ts
+++ b/packages/modelence/src/client/method.ts
@@ -27,11 +27,41 @@ export type CallMethodOptions = {
   errorHandler?: (error: Error, methodName: string) => void;
 };
 
+/**
+ * Calls a server-side method (query or mutation) defined on a Modelence module.
+ *
+ * Both `args` and `options` are optional. Use the type parameter `T` to type the return value.
+ *
+ * @example
+ * ```typescript
+ * import { callMethod } from 'modelence/client';
+ *
+ * // No arguments
+ * const todos = await callMethod<Todo[]>('todo.getAll');
+ *
+ * // With arguments
+ * const todo = await callMethod<Todo>('todo.getOne', { id: '123' });
+ *
+ * // With a custom error handler
+ * const created = await callMethod<Todo>(
+ *   'todo.create',
+ *   { title: 'Buy groceries' },
+ *   { errorHandler: (error, methodName) => console.error(methodName, error) }
+ * );
+ * ```
+ *
+ * @param methodName - Fully qualified method name, e.g. `'todo.getAll'`.
+ * @param args - Arguments passed to the server-side method. Defaults to `{}`.
+ * @param options - Call-site options such as a custom {@link CallMethodOptions.errorHandler}. Defaults to `{}`.
+ * @returns A promise that resolves to the method's return value.
+ */
 export async function callMethod<T = unknown>(
   methodName: string,
-  args: MethodArgs = {},
-  options: CallMethodOptions = {}
+  args?: MethodArgs,
+  options?: CallMethodOptions
 ): Promise<T> {
+  args = args ?? {};
+  options = options ?? {};
   try {
     return await call<T>(`/api/_internal/method/${methodName}`, args);
   } catch (error) {


### PR DESCRIPTION
* add call method description
* export CallMethodOptions, it's required for proper typedoc only at the moment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is primarily API documentation and type-export adjustments, with only minor signature/defaulting changes to `callMethod`.
> 
> **Overview**
> Adds comprehensive TSDoc (including examples and parameter docs) for `callMethod` and exposes `CallMethodOptions` from `modelence/client` for typedoc/consumer typing.
> 
> Updates `callMethod` to accept optional `args`/`options` parameters and normalizes them internally to `{}` before invoking the request and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40745bb1c3aec468f304b5128c3aea3a0de06b9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->