### PR TITLE
docs: improve email docs

### DIFF
--- a/docs/gen/scripts/custom-frontmatter.mjs
+++ b/docs/gen/scripts/custom-frontmatter.mjs
@@ -41,10 +41,19 @@ export function load(app) {
 
       const baseUrl = ['api-reference', ...page.url.split('/').slice(0, -1).filter(Boolean)].join('/');
 
+      const pageSlug = page.url.split('/').pop()?.replace(/\.mdx$/, '') ?? '';
+
       // Add a leading dot to internal links to avoid target="_blank"
-      page.contents = page.contents.replace(/\]\(([^/)][^)#]*[^/])\)/g, (match, linkPath) => {
+      page.contents = page.contents.replace(/\]\(([^/)#][^)#]*[^/])\)/g, (match, linkPath) => {
         return `](/${baseUrl}/${linkPath})`;
       });
+
+      // Resolve same-page anchor links to the full page route so the docs link checker can validate them
+      if (pageSlug) {
+        page.contents = page.contents.replace(/\]\((#[^)]+)\)/g, (match, anchor) => {
+          return `](/${baseUrl}/${pageSlug}${anchor})`;
+        });
+      }
     }
   });
 }

--- a/docs/web/authentication/email-verification.mdx
+++ b/docs/web/authentication/email-verification.mdx
@@ -4,6 +4,8 @@ title: 'Email Verification'
 
 Email verification adds an extra layer of security by ensuring users own the email address they register with.
 
+> The email delivery setup below (provider, sender, template, redirect URL) is configured under the **`email:`** key of `startApp`. To run code when verification succeeds or fails, register the `onAfterEmailVerification` / `onEmailVerificationError` callbacks under **`auth:`** — see [Auth Hooks](/authentication/hooks).
+
 ## Enabling Email Verification
 
 First, configure your email provider (see [Email Configuration](/email)):

--- a/docs/web/authentication/hooks.mdx
+++ b/docs/web/authentication/hooks.mdx
@@ -2,7 +2,7 @@
 title: 'Auth Hooks'
 ---
 
-The [AuthConfig](/api-reference/modelence/server/type-aliases/AuthConfig) type provides hooks for authentication events. Configure these in your `startApp` call:
+The [AuthConfig](/api-reference/modelence/server/type-aliases/AuthConfig) type provides hooks for authentication events. Configure these in your `startApp` call under the **`auth:`** key.
 
 ## Validation Hooks
 

--- a/docs/web/authentication/index.mdx
+++ b/docs/web/authentication/index.mdx
@@ -17,6 +17,15 @@ Modelence authentication includes:
 - **[Rate Limiting](/authentication/rate-limiting)** - Built-in protection against brute force attacks
 - **[Google Sign-In](/authentication/google-sign-in)** - OAuth authentication with Google accounts
 
+## Where to configure what
+
+Modelence splits authentication configuration across two top-level keys in `startApp`:
+
+- **`auth: { ... }`** — authentication *lifecycle*: validation hooks (`validateSignup`, `validateProfileUpdate`), event callbacks (`onAfterLogin`, `onAfterSignup`, `onAfterEmailVerification`, …), `generateHandle`, OAuth linking behavior, and `rateLimits`. See [AuthConfig](/api-reference/modelence/server/type-aliases/AuthConfig) and [Hooks](/authentication/hooks).
+- **`email: { ... }`** — email *delivery*: the email provider, sender address, and per-flow templates/subjects/redirect URLs for `verification` and `passwordReset`. See [Email Configuration](/email).
+
+The two are complementary: `email:` controls whether and how the verification/reset email is delivered; `auth:` controls what happens when the user clicks the link (and the rest of the auth lifecycle).
+
 ## How Authentication Works
 
 ### Session Management

--- a/docs/web/authentication/password-reset.mdx
+++ b/docs/web/authentication/password-reset.mdx
@@ -4,6 +4,8 @@ title: 'Password Reset'
 
 Modelence provides a secure password reset flow with email tokens.
 
+> The reset email delivery setup below (provider, sender, template, redirect URL) is configured under the **`email:`** key of `startApp`. To run code on related auth events, register callbacks under **`auth:`** — see [Auth Hooks](/authentication/hooks).
+
 ## Configuration
 
 Configure password reset emails in your server setup:

