### PR TITLE
chore: update API reference

### DIFF
--- a/docs/web/docs.json
+++ b/docs/web/docs.json
@@ -127,6 +127,7 @@
                       "api-reference/modelence/server/type-aliases/AppOptions",
                       "api-reference/modelence/server/type-aliases/AuthConfig",
                       "api-reference/modelence/server/type-aliases/AuthOption",
+                      "api-reference/modelence/server/type-aliases/AuthRateLimitOverride",
                       "api-reference/modelence/server/type-aliases/AuthRateLimitsConfig",
                       "api-reference/modelence/server/type-aliases/CloudBackendConnectResponse",
                       "api-reference/modelence/server/type-aliases/ConfigType",
@@ -207,6 +208,7 @@
                   {
                     "group": "Type Aliases",
                     "pages": [
+                      "api-reference/modelence/client/type-aliases/CallMethodOptions",
                       "api-reference/modelence/client/type-aliases/MethodArgs",
                       "api-reference/modelence/client/type-aliases/UserInfo"
                     ]
@@ -392,18 +394,6 @@
                   "api-reference/@modelence/aws-ses/type-aliases/EmailPayload"
                 ]
               }
-            ]
-          },
-          {
-            "group": "WebSockets",
-            "pages": [
-              "api-reference/modelence/server/classes/ServerChannel",
-              "api-reference/modelence/client/classes/ClientChannel",
-              "api-reference/modelence/client/functions/startWebsockets",
-              "api-reference/modelence/index/interfaces/WebsocketServerProvider",
-              "api-reference/modelence/index/interfaces/WebsocketClientProvider",
-              "api-reference/modelence/client/functions/setWebsocketClientProvider",
-              "api-reference/modelence/client/functions/getWebsocketClientProvider"
             ]
           }
         ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, documentation-only navigation changes; main risk is broken/removed links in the generated API reference sidebar.
> 
> **Overview**
> Refreshes `docs/web/docs.json` API Reference navigation by adding new type-alias pages (`AuthRateLimitOverride` on server and `CallMethodOptions` on client).
> 
> Removes the separate **WebSockets** navigation group from the sidebar (its pages are no longer listed under that standalone section).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099b9f29f573412df7015fad14b43229801589a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->