### PR TITLE
docs: add onBeforeSignup to hooks.mdx

### DIFF
--- a/docs/web/authentication/hooks.mdx
+++ b/docs/web/authentication/hooks.mdx
@@ -43,6 +43,8 @@ startApp({
 
 ### `onBeforeSignup`
 
+<Note>Available since `modelence@0.17.0`.</Note>
+
 Called after `validateSignup` and the built-in disposable-email check, but before the user document is inserted. Use this to plug in a custom domain-policy check (e.g. a tenant-specific email-domain verification service) without disabling the built-in disposable-email check. Throw an error to reject the signup — the thrown error is re-thrown to the caller and `onSignupError` fires.
 
 Currently only invoked for `'email'` provider signups. OAuth signups are not gated because OAuth providers (Google, GitHub, etc.) do not issue disposable accounts.
@@ -63,7 +65,7 @@ startApp({
 });
 ```
 
-To replace the built-in disposable-email check entirely with your own logic, set `allowDisposableEmails: true` and enforce your policy in `onBeforeSignup`.
+To replace the built-in disposable-email check entirely with your own logic, set `allowDisposableEmails: true` (also available since `modelence@0.17.0`) and enforce your policy in `onBeforeSignup`.
 
 ```typescript
 startApp({

--- a/docs/web/authentication/hooks.mdx
+++ b/docs/web/authentication/hooks.mdx
@@ -41,6 +41,57 @@ startApp({
 
 **Returns:** `void | Promise<void>` 
 
+### `onBeforeSignup`
+
+Called after `validateSignup` and the built-in disposable-email check, but before the user document is inserted. Use this to plug in a custom domain-policy check (e.g. a tenant-specific email-domain verification service) without disabling the built-in disposable-email check. Throw an error to reject the signup — the thrown error is re-thrown to the caller and `onSignupError` fires.
+
+Currently only invoked for `'email'` provider signups. OAuth signups are not gated because OAuth providers (Google, GitHub, etc.) do not issue disposable accounts.
+
+```typescript
+import { startApp } from 'modelence/server';
+
+startApp({
+  auth: {
+    onBeforeSignup: async ({ email, firstName, lastName, handle, provider, connectionInfo }) => {
+      const domain = email.split('@')[1];
+      const allowed = await isAllowedDomain(domain);
+      if (!allowed) {
+        throw new Error(`Signups from ${domain} are not allowed`);
+      }
+    },
+  },
+});
+```
+
+To replace the built-in disposable-email check entirely with your own logic, set `allowDisposableEmails: true` and enforce your policy in `onBeforeSignup`.
+
+```typescript
+startApp({
+  auth: {
+    allowDisposableEmails: true,
+    onBeforeSignup: async ({ email }) => {
+      const verdict = await classifyEmailDomain(email);
+      if (verdict === 'disposable') {
+        throw new Error('Disposable email addresses are not allowed');
+      }
+    },
+  },
+});
+```
+
+**Props:**
+
+| Property         | Type                       |
+| ---------------- | -------------------------- |
+| `email`          | `string`                   |
+| `firstName`      | `string \| undefined`      |
+| `lastName`       | `string \| undefined`      |
+| `handle`         | `string \| undefined`      |
+| `provider`       | `'email'`                  |
+| `connectionInfo` | `ConnectionInfo \| undefined` |
+
+**Returns:** `void | Promise<void>`
+
 ### `validateProfileUpdate`
 
 Called before a user's profile is updated. Use this to enforce custom validation rules on profile updates. Throw an error to reject the update.
@@ -176,6 +227,12 @@ startApp({
     validateProfileUpdate: ({ handle }) => {
       if (handle && !/^[a-z0-9-]+$/.test(handle)) {
         throw new Error('Handle can only contain lowercase letters, numbers, and hyphens');
+      }
+    },
+    onBeforeSignup: async ({ email }) => {
+      const domain = email.split('@')[1];
+      if (domain === 'blocked.example') {
+        throw new Error(`Signups from ${domain} are not allowed`);
       }
     },
     generateHandle: ({ email, firstName, lastName }) => {


### PR DESCRIPTION
* add onBeforeSignup to hooks.mdx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes with no runtime or security-sensitive code modifications.
> 
> **Overview**
> Documents a new `auth.onBeforeSignup` hook (available since `modelence@0.17.0`), including when it runs in the signup flow, limitations (email provider only), and the error behavior.
> 
> Updates the “Full Example” to include an `onBeforeSignup` sample and notes how to pair it with `allowDisposableEmails: true` to fully replace the built-in disposable-email check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdcb580be9777f89faf1b8fe559279fd10ce03ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->