--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -114,27 +114,88 @@ export type AuthOption = {
  * ```
  */
 export type AuthConfig = {
-  // Optional pre-signup validation hook.
+  /**
+   * Pre-signup validation hook. Runs before a new user is created during
+   * email/password signup, after format checks but before duplicate detection.
+   * Throw to reject the signup — the thrown message is surfaced to the client.
+   *
+   * Receives the raw signup payload (`email`, `password`, and optional
+   * `firstName`, `lastName`, `avatarUrl`, `handle`). May be async.
+   */
   validateSignup?: (props: SignupProps) => void | Promise<void>;
+
+  /**
+   * Pre-update validation hook. Runs before a user's profile fields
+   * (`firstName`, `lastName`, `avatarUrl`, `handle`) are written.
+   * Throw to reject the update — the thrown message is surfaced to the client.
+   * May be async.
+   */
   validateProfileUpdate?: (props: UpdateProfileProps) => void | Promise<void>;
 
-  // After Authentication callbacks
+  /**
+   * Fires after a successful login (email/password or OAuth) once the session
+   * has been linked to the user. Receives `{ provider, user, session, connectionInfo }`.
+   * Use for analytics, audit logging, or post-login side effects.
+   */
   onAfterLogin?: (props: AuthSuccessProps) => void;
+
+  /**
+   * Fires when a login attempt fails. Receives `{ provider, error, session, connectionInfo }`.
+   * Use for failure analytics or alerting — does NOT change the response sent to the client.
+   */
   onLoginError?: (props: AuthErrorProps) => void;
+
+  /**
+   * Fires after a successful signup once the user record is created and the
+   * session is linked. Receives `{ provider, user, session, connectionInfo }`.
+   * Common uses: send welcome email, create default workspace, track activation.
+   */
   onAfterSignup?: (props: AuthSuccessProps) => void;
+
+  /**
+   * Fires when a signup attempt fails (validation, duplicate email, etc.).
+   * Receives `{ provider, error, session, connectionInfo }`.
+   * Use for failure analytics — does NOT change the response sent to the client.
+   */
   onSignupError?: (props: AuthErrorProps) => void;
+
+  /**
+   * Fires after a user's email is successfully verified (via the verification
+   * link or implicitly via password reset). Receives `{ provider, user, session, connectionInfo }`.
+   */
   onAfterEmailVerification?: (props: AuthSuccessProps) => void;
+
+  /**
+   * Fires when email verification fails (invalid or expired token).
+   * Receives `{ provider, error, session, connectionInfo }`.
+   */
   onEmailVerificationError?: (props: AuthErrorProps) => void;
-  // OAuth account linking callbacks
+
+  /**
+   * Fires after an OAuth provider is linked to an existing account
+   * (either automatically when `oauthAccountLinking: 'auto'` or via an
+   * explicit link flow). Receives `{ provider, user, session, connectionInfo }`.
+   */
   onAfterOAuthLink?: (props: AuthSuccessProps) => void;
+
+  /**
+   * Fires when OAuth account linking fails. Receives
+   * `{ provider, error, session, connectionInfo }`.
+   */
   onOAuthLinkError?: (props: AuthErrorProps) => void;
-  // Custom handle generator.
-  // If provided, this overrides the default handle generation logic.
+
+  /**
+   * Custom handle generator. If provided, overrides the default behavior
+   * (which derives the handle from the email local-part). Receives
+   * `{ email, firstName?, lastName? }` and returns the desired handle
+   * synchronously or as a `Promise<string>`. If the returned handle collides
+   * with an existing one, Modelence appends a numeric suffix automatically.
+   */
   generateHandle?: (props: GenerateHandleProps) => Promise<string> | string;
 
-  /** deprecated: use onAfterLogin and onLoginError */
+  /** @deprecated Use {@link AuthConfig.onAfterLogin} and {@link AuthConfig.onLoginError} instead. */
   login?: AuthOption;
-  /** deprecated: user onAfterSignup and onSignupError */
+  /** @deprecated Use {@link AuthConfig.onAfterSignup} and {@link AuthConfig.onSignupError} instead. */
   signup?: AuthOption;
 
   /**
@@ -144,7 +205,18 @@ export type AuthConfig = {
    *   if the provider email is verified.
    */
   oauthAccountLinking?: 'auto' | 'manual';
+
+  /**
+   * Customizes how OAuth authentication errors are rendered. By default,
+   * OAuth errors are returned as JSON; providing this returns a custom HTML
+   * response instead, which is useful when the OAuth flow runs in a browser
+   * context. Receives `{ error, statusCode }` and returns an HTML string
+   * (or `null`/`undefined` to fall back to the default JSON response).
+   *
+   * Always escape interpolated values to prevent XSS.
+   */
   errorComponent?: (props: OAuthErrorInfo) => string | null | undefined;
+
   /**
    * Overrides the built-in rate limits for authentication endpoints.
    * Only the fields you specify are overridden; all others keep their defaults.


### PR DESCRIPTION
* improve email docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and JSDoc comment improvements; the only functional change is docs-generation link rewriting, which could affect generated API reference navigation if the regex is wrong.
> 
> **Overview**
> Clarifies documentation around where to configure email delivery (`email:`) vs auth lifecycle hooks (`auth:`), adding cross-links and a new “where to configure what” section across the auth overview, email verification, password reset, and hooks pages.
> 
> Improves `typedoc` markdown post-processing to better rewrite internal links (handling `#` anchors and expanding same-page anchors to full routes) so link checking and navigation work in generated API reference pages.
> 
> Expands inline JSDoc on `AuthConfig` to more explicitly document hook timing, payloads, and deprecations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdfc41d97b429f499591777c9051f478b71022d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->