### PR TITLE
docs: rename rate limiting to custom rate limiting

### DIFF
--- a/docs/web/authentication/rate-limiting.mdx
+++ b/docs/web/authentication/rate-limiting.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Rate Limiting'
+title: 'Auth Rate Limiting'
 ---
 
 Modelence includes built-in rate limiting on all authentication endpoints to protect against brute force attacks and abuse.
@@ -38,4 +38,4 @@ and keeps a periodically updated dataset of all disposable email providers.
 
 ---
 
-For defining custom rate limits on your own modules, see [Rate Limiting](/rate-limiting).
+For defining custom rate limits on your own modules, see [Custom Rate Limiting](/rate-limiting).

--- a/docs/web/core-concepts/modules.mdx
+++ b/docs/web/core-concepts/modules.mdx
@@ -161,7 +161,7 @@ export default new Module('todo', {
 ```
 
 <Tip>
-Learn more about rate limiting in the [Rate Limiting documentation](/rate-limiting).
+Learn more about rate limiting in the [Custom Rate Limiting documentation](/rate-limiting).
 </Tip>
 
 ## Best Practices

--- a/docs/web/rate-limiting.mdx
+++ b/docs/web/rate-limiting.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Rate Limiting'
+title: 'Custom Rate Limiting'
 icon: 'gauge'
 ---
 


### PR DESCRIPTION
* rename rate limiting to custom rate limiting
* rename authentication -> rate limiting to authentication rate limiting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that renames page titles and updates internal links; main risk is broken/incorrect doc navigation if any external references rely on the old wording.
> 
> **Overview**
> Updates documentation to clearly separate built-in authentication limits from user-defined limits by renaming the auth page to **`Auth Rate Limiting`** and the generic page to **`Custom Rate Limiting`**.
> 
> Adjusts in-doc references (e.g., in `modules.mdx` and the auth rate limiting page) to point to the newly named *Custom Rate Limiting* documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 678ae1ad449b0211d09d668a75810c9fa14973a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->