### PR TITLE
Update: Added req and res to context parameter of handlers on runMethod

### DIFF
--- a/packages/modelence/src/app/server.test.ts
+++ b/packages/modelence/src/app/server.test.ts
@@ -259,7 +259,7 @@ describe('app/server getCallContext', () => {
       roles: ['user'],
     } as never);
 
-    const ctx = await getCallContext(req);
+    const ctx = await getCallContext(req, {} as Response);
 
     expect(mockAuthenticate).toHaveBeenCalledWith('cookie-token');
     expect(ctx.session?.authToken).toBe('session-token');
@@ -284,7 +284,7 @@ describe('app/server getCallContext', () => {
     });
     mockGetMongodbUri.mockReturnValue('');
 
-    const ctx = await getCallContext(req);
+    const ctx = await getCallContext(req, {} as Response);
 
     expect(ctx.session).toBeNull();
     expect(ctx.roles).toEqual(['guest']);
@@ -298,7 +298,7 @@ describe('app/server getCallContext', () => {
     });
     mockGetMongodbUri.mockReturnValue('');
 
-    const ctx = await getCallContext(req);
+    const ctx = await getCallContext(req, {} as Response);
 
     expect(ctx.connectionInfo.ip).toBe('192.168.0.10');
   });
@@ -315,7 +315,7 @@ describe('app/server getCallContext', () => {
       roles: ['user'],
     } as never);
 
-    const ctx = await getCallContext(req);
+    const ctx = await getCallContext(req, {} as Response);
 
     expect(mockAuthenticate).toHaveBeenCalledWith('body-token');
     expect(ctx.session?.authToken).toBe('body-token');
@@ -327,7 +327,7 @@ describe('app/server getCallContext', () => {
     });
     mockGetMongodbUri.mockReturnValue('');
 
-    const ctx = await getCallContext(req);
+    const ctx = await getCallContext(req, {} as Response);
 
     expect(ctx.session).toBeNull();
     expect(ctx.roles).toEqual(['guest']);
@@ -339,7 +339,7 @@ describe('app/server getCallContext', () => {
     });
     mockGetMongodbUri.mockReturnValue('');
 
