### PR TITLE
docs: add github link

### DIFF
--- a/docs/web/authentication/index.mdx
+++ b/docs/web/authentication/index.mdx
@@ -16,6 +16,7 @@ Modelence authentication includes:
 - **[Hooks](/authentication/hooks)** - Add custom handlers and error rendering components for your authentication flow
 - **[Rate Limiting](/authentication/rate-limiting)** - Built-in protection against brute force attacks
 - **[Google Sign-In](/authentication/google-sign-in)** - OAuth authentication with Google accounts
+- **[GitHub Sign-In](/authentication/github-sign-in)** - OAuth authentication with GitHub accounts
 
 ## How Authentication Works
 
@@ -61,6 +62,17 @@ When a user logs in:
 2. **Session Update** - Current session is linked to the authenticated user
 3. **User Data** - User information is returned to the client
 4. **State Update** - Client-side session state is updated
+
+### OAuth Account Linking
+
+When a user signs in with an OAuth provider (Google or GitHub) using an email that already matches an existing email/password account, behavior is controlled by the [`oauthAccountLinking`](/api-reference/modelence/server/type-aliases/AuthConfig#oauthaccountlinking) auth config option:
+
+- **`'manual'`** (default) - The OAuth sign-in is rejected with an error: *"User with this email already exists. Please log in instead."* The user must log in with their existing password first and link the provider deliberately.
+- **`'auto'`** - The OAuth provider is automatically linked to the existing account, but only when **both** the OAuth-provided email is verified by the provider **and** the matching email on the existing account is also marked verified locally. This dual-verification requirement prevents pre-registration account takeover (e.g., someone registering a password account against an email they don't own, then waiting for the real owner to sign in via OAuth). When auto-linking succeeds, missing `firstName`, `lastName`, and `avatarUrl` fields are backfilled from the provider profile.
+
+If either email is unverified — even in `'auto'` mode — the sign-in is rejected with the same error.
+
+Once an OAuth provider is linked, subsequent sign-ins with the same provider look up the user directly by the provider's user ID, regardless of email.
 
 ## Basic Implementation
 


### PR DESCRIPTION
* add github link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates describing GitHub OAuth sign-in and the `oauthAccountLinking` configuration behavior; no runtime code paths change.
> 
> **Overview**
> Updates the auth overview docs to include **GitHub OAuth sign-in** and adds a new **OAuth account linking** section documenting how `oauthAccountLinking` (`'manual'` vs `'auto'`) handles existing email/password accounts, including the dual email-verification requirement and profile backfill behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8417ecd115f0f611b1bb2de2cbaf69ea9925493e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->