### PR TITLE
docs: remove data api demo

### DIFF
--- a/docs/web/data-api.mdx
+++ b/docs/web/data-api.mdx
@@ -75,7 +75,7 @@ The Data API supports two authentication methods:
 
 #### 1. Direct API Key Authentication
 
-Set the api key as the value of 'dataApi.apiKey' in Modelence Cloud from the Application page. (Alternatively you can use DATA_API_KEY environment variable).
+Set the api key as the value of `dataApi.apiKey` in Modelence Cloud from the Application page. (Alternatively you can use the `DATA_API_KEY` environment variable).
 
 Use the `apiKey` header in your requests:
 

--- a/docs/web/data-api.mdx
+++ b/docs/web/data-api.mdx
@@ -18,10 +18,6 @@ An open-source API to read, write, and aggregate data in MongoDB. The applicatio
 - **Authentication**: API key-based security
 - **MongoDB Operations**: Direct access to MongoDB features
 
-## Sandbox
-
-Try the Data API live at [data-api-demo.modelence.app](http://data-api-demo.modelence.app/) to explore all endpoints and test operations without setup.
-
 ## Project Setup
 
 ### 1. Create a new application

--- a/docs/web/telemetry.mdx
+++ b/docs/web/telemetry.mdx
@@ -77,7 +77,7 @@ logError(message: string, args: object)
 
 ## Environment Variables
 
-### MODELENCE_LOG_LEVEL
+### `MODELENCE_LOG_LEVEL`
 
 Controls the verbosity of console logging. This is especially useful during local development or when debugging production issues.
 

--- a/docs/web/voyage-ai.mdx
+++ b/docs/web/voyage-ai.mdx
@@ -67,7 +67,7 @@ You can also view a [live demo](https://voyage-ai-mg8435n3pj5-sandbox.prod.model
 
 If you want to add Voyage AI to an existing project, follow these steps:
 
-### Step 1: Install Dependencies
+## Step 1: Install Dependencies
 
 Install the Voyage AI client library:
 


### PR DESCRIPTION
* remove data api demo
* fix minor issues in data api, telemetry, voyage ai

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits removing an external demo reference and fixing minor markdown formatting; no product code or runtime behavior changes.
> 
> **Overview**
> Removes the **Data API sandbox/demo** section and link from `docs/web/data-api.mdx`.
> 
> Cleans up minor documentation formatting: wraps config keys/env vars in backticks (Data API auth + Telemetry `MODELENCE_LOG_LEVEL`) and normalizes a heading level in the Voyage AI guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee66e50bf79b1839d76ddce59ffc01b92e0e7bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->