-    const ctx = await getCallContext(req);
+    const ctx = await getCallContext(req, {} as Response);
 
     expect(ctx.clientInfo).toEqual({
       screenWidth: 0,
@@ -363,7 +363,7 @@ describe('app/server getCallContext', () => {
     });
     mockGetMongodbUri.mockReturnValue('');
 
-    const ctx = await getCallContext(req);
+    const ctx = await getCallContext(req, {} as Response);
 
     expect(ctx.connectionInfo).toEqual({
       ip: undefined,
@@ -383,7 +383,7 @@ describe('app/server getCallContext', () => {
     });
     mockGetMongodbUri.mockReturnValue('');
 
-    const ctx = await getCallContext(req);
+    const ctx = await getCallContext(req, {} as Response);
 
     expect(ctx.connectionInfo.ip).toBe('1.2.3.4');
   });
@@ -395,7 +395,7 @@ describe('app/server getCallContext', () => {
     req.headers['x-forwarded-for'] = ['1.2.3.4', '5.6.7.8'];
     mockGetMongodbUri.mockReturnValue('');
 
-    const ctx = await getCallContext(req);
+    const ctx = await getCallContext(req, {} as Response);
 
     expect(ctx.connectionInfo.ip).toBe('1.2.3.4');
   });
@@ -407,7 +407,7 @@ describe('app/server getCallContext', () => {
     req.socket = { remoteAddress: '10.0.0.5' } as unknown as Request['socket'];
     mockGetMongodbUri.mockReturnValue('');
 
-    const ctx = await getCallContext(req);
+    const ctx = await getCallContext(req, {} as Response);
 
     expect(ctx.connectionInfo.ip).toBe('10.0.0.5');
   });

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -9,7 +9,7 @@ import cookieParser from 'cookie-parser';
 import express, { Request, Response } from 'express';
 import http from 'http';
 import z from 'zod';
-import type { AppServer } from '../types';
+import type { AppServer, HttpContext } from '../types';
 import { authenticate } from '../auth';
 import { getUnauthenticatedRoles } from '../auth/role';
 import { getMongodbUri } from '../db/client';
@@ -102,7 +102,7 @@ export async function startServer(
 
   // Set httpOnly cookie for OAuth linking flow
   app.post('/api/_internal/auth/set-link-cookie', async (req: Request, res: Response) => {
-    const { session } = await getCallContext(req);
+    const { session } = await getCallContext(req, res);
 
     if (!session?.userId) {
       res.status(401).json({ error: 'Not authenticated' });
@@ -121,8 +121,8 @@ export async function startServer(
   });
 
   app.post('/api/_internal/method/:methodName(*)', async (req: Request, res: Response) => {
-    const { methodName } = req.params;
-    const context = await getCallContext(req);
+    const methodName = req.params.methodName as string;
+    const context = await getCallContext(req, res);
 
     try {
       const result = sanitizeResult(await runMethod(methodName, req.body.args, context));
@@ -176,7 +176,7 @@ export async function startServer(
   });
 }
 
-export async function getCallContext(req: Request) {
+export async function getCallContext(req: Request, res: Response): Promise<HttpContext> {
   const path = (req.path ?? req.url ?? '').split('?')[0];
 
   const isOAuthCallback = path.startsWith('/api/_internal/auth/') && path.endsWith('/callback');
@@ -227,6 +227,8 @@ export async function getCallContext(req: Request) {
       session,
       user,
       roles,
+      req,
+      res,
     };
   }
 
@@ -236,6 +238,8 @@ export async function getCallContext(req: Request) {
     session: null,
     user: null,
     roles: getUnauthenticatedRoles(),
+    req,
+    res,
   };
 }
 

--- a/packages/modelence/src/auth/providers/oauth-common.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.ts
@@ -302,7 +302,7 @@ export async function handleOAuthUserAuthentication(
     [`authMethods.${userData.providerName}.id`]: userData.id,
   });
 
-  const { session, connectionInfo } = await getCallContext(req);
+  const { session, connectionInfo } = await getCallContext(req, res);
 
   if (existingUser) {
     return handleExistingProviderLogin(res, userData, existingUser, session, connectionInfo);
@@ -396,7 +396,7 @@ export async function handleOAuthProviderLink(
   userData: OAuthUserData
 ): Promise<void> {
   const authConfig = getAuthConfig();
-  const { session, connectionInfo } = await getCallContext(req);
+  const { session, connectionInfo } = await getCallContext(req, res);
 
   if (!session?.userId) {
     clearOAuthLinkCookie(res);

--- a/packages/modelence/src/methods/index.ts
+++ b/packages/modelence/src/methods/index.ts
@@ -1,7 +1,7 @@
 import { requireServer } from '../utils';
 import { startTransaction } from '@/telemetry';
 import { requireAccess } from '../auth/role';
-import { Method, MethodDefinition, MethodType, Args, Context } from './types';
+import { Method, MethodDefinition, MethodType, Args, Context, HttpContext } from './types';
 import { LiveData } from '../live-query';
 
 const methods: Record<string, Method<unknown>> = {};
@@ -64,7 +64,7 @@ function _createMethodInternal<T = unknown>(
   methods[name] = { type, name, handler, permissions };
 }
 
-export async function runMethod(name: string, args: Args, context: Context) {
+export async function runMethod(name: string, args: Args, context: HttpContext) {
   requireServer();
 
   const method = methods[name];

--- a/packages/modelence/src/methods/types.ts
+++ b/packages/modelence/src/methods/types.ts
@@ -1,4 +1,5 @@
 import { Session, UserInfo, Permission } from '../auth/types';
+import { Request, Response } from 'express';
 
 export type ClientInfo = {
   screenWidth: number;
@@ -25,6 +26,11 @@ export type Context = {
   connectionInfo: ConnectionInfo;
 };
 
+export type HttpContext = Context & {
+  req: Request;
+  res: Response;
+};
+
 export type Args = Record<string, unknown>;
 
 export type UpdateProfileProps = {
@@ -39,7 +45,7 @@ export type SignupProps = UpdateProfileProps & {
   password: string;
 };
 
-export type Handler<T = unknown> = (args: Args, context: Context) => Promise<T> | T;
+export type Handler<T = unknown> = (args: Args, context: Context | HttpContext) => Promise<T> | T;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyMethodShape = ((...args: any[]) => any) | { handler: (...args: any[]) => any };

--- a/packages/modelence/src/methods/types.ts
+++ b/packages/modelence/src/methods/types.ts
@@ -45,6 +45,7 @@ export type SignupProps = UpdateProfileProps & {
   password: string;
 };
 
+// TODO: Query-mutation and live query share the same handler, but only runMethod provides HttpContext (req, res) and Live queries receive plain Context, so handlers typed with HttpContext may access undefined req-res and fail at runtime.
 export type Handler<T = unknown> = (args: Args, context: Context | HttpContext) => Promise<T> | T;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/modelence/src/routes/handler.ts
+++ b/packages/modelence/src/routes/handler.ts
@@ -34,7 +34,7 @@ export function createRouteHandler(method: string, path: string, handler: RouteH
         {
           query: req.query as Record<string, string>,
           body: req.body,
-          params: req.params,
+          params: req.params as Record<string, string>,
           headers: req.headers as Record<string, string>,
           cookies: req.cookies,
           rawBody: Buffer.isBuffer(req.body) ? req.body : undefined,


### PR DESCRIPTION
Added a new type:

In `src/methods/types.ts`

```ts
export type HttpContext = Context & {
  req: Request;
  res: Response;
};
```

This provides guaranteed access to `req` and `res` in all `runMethod` handlers.

`runLiveMethod` handlers use sockets, so `req` and `res` are not available there and I intentionally excluded them.

--
Instead of manually accessing request data from a generic context, we can use `HttpContext` in handlers,

```ts
import { z } from 'zod';
import { Module, ObjectId } from 'modelence/server';
import { dbTodos } from './db';
import { HttpContext } from 'modelence/types';

export default new Module('todos', {
  stores: [dbTodos],
  queries: {
    async getAll() {
      return await dbTodos.fetch({});
    },
  },
  mutations: {
    async setCompleted(args, { req, res }: HttpContext) {
      console.log(req.method);
      console.log(req.cookies);
    },
  },
});
```

Testing

I Tested this update locally, accessing values from `req` inside handlers:

```ts
console.log(req.method);
console.log(req.cookies);
```

Verified that request method and cookies were available and returned expected values.
<img width="1158" height="490" alt="Screenshot (725)" src="https://github.com/user-attachments/assets/61f93130-15de-4c69-b9ac-15f56862573a" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the shape and typing of the server-side method context and threads Express `req`/`res` through authentication and method execution paths; incorrect assumptions can cause runtime issues for non-HTTP (live) handlers.
> 
> **Overview**
> **Adds an HTTP-specific context type and threads Express request/response through server method execution.** `getCallContext` now requires `res` and returns a `HttpContext` that includes `req`/`res`, and the internal method endpoint passes this through to `runMethod` so method handlers can access HTTP primitives.
> 
> OAuth flows were updated to call `getCallContext(req, res)`, tests were adjusted accordingly, and route handler request params are tightened to `Record<string, string>` to match expected handler input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7979c56245e17594c05071840425c579e03094c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->