### PR TITLE
feat: add react native support

### DIFF
--- a/docs/web/docs.json
+++ b/docs/web/docs.json
@@ -182,7 +182,6 @@
                     "group": "Functions",
                     "pages": [
                       "api-reference/modelence/client/functions/callMethod",
-                      "api-reference/modelence/client/functions/configureClient",
                       "api-reference/modelence/client/functions/connectModelenceQueryClient",
                       "api-reference/modelence/client/functions/createClientModule",
                       "api-reference/modelence/client/functions/createQueryKey",
@@ -226,7 +225,6 @@
                     "group": "Type Aliases",
                     "pages": [
                       "api-reference/modelence/client/type-aliases/CallMethodOptions",
-                      "api-reference/modelence/client/type-aliases/ClientConfig",
                       "api-reference/modelence/client/type-aliases/MethodArgs",
                       "api-reference/modelence/client/type-aliases/ModelenceQueryKey",
                       "api-reference/modelence/client/type-aliases/UserInfo"

--- a/docs/web/docs.json
+++ b/docs/web/docs.json
@@ -18,7 +18,8 @@
             "pages": [
               "index",
               "quickstart",
-              "setup"
+              "setup",
+              "react-native"
             ]
           },
           {
@@ -181,6 +182,7 @@
                     "group": "Functions",
                     "pages": [
                       "api-reference/modelence/client/functions/callMethod",
+                      "api-reference/modelence/client/functions/configureClient",
                       "api-reference/modelence/client/functions/connectModelenceQueryClient",
                       "api-reference/modelence/client/functions/createClientModule",
                       "api-reference/modelence/client/functions/createQueryKey",
@@ -224,6 +226,7 @@
                     "group": "Type Aliases",
                     "pages": [
                       "api-reference/modelence/client/type-aliases/CallMethodOptions",
+                      "api-reference/modelence/client/type-aliases/ClientConfig",
                       "api-reference/modelence/client/type-aliases/MethodArgs",
                       "api-reference/modelence/client/type-aliases/ModelenceQueryKey",
                       "api-reference/modelence/client/type-aliases/UserInfo"

--- a/docs/web/docs.json
+++ b/docs/web/docs.json
@@ -173,15 +173,19 @@
                     "group": "Classes",
                     "pages": [
                       "api-reference/modelence/client/classes/ClientChannel",
-                      "api-reference/modelence/client/classes/MethodError"
+                      "api-reference/modelence/client/classes/MethodError",
+                      "api-reference/modelence/client/classes/ModelenceQueryClient"
                     ]
                   },
                   {
                     "group": "Functions",
                     "pages": [
                       "api-reference/modelence/client/functions/callMethod",
+                      "api-reference/modelence/client/functions/connectModelenceQueryClient",
                       "api-reference/modelence/client/functions/createClientModule",
+                      "api-reference/modelence/client/functions/createQueryKey",
                       "api-reference/modelence/client/functions/deleteFile",
+                      "api-reference/modelence/client/functions/disconnectModelenceQueryClient",
                       "api-reference/modelence/client/functions/downloadFile",
                       "api-reference/modelence/client/functions/getConfig",
                       "api-reference/modelence/client/functions/getFileUrl",
@@ -190,6 +194,10 @@
                       "api-reference/modelence/client/functions/linkOAuthProvider",
                       "api-reference/modelence/client/functions/loginWithPassword",
                       "api-reference/modelence/client/functions/logout",
+                      "api-reference/modelence/client/functions/modelenceLiveQuery",
+                      "api-reference/modelence/client/functions/modelenceMutation",
+                      "api-reference/modelence/client/functions/modelenceQuery",
+                      "api-reference/modelence/client/functions/ModelenceQueryProvider",
                       "api-reference/modelence/client/functions/renderApp",
                       "api-reference/modelence/client/functions/resendEmailVerification",
                       "api-reference/modelence/client/functions/resetPassword",
@@ -217,6 +225,7 @@
                     "pages": [
                       "api-reference/modelence/client/type-aliases/CallMethodOptions",
                       "api-reference/modelence/client/type-aliases/MethodArgs",
+                      "api-reference/modelence/client/type-aliases/ModelenceQueryKey",
                       "api-reference/modelence/client/type-aliases/UserInfo"
                     ]
                   }

--- a/docs/web/docs.json
+++ b/docs/web/docs.json
@@ -174,19 +174,22 @@
                     "group": "Classes",
                     "pages": [
                       "api-reference/modelence/client/classes/ClientChannel",
-                      "api-reference/modelence/client/classes/MethodError",
-                      "api-reference/modelence/client/classes/ModelenceQueryClient"
+                      "api-reference/modelence/client/classes/MethodError"
+                    ]
+                  },
+                  {
+                    "group": "Interfaces",
+                    "pages": [
+                      "api-reference/modelence/client/interfaces/ClientConfig"
                     ]
                   },
                   {
                     "group": "Functions",
                     "pages": [
                       "api-reference/modelence/client/functions/callMethod",
-                      "api-reference/modelence/client/functions/connectModelenceQueryClient",
+                      "api-reference/modelence/client/functions/configureClient",
                       "api-reference/modelence/client/functions/createClientModule",
-                      "api-reference/modelence/client/functions/createQueryKey",
                       "api-reference/modelence/client/functions/deleteFile",
-                      "api-reference/modelence/client/functions/disconnectModelenceQueryClient",
                       "api-reference/modelence/client/functions/downloadFile",
                       "api-reference/modelence/client/functions/getConfig",
                       "api-reference/modelence/client/functions/getFileUrl",
@@ -195,10 +198,6 @@
                       "api-reference/modelence/client/functions/linkOAuthProvider",
                       "api-reference/modelence/client/functions/loginWithPassword",
                       "api-reference/modelence/client/functions/logout",
-                      "api-reference/modelence/client/functions/modelenceLiveQuery",
-                      "api-reference/modelence/client/functions/modelenceMutation",
-                      "api-reference/modelence/client/functions/modelenceQuery",
-                      "api-reference/modelence/client/functions/ModelenceQueryProvider",
                       "api-reference/modelence/client/functions/renderApp",
                       "api-reference/modelence/client/functions/resendEmailVerification",
                       "api-reference/modelence/client/functions/resetPassword",
@@ -226,7 +225,6 @@
                     "pages": [
                       "api-reference/modelence/client/type-aliases/CallMethodOptions",
                       "api-reference/modelence/client/type-aliases/MethodArgs",
-                      "api-reference/modelence/client/type-aliases/ModelenceQueryKey",
                       "api-reference/modelence/client/type-aliases/UserInfo"
                     ]
                   }

--- a/docs/web/react-native.mdx
+++ b/docs/web/react-native.mdx
@@ -1,0 +1,164 @@
+---
+title: 'React Native'
+icon: 'mobile'
+---
+
+Modelence's client library works in React Native. Because React Native lacks browser APIs like `localStorage` and `window`, you configure the client with `configureClient` so the SDK knows how to store auth tokens, read device dimensions, and resolve server URLs.
+
+## Setup
+
+<Steps>
+  <Step title="Install dependencies">
+    Add Modelence to your React Native project:
+
+    ```bash
+    npm install modelence
+    ```
+
+    You'll also need `@react-native-async-storage/async-storage` (or any other persistent key-value store) to persist the auth token across app restarts.
+
+    ```bash
+    npm install @react-native-async-storage/async-storage
+    ```
+  </Step>
+
+  <Step title="Configure the client">
+    Call `configureClient` once, before your app mounts — for example at the top of your entry file (`App.tsx` or `index.ts`).
+
+    ```typescript
+    import { configureClient } from 'modelence/client';
+    import AsyncStorage from '@react-native-async-storage/async-storage';
+    import { Dimensions, Linking, PixelRatio } from 'react-native';
+
+    const AUTH_TOKEN_KEY = 'modelence_auth_token';
+
+    configureClient({
+      baseUrl: 'https://your-modelence-app.com',
+
+      getAuthToken: async () => {
+        return (await AsyncStorage.getItem(AUTH_TOKEN_KEY)) ?? undefined;
+      },
+
+      setAuthToken: async (token) => {
+        if (token === null) {
+          await AsyncStorage.removeItem(AUTH_TOKEN_KEY);
+        } else {
+          await AsyncStorage.setItem(AUTH_TOKEN_KEY, token);
+        }
+      },
+
+      getClientInfo: () => {
+        const screen = Dimensions.get('screen');
+        const window = Dimensions.get('window');
+        return {
+          screenWidth: screen.width,
+          screenHeight: screen.height,
+          windowWidth: window.width,
+          windowHeight: window.height,
+          pixelRatio: PixelRatio.get(),
+          orientation: screen.width > screen.height ? 'landscape' : 'portrait',
+        };
+      },
+
+      // Used for OAuth redirects — opens the URL in the device browser
+      openUrl: (url) => Linking.openURL(url),
+    });
+    ```
+  </Step>
+
+  <Step title="Wrap your app with AppProvider">
+    Wrap your root component with `AppProvider` the same way you would in a web app:
+
+    ```tsx
+    import { AppProvider } from 'modelence/client';
+
+    export default function App() {
+      return (
+        <AppProvider>
+          <RootNavigator />
+        </AppProvider>
+      );
+    }
+    ```
+  </Step>
+</Steps>
+
+## ClientConfig reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `baseUrl` | `string` | Absolute URL of your Modelence server, e.g. `https://myapp.com`. All API and WebSocket connections are made relative to this URL. |
+| `getAuthToken` | `() => string \| undefined` | Returns the stored auth token. Called before every request. |
+| `setAuthToken` | `(token: string \| null) => void` | Persists or clears the auth token. Called after login, signup, and logout. |
+| `getClientInfo` | `() => ClientInfo` | Returns device screen dimensions and pixel ratio. Used for telemetry. |
+| `openUrl` | `(url: string) => void` | _(Optional)_ Opens a URL externally. Defaults to `window.location.href` assignment in browsers. Pass `Linking.openURL` for React Native OAuth redirects. |
+
+## Using authentication
+
+Auth functions work the same way as on the web:
+
+```typescript
+import { loginWithPassword, logout, useSession } from 'modelence/client';
+
+// Login
+await loginWithPassword({ email: 'user@example.com', password: 'secret' });
+
+// Access current user
+function ProfileScreen() {
+  const { user } = useSession();
+  if (!user) return <Text>Not logged in</Text>;
+  return <Text>Hello, {user.handle}</Text>;
+}
+
+// Logout
+await logout(); // clears the stored token via setAuthToken(null)
+```
+
+## Calling methods
+
+`callMethod` works without any changes — it automatically prepends `baseUrl` to every request:
+
+```typescript
+import { callMethod } from 'modelence/client';
+
+const result = await callMethod('myModule.getData', { id: '123' });
+```
+
+## Live queries and WebSockets
+
+Live queries connect over WebSocket to `baseUrl`. No additional configuration is needed beyond `configureClient`:
+
+```typescript
+import { useQuery } from 'modelence/client';
+import { myModule } from './modules/myModule';
+
+function ItemList() {
+  const items = useQuery(myModule.queries.listItems);
+  return items?.map(item => <Text key={item._id}>{item.name}</Text>);
+}
+```
+
+## OAuth sign-in
+
+For Google or GitHub sign-in, Modelence opens an OAuth URL in the browser. On React Native, provide `openUrl` in `configureClient` so the SDK can hand off to the device browser via `Linking.openURL`:
+
+```typescript
+import { linkOAuthProvider } from 'modelence/client';
+import { Linking } from 'react-native';
+
+configureClient({
+  // ...
+  openUrl: (url) => Linking.openURL(url),
+});
+
+// Trigger OAuth linking
+await linkOAuthProvider({ provider: 'google' });
+```
+
+After the OAuth flow completes, the provider redirects back to your app via a deep link. Configure your deep link scheme to call `loginWithOAuth` with the returned token.
+
+## Notes
+
+- **No `AppProvider` required for auth-only usage.** You can call `loginWithPassword`, `callMethod`, etc. without `AppProvider`. The provider is needed only if you use React hooks like `useSession` or `useQuery`.
+- **Token persistence is your responsibility.** Modelence calls `setAuthToken` and `getAuthToken` but does not bundle a storage library. Use `AsyncStorage`, `expo-secure-store`, or any store that fits your security requirements.
+- **`orientation` in `ClientInfo` is optional.** Pass `null` if your app does not track orientation.

--- a/docs/web/react-native.mdx
+++ b/docs/web/react-native.mdx
@@ -34,18 +34,27 @@ Modelence's client library works in React Native. Because React Native lacks bro
 
     const AUTH_TOKEN_KEY = 'modelence_auth_token';
 
+    // getAuthToken is called synchronously on every request, so we keep the
+    // token in memory and mirror writes to AsyncStorage for persistence across
+    // app restarts. Load the persisted value before mounting your app (see
+    // the loadAuthToken helper below).
+    let authToken: string | undefined;
+
+    export async function loadAuthToken() {
+      authToken = (await AsyncStorage.getItem(AUTH_TOKEN_KEY)) ?? undefined;
+    }
+
     configureClient({
       baseUrl: 'https://your-modelence-app.com',
 
-      getAuthToken: async () => {
-        return (await AsyncStorage.getItem(AUTH_TOKEN_KEY)) ?? undefined;
-      },
+      getAuthToken: () => authToken,
 
-      setAuthToken: async (token) => {
+      setAuthToken: (token) => {
+        authToken = token ?? undefined;
         if (token === null) {
-          await AsyncStorage.removeItem(AUTH_TOKEN_KEY);
+          AsyncStorage.removeItem(AUTH_TOKEN_KEY);
         } else {
-          await AsyncStorage.setItem(AUTH_TOKEN_KEY, token);
+          AsyncStorage.setItem(AUTH_TOKEN_KEY, token);
         }
       },
 
@@ -69,12 +78,22 @@ Modelence's client library works in React Native. Because React Native lacks bro
   </Step>
 
   <Step title="Wrap your app with AppProvider">
-    Wrap your root component with `AppProvider` the same way you would in a web app:
+    Load the persisted auth token before mounting your app, then wrap your root component with `AppProvider`:
 
     ```tsx
     import { AppProvider } from 'modelence/client';
+    import { loadAuthToken } from './modelenceConfig'; // the file from the previous step
+    import { useEffect, useState } from 'react';
 
     export default function App() {
+      const [ready, setReady] = useState(false);
+
+      useEffect(() => {
+        loadAuthToken().then(() => setReady(true));
+      }, []);
+
+      if (!ready) return null;
+
       return (
         <AppProvider>
           <RootNavigator />
@@ -90,8 +109,8 @@ Modelence's client library works in React Native. Because React Native lacks bro
 | Field | Type | Description |
 |-------|------|-------------|
 | `baseUrl` | `string` | Absolute URL of your Modelence server, e.g. `https://myapp.com`. All API and WebSocket connections are made relative to this URL. |
-| `getAuthToken` | `() => string \| undefined` | Returns the stored auth token. Called before every request. |
-| `setAuthToken` | `(token: string \| null) => void` | Persists or clears the auth token. Called after login, signup, and logout. |
+| `getAuthToken` | `() => string \| undefined` | Returns the stored auth token synchronously. Called before every request — must not return a `Promise`. |
+| `setAuthToken` | `(token: string \| null) => void` | Persists or clears the auth token synchronously. Called after login and logout. Async side-effects (e.g. writing to `AsyncStorage`) are fine as long as the function itself is not `async`. |
 | `getClientInfo` | `() => ClientInfo` | Returns device screen dimensions and pixel ratio. Used for telemetry. |
 | `openUrl` | `(url: string) => void` | _(Optional)_ Opens a URL externally. Defaults to `window.location.href` assignment in browsers. Pass `Linking.openURL` for React Native OAuth redirects. |
 

--- a/docs/web/react-native.mdx
+++ b/docs/web/react-native.mdx
@@ -3,6 +3,8 @@ title: 'React Native'
 icon: 'mobile'
 ---
 
+<Note>React Native support is available from **modelence v0.19.0**.</Note>
+
 Modelence's client library works in React Native. Because React Native lacks browser APIs like `localStorage` and `window`, you configure the client with `configureClient` so the SDK knows how to store auth tokens, read device dimensions, and resolve server URLs.
 
 ## Setup

--- a/packages/modelence/eslint.config.js
+++ b/packages/modelence/eslint.config.js
@@ -9,6 +9,7 @@ export default [
       parserOptions: {
         ecmaVersion: 'latest',
         sourceType: 'module',
+        project: './tsconfig.json',
       },
     },
     plugins: {
@@ -23,6 +24,7 @@ export default [
         },
       ],
       '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-floating-promises': 'error',
       'no-console': 'off',
     },
   },

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@socket.io/mongo-adapter": "^0.4.0",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.18.0-dev.rn.0",
+  "version": "0.19.0",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.18.0",
+  "version": "0.18.0-dev.rn.0",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.19.0",
+  "version": "0.18.0-dev.rn.1",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.18.0-dev.rn.1",
+  "version": "0.19.0",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/app/loggerProcess.ts
+++ b/packages/modelence/src/app/loggerProcess.ts
@@ -111,7 +111,7 @@ async function sendLogs() {
 
 function loopSendLogs() {
   setTimeout(() => {
-    sendLogs();
+    void sendLogs();
     loopSendLogs();
   }, 1000);
 }

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -130,7 +130,7 @@ export async function startServer(
       return;
     }
 
-    const nonce = issueLinkNonce(String(session.userId));
+    const nonce = await issueLinkNonce(String(session.userId));
     res.json({ nonce });
   });
 
@@ -176,7 +176,7 @@ export async function startServer(
 
   const websocketProvider = getWebsocketConfig()?.provider;
   if (websocketProvider) {
-    websocketProvider.init({
+    void websocketProvider.init({
       httpServer,
       channels,
     });

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -20,6 +20,7 @@ import { ServerChannel } from '@/websocket/serverChannel';
 import { getSecurityConfig } from './securityConfig';
 import { getWebsocketConfig } from './websocketConfig';
 import { getConfig } from '@/config/server';
+import { issueLinkNonce } from '@/auth/session';
 
 function getBodyParserMiddleware(config?: {
   json?: boolean | { limit?: string };
@@ -100,7 +101,7 @@ export async function startServer(
   app.use(googleAuthRouter());
   app.use(githubAuthRouter());
 
-  // Set httpOnly cookie for OAuth linking flow
+  // Browser OAuth linking: set httpOnly cookie so the authToken never travels in a URL.
   app.post('/api/_internal/auth/set-link-cookie', async (req: Request, res: Response) => {
     const { session } = await getCallContext(req, res);
 
@@ -118,6 +119,19 @@ export async function startServer(
     });
 
     res.json({ ok: true });
+  });
+
+  // React Native OAuth linking: issues a single-use nonce the app puts in the OAuth URL.
+  app.post('/api/_internal/auth/issue-link-nonce', async (req: Request, res: Response) => {
+    const { session } = await getCallContext(req, res);
+
+    if (!session?.userId) {
+      res.status(401).json({ error: 'Not authenticated' });
+      return;
+    }
+
+    const nonce = issueLinkNonce(String(session.userId));
+    res.json({ nonce });
   });
 
   app.post('/api/_internal/method/:methodName(*)', async (req: Request, res: Response) => {

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -199,12 +199,23 @@ export async function linkOAuthProvider(options: { provider: OAuthProvider }): P
   const baseUrl = config?.baseUrl ?? '';
 
   if (config?.openUrl) {
-    // React Native: pass authToken as a URL param; server embeds userId in state cookie.
+    // React Native: exchange authToken for a single-use nonce via an authenticated
+    // request, then put the nonce in the URL. A crafted external link can't work
+    // because the nonce is bound to this session and consumed on first use.
     const token = getAuthToken();
     if (!token) {
       throw new Error('Failed to initialize OAuth linking. Please ensure you are logged in.');
     }
-    const url = `${baseUrl}/api/_internal/auth/${provider}?mode=link&authToken=${encodeURIComponent(token)}`;
+    const nonceResponse = await fetch(`${baseUrl}/api/_internal/auth/issue-link-nonce`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ authToken: token }),
+    });
+    if (!nonceResponse.ok) {
+      throw new Error('Failed to initialize OAuth linking. Please ensure you are logged in.');
+    }
+    const { nonce } = await nonceResponse.json();
+    const url = `${baseUrl}/api/_internal/auth/${provider}?mode=link&linkNonce=${encodeURIComponent(nonce)}`;
     config.openUrl(url);
   } else {
     // Browser: set httpOnly cookie via same-origin fetch (keeps token out of redirect params).

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -1,7 +1,8 @@
 import { setCurrentUser } from '@/client/session';
 import { callMethod } from '@/client/method';
 import { getLocalStorageSession } from '@/client/localStorage';
-import { ClientInfo } from '@/methods/types';
+import { getClientConfig } from '@/client/clientConfig';
+import type { ClientInfo } from '@/methods/types';
 import { OAuthProvider } from '../types';
 
 export type UserInfo = {
@@ -143,6 +144,10 @@ export async function resendEmailVerification(options: { email: string }) {
  */
 export async function logout() {
   await callMethod('_system.user.logout');
+  const config = getClientConfig();
+  if (config) {
+    config.setAuthToken(null);
+  }
   setCurrentUser(null);
 }
 
@@ -183,11 +188,12 @@ export async function resetPassword(options: { token: string; password: string }
  */
 export async function linkOAuthProvider(options: { provider: OAuthProvider }): Promise<void> {
   const { provider } = options;
+  const config = getClientConfig();
+  const baseUrl = config?.baseUrl ?? '';
 
   const token = getAuthToken();
   if (token) {
-    // Ask the server to set a secure httpOnly cookie for the OAuth linking flow
-    const response = await fetch('/api/_internal/auth/set-link-cookie', {
+    const response = await fetch(`${baseUrl}/api/_internal/auth/set-link-cookie`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ authToken: token }),
@@ -197,7 +203,13 @@ export async function linkOAuthProvider(options: { provider: OAuthProvider }): P
       throw new Error('Failed to initialize OAuth linking. Please ensure you are logged in.');
     }
   }
-  window.location.href = `/api/_internal/auth/${provider}?mode=link`;
+
+  const url = `${baseUrl}/api/_internal/auth/${provider}?mode=link`;
+  if (config?.openUrl) {
+    config.openUrl(url);
+  } else {
+    window.location.href = url;
+  }
 }
 /**
  * Unlink an OAuth provider from the currently signed-in user's account.
@@ -218,10 +230,18 @@ export async function unlinkOAuthProvider(options: { provider: OAuthProvider }):
  * @returns The auth token or undefined if not authenticated.
  */
 export function getAuthToken(): string | undefined {
+  const config = getClientConfig();
+  if (config) {
+    return config.getAuthToken();
+  }
   return getLocalStorageSession()?.authToken;
 }
 
 export function getClientInfo(): ClientInfo {
+  const config = getClientConfig();
+  if (config) {
+    return config.getClientInfo();
+  }
   return {
     screenWidth: window.screen.width,
     screenHeight: window.screen.height,

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -71,10 +71,17 @@ export async function signupWithPassword(options: {
  */
 export async function loginWithPassword(options: { email: string; password: string }) {
   const { email, password } = options;
-  const { user } = await callMethod<{ user: RawUserData }>('_system.user.loginWithPassword', {
-    email,
-    password,
-  });
+  const { user, session } = await callMethod<{ user: RawUserData; session: { authToken: string } }>(
+    '_system.user.loginWithPassword',
+    {
+      email,
+      password,
+    }
+  );
+  const config = getClientConfig();
+  if (config) {
+    config.setAuthToken(session.authToken);
+  }
   const enrichedUser = setCurrentUser(user);
   return enrichedUser;
 }

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -198,24 +198,33 @@ export async function linkOAuthProvider(options: { provider: OAuthProvider }): P
   const config = getClientConfig();
   const baseUrl = config?.baseUrl ?? '';
 
-  const token = getAuthToken();
-  if (token) {
-    const response = await fetch(`${baseUrl}/api/_internal/auth/set-link-cookie`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ authToken: token }),
-      credentials: 'include',
-    });
-    if (!response.ok) {
+  if (config?.openUrl) {
+    // React Native: the system browser has no shared cookie jar with the in-app
+    // fetch layer, so we pass the auth token as a URL param instead. The server
+    // validates it during OAuth initiation (which runs in the browser) and
+    // embeds the resolved userId in its state cookie.
+    const token = getAuthToken();
+    if (!token) {
       throw new Error('Failed to initialize OAuth linking. Please ensure you are logged in.');
     }
-  }
-
-  const url = `${baseUrl}/api/_internal/auth/${provider}?mode=link`;
-  if (config?.openUrl) {
+    const url = `${baseUrl}/api/_internal/auth/${provider}?mode=link&authToken=${encodeURIComponent(token)}`;
     config.openUrl(url);
   } else {
-    window.location.href = url;
+    // Browser: set an httpOnly cookie via a same-origin fetch so the token is
+    // never exposed to the OAuth provider as a redirect parameter.
+    const token = getAuthToken();
+    if (token) {
+      const response = await fetch(`${baseUrl}/api/_internal/auth/set-link-cookie`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ authToken: token }),
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        throw new Error('Failed to initialize OAuth linking. Please ensure you are logged in.');
+      }
+    }
+    window.location.href = `${baseUrl}/api/_internal/auth/${provider}?mode=link`;
   }
 }
 /**

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -199,10 +199,7 @@ export async function linkOAuthProvider(options: { provider: OAuthProvider }): P
   const baseUrl = config?.baseUrl ?? '';
 
   if (config?.openUrl) {
-    // React Native: the system browser has no shared cookie jar with the in-app
-    // fetch layer, so we pass the auth token as a URL param instead. The server
-    // validates it during OAuth initiation (which runs in the browser) and
-    // embeds the resolved userId in its state cookie.
+    // React Native: pass authToken as a URL param; server embeds userId in state cookie.
     const token = getAuthToken();
     if (!token) {
       throw new Error('Failed to initialize OAuth linking. Please ensure you are logged in.');
@@ -210,8 +207,7 @@ export async function linkOAuthProvider(options: { provider: OAuthProvider }): P
     const url = `${baseUrl}/api/_internal/auth/${provider}?mode=link&authToken=${encodeURIComponent(token)}`;
     config.openUrl(url);
   } else {
-    // Browser: set an httpOnly cookie via a same-origin fetch so the token is
-    // never exposed to the OAuth provider as a redirect parameter.
+    // Browser: set httpOnly cookie via same-origin fetch (keeps token out of redirect params).
     const token = getAuthToken();
     if (token) {
       const response = await fetch(`${baseUrl}/api/_internal/auth/set-link-cookie`, {

--- a/packages/modelence/src/auth/login.test.ts
+++ b/packages/modelence/src/auth/login.test.ts
@@ -127,7 +127,11 @@ describe('auth/login', () => {
         id: userId,
         handle: 'demo',
         roles: [],
+        firstName: undefined,
+        lastName: undefined,
+        avatarUrl: undefined,
       },
+      session: { authToken: 'token-1' },
     });
   });
 

--- a/packages/modelence/src/auth/login.ts
+++ b/packages/modelence/src/auth/login.ts
@@ -73,6 +73,7 @@ export async function handleLoginWithPassword(
 
     return {
       user: serializeUserForClient(userDoc),
+      session: { authToken: session.authToken },
     };
   } catch (error) {
     if (error instanceof Error) {

--- a/packages/modelence/src/auth/providers/github.ts
+++ b/packages/modelence/src/auth/providers/github.ts
@@ -16,7 +16,7 @@ import {
   type OAuthUserData,
   clearOAuthLinkCookie,
   validateOAuthStateAndGetMode,
-  resolveUserIdFromAuthTokenParam,
+  resolveUserIdFromLinkNonce,
   sendOAuthError,
 } from './oauth-common';
 
@@ -218,12 +218,12 @@ function getRouter(): ExpressRouter {
 
       const mode = req.query.mode === 'link' ? 'link' : 'login';
 
-      // React Native: resolve userId from authToken param and embed in state cookie.
+      // React Native: consume single-use nonce and embed resolved userId in state cookie.
       let linkedUserId: string | null = null;
-      if (mode === 'link' && req.query.authToken) {
-        linkedUserId = await resolveUserIdFromAuthTokenParam(req.query.authToken as string);
+      if (mode === 'link' && req.query.linkNonce) {
+        linkedUserId = await resolveUserIdFromLinkNonce(req.query.linkNonce as string);
         if (!linkedUserId) {
-          sendOAuthError(res, 401, 'Invalid or expired auth token for OAuth linking.');
+          sendOAuthError(res, 401, 'Invalid or expired link nonce for OAuth linking.');
           return;
         }
       }

--- a/packages/modelence/src/auth/providers/github.ts
+++ b/packages/modelence/src/auth/providers/github.ts
@@ -218,9 +218,7 @@ function getRouter(): ExpressRouter {
 
       const mode = req.query.mode === 'link' ? 'link' : 'login';
 
-      // React Native linking: resolve the userId from the authToken query param
-      // so it can be embedded in the state cookie (the system browser won't carry
-      // the app's session cookie).
+      // React Native: resolve userId from authToken param and embed in state cookie.
       let linkedUserId: string | null = null;
       if (mode === 'link' && req.query.authToken) {
         linkedUserId = await resolveUserIdFromAuthTokenParam(req.query.authToken as string);

--- a/packages/modelence/src/auth/providers/github.ts
+++ b/packages/modelence/src/auth/providers/github.ts
@@ -16,6 +16,7 @@ import {
   type OAuthUserData,
   clearOAuthLinkCookie,
   validateOAuthStateAndGetMode,
+  resolveUserIdFromAuthTokenParam,
   sendOAuthError,
 } from './oauth-common';
 
@@ -117,8 +118,9 @@ async function handleGitHubAuthenticationCallback(req: Request, res: Response) {
     return;
   }
 
-  const mode = validateOAuthStateAndGetMode(req, res, 'authStateGithub');
-  if (!mode) return;
+  const stateResult = validateOAuthStateAndGetMode(req, res, 'authStateGithub');
+  if (!stateResult) return;
+  const { mode, linkedUserId } = stateResult;
 
   const githubClientId = String(getConfig('_system.user.auth.github.clientId'));
   const githubClientSecret = String(getConfig('_system.user.auth.github.clientSecret'));
@@ -167,7 +169,7 @@ async function handleGitHubAuthenticationCallback(req: Request, res: Response) {
     };
 
     if (mode === 'link') {
-      await handleOAuthProviderLink(req, res, userData);
+      await handleOAuthProviderLink(req, res, userData, linkedUserId);
     } else {
       await handleOAuthUserAuthentication(req, res, userData);
     }
@@ -201,7 +203,7 @@ function getRouter(): ExpressRouter {
   githubAuthRouter.get(
     '/api/_internal/auth/github',
     checkGitHubEnabled,
-    (req: Request, res: Response) => {
+    async (req: Request, res: Response) => {
       const githubClientId = String(getConfig('_system.user.auth.github.clientId'));
       const redirectUri = getRedirectUri('github');
       const githubScopes = getConfig('_system.user.auth.github.scopes');
@@ -216,7 +218,20 @@ function getRouter(): ExpressRouter {
 
       const mode = req.query.mode === 'link' ? 'link' : 'login';
 
-      res.cookie('authStateGithub', `${state}:${mode}`, {
+      // React Native linking: resolve the userId from the authToken query param
+      // so it can be embedded in the state cookie (the system browser won't carry
+      // the app's session cookie).
+      let linkedUserId: string | null = null;
+      if (mode === 'link' && req.query.authToken) {
+        linkedUserId = await resolveUserIdFromAuthTokenParam(req.query.authToken as string);
+        if (!linkedUserId) {
+          sendOAuthError(res, 401, 'Invalid or expired auth token for OAuth linking.');
+          return;
+        }
+      }
+
+      const stateValue = linkedUserId ? `${state}:${mode}:${linkedUserId}` : `${state}:${mode}`;
+      res.cookie('authStateGithub', stateValue, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
         sameSite: 'lax',

--- a/packages/modelence/src/auth/providers/google.ts
+++ b/packages/modelence/src/auth/providers/google.ts
@@ -16,7 +16,7 @@ import {
   type OAuthUserData,
   clearOAuthLinkCookie,
   validateOAuthStateAndGetMode,
-  resolveUserIdFromAuthTokenParam,
+  resolveUserIdFromLinkNonce,
   sendOAuthError,
 } from './oauth-common';
 
@@ -159,12 +159,12 @@ function getRouter(): ExpressRouter {
 
       const mode = req.query.mode === 'link' ? 'link' : 'login';
 
-      // React Native: resolve userId from authToken param and embed in state cookie.
+      // React Native: consume single-use nonce and embed resolved userId in state cookie.
       let linkedUserId: string | null = null;
-      if (mode === 'link' && req.query.authToken) {
-        linkedUserId = await resolveUserIdFromAuthTokenParam(req.query.authToken as string);
+      if (mode === 'link' && req.query.linkNonce) {
+        linkedUserId = await resolveUserIdFromLinkNonce(req.query.linkNonce as string);
         if (!linkedUserId) {
-          sendOAuthError(res, 401, 'Invalid or expired auth token for OAuth linking.');
+          sendOAuthError(res, 401, 'Invalid or expired link nonce for OAuth linking.');
           return;
         }
       }

--- a/packages/modelence/src/auth/providers/google.ts
+++ b/packages/modelence/src/auth/providers/google.ts
@@ -159,9 +159,7 @@ function getRouter(): ExpressRouter {
 
       const mode = req.query.mode === 'link' ? 'link' : 'login';
 
-      // React Native linking: resolve the userId from the authToken query param
-      // so it can be embedded in the state cookie (the system browser won't carry
-      // the app's session cookie).
+      // React Native: resolve userId from authToken param and embed in state cookie.
       let linkedUserId: string | null = null;
       if (mode === 'link' && req.query.authToken) {
         linkedUserId = await resolveUserIdFromAuthTokenParam(req.query.authToken as string);

--- a/packages/modelence/src/auth/providers/google.ts
+++ b/packages/modelence/src/auth/providers/google.ts
@@ -16,6 +16,7 @@ import {
   type OAuthUserData,
   clearOAuthLinkCookie,
   validateOAuthStateAndGetMode,
+  resolveUserIdFromAuthTokenParam,
   sendOAuthError,
 } from './oauth-common';
 
@@ -86,8 +87,9 @@ async function handleGoogleAuthenticationCallback(req: Request, res: Response) {
     return;
   }
 
-  const mode = validateOAuthStateAndGetMode(req, res, 'authStateGoogle');
-  if (!mode) return;
+  const stateResult = validateOAuthStateAndGetMode(req, res, 'authStateGoogle');
+  if (!stateResult) return;
+  const { mode, linkedUserId } = stateResult;
 
   const googleClientId = String(getConfig('_system.user.auth.google.clientId'));
   const googleClientSecret = String(getConfig('_system.user.auth.google.clientSecret'));
@@ -115,7 +117,7 @@ async function handleGoogleAuthenticationCallback(req: Request, res: Response) {
       avatarUrl: googleUser.picture || undefined,
     };
     if (mode === 'link') {
-      await handleOAuthProviderLink(req, res, userData);
+      await handleOAuthProviderLink(req, res, userData, linkedUserId);
     } else {
       await handleOAuthUserAuthentication(req, res, userData);
     }
@@ -149,7 +151,7 @@ function getRouter(): ExpressRouter {
   googleAuthRouter.get(
     '/api/_internal/auth/google',
     checkGoogleEnabled,
-    (req: Request, res: Response) => {
+    async (req: Request, res: Response) => {
       const googleClientId = String(getConfig('_system.user.auth.google.clientId'));
       const redirectUri = getRedirectUri('google');
 
@@ -157,7 +159,20 @@ function getRouter(): ExpressRouter {
 
       const mode = req.query.mode === 'link' ? 'link' : 'login';
 
-      res.cookie('authStateGoogle', `${state}:${mode}`, {
+      // React Native linking: resolve the userId from the authToken query param
+      // so it can be embedded in the state cookie (the system browser won't carry
+      // the app's session cookie).
+      let linkedUserId: string | null = null;
+      if (mode === 'link' && req.query.authToken) {
+        linkedUserId = await resolveUserIdFromAuthTokenParam(req.query.authToken as string);
+        if (!linkedUserId) {
+          sendOAuthError(res, 401, 'Invalid or expired auth token for OAuth linking.');
+          return;
+        }
+      }
+
+      const stateValue = linkedUserId ? `${state}:${mode}:${linkedUserId}` : `${state}:${mode}`;
+      res.cookie('authStateGoogle', stateValue, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
         sameSite: 'lax',

--- a/packages/modelence/src/auth/providers/oauth-common.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.ts
@@ -1,7 +1,7 @@
 import { type Request, type Response } from 'express';
 import { MongoServerError, ObjectId } from 'mongodb';
 import { usersCollection } from '@/auth/db';
-import { createSession, setAuthTokenCookie } from '@/auth/session';
+import { createSession, setAuthTokenCookie, sessionsCollection } from '@/auth/session';
 import { getAuthConfig } from '@/app/authConfig';
 import { getCallContext } from '@/app/server';
 import { getConfig } from '@/config/server';
@@ -18,6 +18,22 @@ export interface OAuthUserData {
   lastName?: string;
   avatarUrl?: string;
 }
+/**
+ * Resolves the userId for an authToken passed as a URL query parameter.
+ * Used by the React Native linking flow where the app cannot share an httpOnly
+ * cookie with the system browser.
+ * Returns the stringified ObjectId on success, or null if the token is missing
+ * / invalid / not associated with an authenticated user.
+ */
+export async function resolveUserIdFromAuthTokenParam(
+  authToken: string | undefined
+): Promise<string | null> {
+  if (!authToken || typeof authToken !== 'string') return null;
+  const session = await sessionsCollection.findOne({ authToken });
+  if (!session?.userId) return null;
+  return String(session.userId);
+}
+
 /*
  * Sends OAuth error response.
  * If `errorComponent` is configured, renders HTML.
@@ -371,15 +387,21 @@ function safelyCallHook(hook?: () => void) {
   }
 }
 
+export interface OAuthStateResult {
+  mode: string;
+  /** Present only when the React Native authToken-in-URL linking flow is used. */
+  linkedUserId?: string;
+}
+
 export function validateOAuthStateAndGetMode(
   req: Request,
   res: Response,
   stateCookieName: string
-): string | null {
+): OAuthStateResult | null {
   const state = req.query.state as string;
   const storedState = req.cookies[stateCookieName];
 
-  const [storedStateValue, storedMode] = (storedState || '').split(':');
+  const [storedStateValue, storedMode, storedUserId] = (storedState || '').split(':');
 
   if (!state || !storedState || state !== storedStateValue) {
     sendOAuthError(res, 400, 'Invalid OAuth state - possible CSRF attack');
@@ -387,24 +409,40 @@ export function validateOAuthStateAndGetMode(
   }
 
   res.clearCookie(stateCookieName);
-  return storedMode || 'login';
+  return {
+    mode: storedMode || 'login',
+    ...(storedUserId ? { linkedUserId: storedUserId } : {}),
+  };
 }
 
 export async function handleOAuthProviderLink(
   req: Request,
   res: Response,
-  userData: OAuthUserData
+  userData: OAuthUserData,
+  linkedUserId?: string
 ): Promise<void> {
   const authConfig = getAuthConfig();
   const { session, connectionInfo } = await getCallContext(req, res);
 
-  if (!session?.userId) {
+  // In the React Native flow, the userId is carried in the state cookie rather
+  // than the browser session cookie (which doesn't exist in that context).
+  let resolvedUserId: ObjectId | null = session?.userId ?? null;
+  if (!resolvedUserId && linkedUserId) {
+    if (!ObjectId.isValid(linkedUserId)) {
+      clearOAuthLinkCookie(res);
+      sendOAuthError(res, 400, 'Invalid OAuth linking state.');
+      return;
+    }
+    resolvedUserId = new ObjectId(linkedUserId);
+  }
+
+  if (!resolvedUserId) {
     clearOAuthLinkCookie(res);
     sendOAuthError(res, 401, 'You must be signed in to link a provider.');
     return;
   }
 
-  const userId = session.userId;
+  const userId = resolvedUserId;
 
   try {
     // Atomically attach the provider to the current user while preventing

--- a/packages/modelence/src/auth/providers/oauth-common.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.ts
@@ -18,13 +18,7 @@ export interface OAuthUserData {
   lastName?: string;
   avatarUrl?: string;
 }
-/**
- * Resolves the userId for an authToken passed as a URL query parameter.
- * Used by the React Native linking flow where the app cannot share an httpOnly
- * cookie with the system browser.
- * Returns the stringified ObjectId on success, or null if the token is missing
- * / invalid / not associated with an authenticated user.
- */
+/** Looks up a session by authToken query param; returns stringified userId or null. */
 export async function resolveUserIdFromAuthTokenParam(
   authToken: string | undefined
 ): Promise<string | null> {
@@ -389,7 +383,7 @@ function safelyCallHook(hook?: () => void) {
 
 export interface OAuthStateResult {
   mode: string;
-  /** Present only when the React Native authToken-in-URL linking flow is used. */
+  /** Set only in the React Native linking flow. */
   linkedUserId?: string;
 }
 
@@ -424,16 +418,18 @@ export async function handleOAuthProviderLink(
   const authConfig = getAuthConfig();
   const { session, connectionInfo } = await getCallContext(req, res);
 
-  // In the React Native flow, the userId is carried in the state cookie rather
-  // than the browser session cookie (which doesn't exist in that context).
-  let resolvedUserId: ObjectId | null = session?.userId ?? null;
-  if (!resolvedUserId && linkedUserId) {
+  // React Native: linkedUserId (from state cookie) takes precedence over the
+  // browser session, which may belong to a different user.
+  let resolvedUserId: ObjectId | null = null;
+  if (linkedUserId) {
     if (!ObjectId.isValid(linkedUserId)) {
       clearOAuthLinkCookie(res);
       sendOAuthError(res, 400, 'Invalid OAuth linking state.');
       return;
     }
     resolvedUserId = new ObjectId(linkedUserId);
+  } else {
+    resolvedUserId = session?.userId ?? null;
   }
 
   if (!resolvedUserId) {

--- a/packages/modelence/src/auth/providers/oauth-common.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.ts
@@ -1,7 +1,7 @@
 import { type Request, type Response } from 'express';
 import { MongoServerError, ObjectId } from 'mongodb';
 import { usersCollection } from '@/auth/db';
-import { createSession, setAuthTokenCookie, sessionsCollection } from '@/auth/session';
+import { createSession, setAuthTokenCookie, consumeLinkNonce } from '@/auth/session';
 import { getAuthConfig } from '@/app/authConfig';
 import { getCallContext } from '@/app/server';
 import { getConfig } from '@/config/server';
@@ -18,14 +18,12 @@ export interface OAuthUserData {
   lastName?: string;
   avatarUrl?: string;
 }
-/** Looks up a session by authToken query param; returns stringified userId or null. */
-export async function resolveUserIdFromAuthTokenParam(
-  authToken: string | undefined
+/** Consumes a single-use link nonce; returns the bound userId string or null. */
+export async function resolveUserIdFromLinkNonce(
+  nonce: string | undefined
 ): Promise<string | null> {
-  if (!authToken || typeof authToken !== 'string') return null;
-  const session = await sessionsCollection.findOne({ authToken });
-  if (!session?.userId) return null;
-  return String(session.userId);
+  if (!nonce || typeof nonce !== 'string') return null;
+  return consumeLinkNonce(nonce);
 }
 
 /*

--- a/packages/modelence/src/auth/session.ts
+++ b/packages/modelence/src/auth/session.ts
@@ -8,6 +8,34 @@ import { schema } from '../data/types';
 import { time } from '../time';
 import { Session } from './types';
 
+export const linkNoncesCollection = new Store('_modelenceLinkNonces', {
+  schema: {
+    nonce: schema.string(),
+    userId: schema.string(),
+    expiresAt: schema.date(),
+  },
+  indexes: [
+    { key: { nonce: 1 }, unique: true },
+    { key: { expiresAt: 1 }, expireAfterSeconds: 0 },
+  ],
+});
+
+export async function issueLinkNonce(userId: string): Promise<string> {
+  const nonce = randomBytes(32).toString('hex');
+  await linkNoncesCollection.insertOne({
+    nonce,
+    userId,
+    expiresAt: new Date(Date.now() + time.minutes(10)),
+  });
+  return nonce;
+}
+
+export async function consumeLinkNonce(nonce: string): Promise<string | null> {
+  const entry = await linkNoncesCollection.findOneAndDelete({ nonce });
+  if (!entry) return null;
+  return entry.userId;
+}
+
 export const sessionsCollection = new Store('_modelenceSessions', {
   schema: {
     authToken: schema.string(),
@@ -104,7 +132,7 @@ export function setAuthTokenCookie(res: Response, authToken: string) {
 }
 
 export default new Module('_system.session', {
-  stores: [sessionsCollection],
+  stores: [sessionsCollection, linkNoncesCollection],
   mutations: {
     init: async function (args, { session, user }) {
       // TODO: mark or track app load somewhere

--- a/packages/modelence/src/bin/build.ts
+++ b/packages/modelence/src/bin/build.ts
@@ -37,7 +37,7 @@ async function buildVite() {
 async function buildServer() {
   console.log('Building server with tsup...');
   return new Promise((resolve) => {
-    tsupBuild({
+    void tsupBuild({
       entry: [getServerPath()],
       format: 'esm',
       sourcemap: true,

--- a/packages/modelence/src/client.ts
+++ b/packages/modelence/src/client.ts
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { AppProvider as OriginalAppProvider } from './client/AppProvider';
 
+export { configureClient, type ClientConfig } from './client/clientConfig';
 export { getConfig } from './config/client';
 export { createClientModule } from './client/module';
 export type { ValueType } from './config/types';

--- a/packages/modelence/src/client/AppProvider.tsx
+++ b/packages/modelence/src/client/AppProvider.tsx
@@ -32,7 +32,7 @@ export function AppProvider({ children, loadingElement }: AppProviderProps) {
       setIsLoading(false);
     }
 
-    initConfig();
+    void initConfig();
   }, []);
 
   if (isLoading) {

--- a/packages/modelence/src/client/clientConfig.ts
+++ b/packages/modelence/src/client/clientConfig.ts
@@ -6,9 +6,9 @@ export interface ClientConfig {
   setAuthToken: (token: string | null) => void;
   getClientInfo: () => ClientInfo;
   /**
-   * Opens an external URL (used for OAuth redirects). Defaults to
-   * `window.location.href` assignment when not provided. React Native apps
-   * should pass `(url) => Linking.openURL(url)`.
+   * Opens a URL for OAuth redirects. React Native must use
+   * `(url) => Linking.openURL(url)` — WebView is not supported.
+   * Defaults to `window.location.href` when not provided.
    */
   openUrl?: (url: string) => void;
 }
@@ -25,6 +25,7 @@ let config: ClientConfig | null = null;
  * @example
  * ```ts
  * import { configureClient } from 'modelence/client';
+ * import { Linking } from 'react-native';
  *
  * let authToken: string | undefined;
  *
@@ -40,6 +41,7 @@ let config: ClientConfig | null = null;
  *     pixelRatio: PixelRatio.get(),
  *     orientation: null,
  *   }),
+ *   openUrl: (url) => Linking.openURL(url),
  * });
  * ```
  */

--- a/packages/modelence/src/client/clientConfig.ts
+++ b/packages/modelence/src/client/clientConfig.ts
@@ -1,0 +1,52 @@
+import type { ClientInfo } from '@/methods/types';
+
+export interface ClientConfig {
+  baseUrl: string;
+  getAuthToken: () => string | undefined;
+  setAuthToken: (token: string | null) => void;
+  getClientInfo: () => ClientInfo;
+  /**
+   * Opens an external URL (used for OAuth redirects). Defaults to
+   * `window.location.href` assignment when not provided. React Native apps
+   * should pass `(url) => Linking.openURL(url)`.
+   */
+  openUrl?: (url: string) => void;
+}
+
+let config: ClientConfig | null = null;
+
+/**
+ * Configure the Modelence client for non-browser environments like React Native.
+ *
+ * When configured, the client uses the provided functions for auth-token
+ * storage, client-info collection, and URL resolution instead of the
+ * default browser APIs (localStorage, window.screen, relative URLs).
+ *
+ * @example
+ * ```ts
+ * import { configureClient } from 'modelence/client';
+ *
+ * let authToken: string | undefined;
+ *
+ * configureClient({
+ *   baseUrl: 'https://myapp.com',
+ *   getAuthToken: () => authToken,
+ *   setAuthToken: (token) => { authToken = token ?? undefined; },
+ *   getClientInfo: () => ({
+ *     screenWidth: Dimensions.get('screen').width,
+ *     screenHeight: Dimensions.get('screen').height,
+ *     windowWidth: Dimensions.get('window').width,
+ *     windowHeight: Dimensions.get('window').height,
+ *     pixelRatio: PixelRatio.get(),
+ *     orientation: null,
+ *   }),
+ * });
+ * ```
+ */
+export function configureClient(userConfig: ClientConfig) {
+  config = userConfig;
+}
+
+export function getClientConfig(): ClientConfig | null {
+  return config;
+}

--- a/packages/modelence/src/client/method.ts
+++ b/packages/modelence/src/client/method.ts
@@ -9,6 +9,7 @@
 
 import { getAuthToken, getClientInfo } from '@/auth/client';
 import { handleError } from '@/client/errorHandler';
+import { getClientConfig } from '@/client/clientConfig';
 import { reviveResponseTypes } from '@/methods/serialize';
 
 export class MethodError extends Error {
@@ -63,7 +64,8 @@ export async function callMethod<T = unknown>(
   args = args ?? {};
   options = options ?? {};
   try {
-    return await call<T>(`/api/_internal/method/${methodName}`, args);
+    const baseUrl = getClientConfig()?.baseUrl ?? '';
+    return await call<T>(`${baseUrl}/api/_internal/method/${methodName}`, args);
   } catch (error) {
     const handler = options.errorHandler ?? handleError;
     handler(error as Error, methodName);

--- a/packages/modelence/src/client/session.test.ts
+++ b/packages/modelence/src/client/session.test.ts
@@ -5,6 +5,7 @@ type CallMethodFn = (typeof import('./method'))['callMethod'];
 const mockCallMethod = vi.fn<CallMethodFn>();
 const mockSetConfig = vi.fn();
 const mockSetLocalStorageSession = vi.fn();
+const mockGetClientConfig = vi.fn();
 const mockSeconds = vi.fn((value: number) => value * 1000);
 
 vi.doMock('./method', () => ({
@@ -17,6 +18,10 @@ vi.doMock('../config/client', () => ({
 
 vi.doMock('./localStorage', () => ({
   setLocalStorageSession: mockSetLocalStorageSession,
+}));
+
+vi.doMock('./clientConfig', () => ({
+  getClientConfig: mockGetClientConfig,
 }));
 
 vi.doMock('../time', () => ({
@@ -37,6 +42,8 @@ describe('client/session', () => {
     mockCallMethod.mockReset();
     mockSetConfig.mockReset();
     mockSetLocalStorageSession.mockReset();
+    mockGetClientConfig.mockReset();
+    mockGetClientConfig.mockReturnValue(null);
     global.setTimeout = ((fn: Parameters<typeof originalSetTimeout>[0], delay?: number) => {
       return originalSetTimeout(fn, delay);
     }) as typeof setTimeout;
@@ -70,6 +77,23 @@ describe('client/session', () => {
     );
     const sameRef = useSessionStore.getState().user;
     expect(storedUser).toBe(sameRef);
+  });
+
+  test('initSession delegates token storage to client config when configured', async () => {
+    const mockSetAuthToken = vi.fn();
+    mockGetClientConfig.mockReturnValue({ setAuthToken: mockSetAuthToken });
+    mockCallMethod.mockResolvedValueOnce({
+      configs: { demo: 'value' },
+      session: { authToken: 'rn-token' },
+      user: { id: '1', handle: 'demo', roles: [] },
+    } as never);
+    mockCallMethod.mockResolvedValueOnce(undefined as never);
+
+    const { initSession: freshInitSession } = await import('./session');
+    await freshInitSession();
+
+    expect(mockSetAuthToken).toHaveBeenCalledWith('rn-token');
+    expect(mockSetLocalStorageSession).not.toHaveBeenCalled();
   });
 
   test('initSession handles null user and schedules heartbeat', async () => {

--- a/packages/modelence/src/client/session.ts
+++ b/packages/modelence/src/client/session.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { callMethod } from './method';
 import { _setConfig } from '../config/client';
 import { setLocalStorageSession } from './localStorage';
+import { getClientConfig } from './clientConfig';
 import { time } from '../time';
 import { Configs } from '../config/types';
 
@@ -77,11 +78,17 @@ export async function initSession() {
 
   const { configs, session, user } = await callMethod<{
     configs: Configs;
-    session: object;
+    session: object & { authToken: string };
     user: object;
   }>('_system.session.init');
   _setConfig(configs);
-  setLocalStorageSession(session);
+
+  const config = getClientConfig();
+  if (config) {
+    config.setAuthToken(session.authToken);
+  } else {
+    setLocalStorageSession(session);
+  }
 
   useSessionStore.getState().setUser(parseUser(user));
 

--- a/packages/modelence/src/config/sync.test.ts
+++ b/packages/modelence/src/config/sync.test.ts
@@ -103,7 +103,7 @@ describe('config/sync', () => {
     expect(intervalCallback).toBeTruthy();
     const firstRun = intervalCallback?.();
     await Promise.resolve();
-    intervalCallback?.();
+    void intervalCallback?.();
     expect(mockFetchConfigs).toHaveBeenCalledTimes(1);
 
     if (fetchResolve) {

--- a/packages/modelence/src/data/store.test.ts
+++ b/packages/modelence/src/data/store.test.ts
@@ -35,7 +35,7 @@ function assertFetchOptionTypeSafety() {
     methods: undefined,
   });
 
-  typedStore.fetch(
+  void typedStore.fetch(
     { name: 'john' },
     {
       sort: { name: 1, score: -1, 'nested.level': 1 },
@@ -44,9 +44,9 @@ function assertFetchOptionTypeSafety() {
   );
 
   // @ts-expect-error unknown top-level field should be rejected in sort
-  typedStore.fetch({ name: 'john' }, { sort: { unknownField: 1 } });
+  void typedStore.fetch({ name: 'john' }, { sort: { unknownField: 1 } });
   // @ts-expect-error unknown top-level field should be rejected in projection
-  typedStore.fetch({ name: 'john' }, { projection: { unknownField: 1 } });
+  void typedStore.fetch({ name: 'john' }, { projection: { unknownField: 1 } });
 }
 void assertFetchOptionTypeSafety;
 
@@ -81,8 +81,8 @@ function assertExtendedStoreDotNotationTypeSafety() {
   });
 
   // Dot-notation paths must be accepted in filter queries on extended stores
-  extendedStore.findOne({ 'integrations.resend.syncStatus': 'success' });
-  extendedStore.fetch({
+  void extendedStore.findOne({ 'integrations.resend.syncStatus': 'success' });
+  void extendedStore.fetch({
     'integrations.resend.syncStatus': 'error',
     $or: [
       { 'integrations.resend.id': { $exists: false } },
@@ -91,7 +91,7 @@ function assertExtendedStoreDotNotationTypeSafety() {
   });
 
   // Dot-notation paths must be accepted in $set updates on extended stores
-  extendedStore.updateOne('someId', {
+  void extendedStore.updateOne('someId', {
     $set: {
       'integrations.resend.id': 'abc',
       'integrations.resend.syncStatus': 'success',

--- a/packages/modelence/src/lock/helpers.ts
+++ b/packages/modelence/src/lock/helpers.ts
@@ -200,7 +200,7 @@ const startLockHeartbeat = ({
 
   const scheduleRefresh = () => {
     heartbeat.timer = setTimeout(() => {
-      acquireLock(resource, {
+      void acquireLock(resource, {
         lockDuration,
         bypassCache: true,
         instanceId,

--- a/packages/modelence/src/websocket/socketio/client.ts
+++ b/packages/modelence/src/websocket/socketio/client.ts
@@ -2,6 +2,7 @@ import io, { Socket } from 'socket.io-client';
 import { WebsocketClientProvider } from '../types';
 import { ClientChannel } from '../clientChannel';
 import { getAuthToken, getClientInfo } from '@/auth/client';
+import { getClientConfig } from '@/client/clientConfig';
 import { reviveResponseTypes } from '@/methods/serialize';
 
 let socketClient: Socket | null = null;
@@ -35,7 +36,8 @@ function resubscribeAll() {
 }
 
 function init(props: { channels?: ClientChannel<unknown>[] }) {
-  socketClient = io('/', {
+  const baseUrl = getClientConfig()?.baseUrl ?? '/';
+  socketClient = io(baseUrl, {
     transports: ['websocket'],
     auth: {
       token: getAuthToken(),

--- a/packages/modelence/src/websocket/socketio/server.ts
+++ b/packages/modelence/src/websocket/socketio/server.ts
@@ -96,7 +96,7 @@ export async function init({
       for (const channel of channels) {
         if (channel.category === category) {
           if (!channel.canAccessChannel || (await channel.canAccessChannel(socket.data))) {
-            socket.join(channelName);
+            void socket.join(channelName);
             authorized = true;
             socket.emit('joinedChannel', channelName);
           }
@@ -110,7 +110,7 @@ export async function init({
     });
 
     socket.on('leaveChannel', (channelName: string) => {
-      socket.leave(channelName);
+      void socket.leave(channelName);
       console.log(`User ${socket.id} left channel ${channelName}`);
       socket.emit('leftChannel', channelName);
     });


### PR DESCRIPTION
* configureClient function allows overriding the methods we use to access the backend and to store the auth token

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, session tokens, and OAuth linking flows (new nonce store and dual client paths); regressions could affect sign-in or provider linking on web or native.
> 
> **Overview**
> **Modelence v0.19.0** adds **React Native** support via **`configureClient`**, which replaces browser-only APIs with injectable **`baseUrl`**, synchronous **auth token** get/set, **`getClientInfo`**, and optional **`openUrl`** for OAuth.
> 
> When configured, **`callMethod`**, **Socket.IO**, and **session init** use **`baseUrl`** and **`setAuthToken`** instead of relative URLs and **`localStorage`**. **Password login** now returns **`session.authToken`** so native clients can persist tokens without cookies.
> 
> **OAuth provider linking** gains a **React Native path**: authenticated clients call **`issue-link-nonce`**, pass **`linkNonce`** on the authorize URL, and the server binds the link to that user via a **single-use Mongo nonce** (browser linking still uses the **httpOnly** link cookie). Google/GitHub routes and **`handleOAuthProviderLink`** honor **`linkedUserId`** from state when present.
> 
> Docs add a **React Native** guide and API nav for **`configureClient`** / **`ClientConfig`**. ESLint enforces **`no-floating-promises`** with targeted **`void`** fixes. Package version bumps to **0.19.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d39dee7da00bf9345446b15e6d75e46067d5c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->