### PR TITLE
Fix incorrect time export path in docs

### DIFF
--- a/docs/web/rate-limiting.mdx
+++ b/docs/web/rate-limiting.mdx
@@ -11,7 +11,7 @@ You can define your own rate limits by adding a `rateLimits` array to a [Module]
 
 ```typescript
 import { Module } from 'modelence/server';
-import { time } from 'modelence/server';
+import { time } from 'modelence';
 
 const myModule = new Module('myFeature', {
   rateLimits: [

--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -9,7 +9,7 @@ import type { RateLimitType } from '@/rate-limit/types';
  *
  * @example
  * ```typescript
- * import { time } from 'modelence/server';
+ * import { time } from 'modelence';
  *
  * const rule: AuthRateLimitOverride = {
  *   type: 'ip',
@@ -43,7 +43,8 @@ export type AuthRateLimitOverride = {
  *
  * @example Tighten the 15-minute signup cap; per-day default is preserved.
  * ```typescript
- * import { startApp, time } from 'modelence/server';
+ * import { startApp } from 'modelence/server';
+ * import { time } from 'modelence';
  *
  * startApp({
  *   auth: {
@@ -122,6 +123,7 @@ export type AuthOption = {
  * @example
  * ```typescript
  * import { startApp } from 'modelence/server';
+ * import { time } from 'modelence';
  *
  * startApp({
  *   auth: {


### PR DESCRIPTION
The current docs claim that time is exported from `modelence/server`, but it is actually exported from `modelence`.

<img width="1366" height="478" alt="Screenshot (742)" src="https://github.com/user-attachments/assets/824b501b-0af0-44cd-bd1a-470d2b3a2e94" />


## Test:

<img width="712" height="286" alt="Screenshot (741)" src="https://github.com/user-attachments/assets/002dda37-46b1-40b9-b299-73d59c3127dd" />

Updated the documentation and comments to show the correct import path.

Before
```ts
import { time } from "modelence/server";
```
After
```ts
import { time } from "modelence";
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Corrects **rate-limiting** documentation and **auth config** JSDoc so `time` is imported from **`modelence`**, not **`modelence/server`**.
> 
> Updates the custom rate-limiting doc example and inline examples in `authConfig.ts` (including splitting `startApp` from `modelence/server` and `time` from `modelence` where both were wrongly shown on one import).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c0e69d03db80417606d492bee8589d55a5cd7c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->