### PR TITLE
fix: user defined modules name must not start with `_system.` prefix

### DIFF
--- a/packages/modelence/src/app/index.test.ts
+++ b/packages/modelence/src/app/index.test.ts
@@ -319,6 +319,13 @@ describe('app/index', () => {
         modules: [createTestModule({ name: '_system.evil' })],
       })
     ).rejects.toThrow("Invalid module name: '_system.evil'");
+
+    // Mixed-case variants must also be rejected (case-insensitive check)
+    await expect(
+      startApp({
+        modules: [createTestModule({ name: '_System.evil' })],
+      })
+    ).rejects.toThrow("Invalid module name: '_System.evil'");
   });
 
   test('loads dotenv configuration', async () => {

--- a/packages/modelence/src/app/index.test.ts
+++ b/packages/modelence/src/app/index.test.ts
@@ -313,6 +313,16 @@ describe('app/index', () => {
     expect(mockMarkAppStarted).toHaveBeenCalledTimes(1);
   });
 
+  test('throws when a user module name starts with _system.', async () => {
+    await expect(
+      startApp({
+        modules: [createTestModule({ name: '_system.evil' })],
+      })
+    ).rejects.toThrow(
+      "Module name '_system.evil' is reserved. User modules must not start with '_system.'"
+    );
+  });
+
   test('loads dotenv configuration', async () => {
     await startApp({});
 

--- a/packages/modelence/src/app/index.test.ts
+++ b/packages/modelence/src/app/index.test.ts
@@ -318,9 +318,7 @@ describe('app/index', () => {
       startApp({
         modules: [createTestModule({ name: '_system.evil' })],
       })
-    ).rejects.toThrow(
-      "Module name '_system.evil' is reserved. User modules must not start with '_system.'"
-    );
+    ).rejects.toThrow("Invalid module name: '_system.evil'");
   });
 
   test('loads dotenv configuration', async () => {

--- a/packages/modelence/src/app/index.ts
+++ b/packages/modelence/src/app/index.ts
@@ -97,7 +97,15 @@ export async function startApp({
       // Silently ignore tracking errors to not disrupt app startup
     });
 
-  // TODO: verify that user modules don't start with `_system.` prefix
+  for (const module of modules) {
+    if (module.name.startsWith('_system.')) {
+      throw new Error(
+        `Invalid module name: '${module.name}'\n\n` +
+          `The '_system.' prefix is reserved for internal use and cannot be used in user-defined modules.\n\n` +
+          `Rename your module to something that does not start with '_system.'`
+      );
+    }
+  }
   const systemModules = [
     userModule,
     sessionModule,

--- a/packages/modelence/src/app/index.ts
+++ b/packages/modelence/src/app/index.ts
@@ -98,7 +98,7 @@ export async function startApp({
     });
 
   for (const module of modules) {
-    if (module.name.startsWith('_system.')) {
+    if (module.name.toLowerCase().startsWith('_system.')) {
       throw new Error(
         `Invalid module name: '${module.name}'\n\n` +
           `The '_system.' prefix is reserved for internal use and cannot be used in user-defined modules.\n\n` +


### PR DESCRIPTION
Adds validation in `startApp`, so user-defined modules don't use the reserved `_system.` prefix, completing the `TODO` comment.

```ts
export async function startApp({
  modules = [],
  roles = {},
  defaultRoles = {},
  server = viteServer,
  migrations = [],
  email = {},
  auth = {},
  security = {},
  websocket = {},
}: AppOptions) {

  // TODO: verify that user modules don't start with `_system.` prefix 🔴
  const systemModules = [
    userModule,
    sessionModule,
    cronModule,
    migrationModule,
    rateLimitModule,
    systemModule,
    lockModule,
    filesModule,
  ];
  const combinedModules = [...systemModules, ...modules];

  //....
  startCronJobs().catch(console.error);

  await startServer(server, { combinedModules, channels });
}
```

## Test

Verified that user defined modules with name prefix `_system.` throws error
<img width="1366" height="601" alt="Screenshot (753)" src="https://github.com/user-attachments/assets/ca8b56bf-21ec-4b19-9839-ec2a41adb5ab" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small fail-fast check at app startup with no changes to auth, data, or runtime behavior for valid module names.
> 
> **Overview**
> **`startApp`** now rejects user-supplied modules whose `name` starts with the reserved `_system.` prefix (case-insensitive), throwing a descriptive error before internal system modules are merged. This replaces the previous **TODO** and blocks apps from registering queries/mutations that look like built-in `_system.*` modules.
> 
> Tests assert failures for `_system.evil` and mixed-case `_System.evil`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23d6f9409306ad97865dc508ca2a77db99b01652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->