### PR TITLE
MOD-432: fix: email verification url

### DIFF
--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@socket.io/mongo-adapter": "^0.4.0",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.19.0",
+  "version": "0.19.0-email.dev.0",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.19.0-email.dev.0",
+  "version": "0.19.1",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/app/securityConfig.ts
+++ b/packages/modelence/src/app/securityConfig.ts
@@ -26,19 +26,6 @@ export type SecurityConfig = {
    * When set, `X-Frame-Options` is omitted since it cannot express multiple origins.
    */
   frameAncestors?: string[];
-
-  /**
-   * Express `trust proxy` setting, controlling how `req.protocol`, `req.ip` and
-   * `req.hostname` are derived from `X-Forwarded-*` headers.
-   *
-   * Defaults to `true` (trusts the whole chain) — fine when the app is only
-   * reachable through a trusted proxy. Tighten when self-hosting: a number is
-   * trusted hop count (e.g. `1`), a string/array trusts IPs or subnets
-   * (e.g. `['loopback', '10.0.0.0/8']`), `false` disables proxy trust.
-   *
-   * https://expressjs.com/en/guide/behind-proxies.html
-   */
-  trustProxy?: boolean | number | string | string[];
 };
 
 let securityConfig: SecurityConfig = Object.freeze({});

--- a/packages/modelence/src/app/securityConfig.ts
+++ b/packages/modelence/src/app/securityConfig.ts
@@ -26,6 +26,19 @@ export type SecurityConfig = {
    * When set, `X-Frame-Options` is omitted since it cannot express multiple origins.
    */
   frameAncestors?: string[];
+
+  /**
+   * Express `trust proxy` setting, controlling how `req.protocol`, `req.ip` and
+   * `req.hostname` are derived from `X-Forwarded-*` headers.
+   *
+   * Defaults to `true` (trusts the whole chain) — fine when the app is only
+   * reachable through a trusted proxy. Tighten when self-hosting: a number is
+   * trusted hop count (e.g. `1`), a string/array trusts IPs or subnets
+   * (e.g. `['loopback', '10.0.0.0/8']`), `false` disables proxy trust.
+   *
+   * https://expressjs.com/en/guide/behind-proxies.html
+   */
+  trustProxy?: boolean | number | string | string[];
 };
 
 let securityConfig: SecurityConfig = Object.freeze({});

--- a/packages/modelence/src/app/server.test.ts
+++ b/packages/modelence/src/app/server.test.ts
@@ -213,6 +213,7 @@ function createResponse(): Response {
     status: vi.fn(),
     sendFile: vi.fn(),
     cookie: vi.fn(),
+    setHeader: vi.fn(),
   } as unknown as Response;
   (res.status as Mock).mockReturnValue(res);
   return res;
@@ -896,6 +897,39 @@ describe('app/server method endpoint', () => {
 
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.send).toHaveBeenCalledWith('Unauthorized');
+    expect(res.setHeader).not.toHaveBeenCalledWith('X-Modelence-Error-Code', expect.anything());
+  });
+
+  test('sets X-Modelence-Error-Code header when error carries a code', async () => {
+    const mockApp = createExpressAppMock();
+    mockExpressApp = mockApp;
+
+    const { AuthError } = await import('../error');
+    mockRunMethod.mockRejectedValue(new AuthError('Unverified', 'EMAIL_NOT_VERIFIED'));
+
+    const mockServer = createMockServer();
+
+    await startServer(mockServer, {
+      combinedModules: [],
+      channels: [],
+    });
+
+    const methodHandler = getRegisteredMethodHandler(mockApp);
+
+    const req = createRequest({
+      params: { methodName: 'testMethod' },
+      body: { args: {} },
+      headers: { host: 'localhost' },
+    });
+    const res = createResponse();
+
+    mockGetMongodbUri.mockReturnValue('');
+
+    await methodHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.send).toHaveBeenCalledWith('Unverified');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Modelence-Error-Code', 'EMAIL_NOT_VERIFIED');
   });
 
   test('handles ZodError with validation messages', async () => {

--- a/packages/modelence/src/app/server.test.ts
+++ b/packages/modelence/src/app/server.test.ts
@@ -564,7 +564,6 @@ describe('app/server startServer', () => {
       channels: [],
     });
 
-    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', true);
     expect(mockApp.use).toHaveBeenCalledWith('json-middleware');
     expect(mockApp.use).toHaveBeenCalledWith('urlencoded-middleware');
     expect(mockApp.use).toHaveBeenCalledWith('cookie-parser-middleware');

--- a/packages/modelence/src/app/server.test.ts
+++ b/packages/modelence/src/app/server.test.ts
@@ -9,6 +9,7 @@ import type { RouteHandler } from '@/routes/types';
 
 // Type definitions for test mocks
 type MockExpressApp = {
+  set: Mock;
   use: Mock;
   post: Mock;
   get: Mock;
@@ -117,6 +118,7 @@ vi.doMock('./websocketConfig', () => ({
 
 let mockExpressApp: MockExpressApp;
 const createExpressAppMock = (): MockExpressApp => ({
+  set: vi.fn(),
   use: vi.fn(),
   post: vi.fn(),
   get: vi.fn(),
@@ -412,6 +414,51 @@ describe('app/server getCallContext', () => {
 
     expect(ctx.connectionInfo.ip).toBe('10.0.0.5');
   });
+
+  test('derives baseUrl from X-Forwarded-Host / X-Forwarded-Proto behind a proxy', async () => {
+    const req = createRequest({
+      headers: {
+        // The internal container values seen behind the reverse proxy.
+        host: '10.1.118.6:3000',
+        'x-forwarded-host': 'tenant-sandbox-3cus3.sandbox.modelence.app',
+        'x-forwarded-proto': 'https',
+      },
+      protocol: 'http',
+    });
+    mockGetMongodbUri.mockReturnValue('');
+
+    const ctx = await getCallContext(req, {} as Response);
+
+    expect(ctx.connectionInfo.baseUrl).toBe('https://tenant-sandbox-3cus3.sandbox.modelence.app');
+  });
+
+  test('uses the first value of comma-separated forwarded headers', async () => {
+    const req = createRequest({
+      headers: {
+        host: '10.1.118.6:3000',
+        'x-forwarded-host': 'public.example.com, internal.example.com',
+        'x-forwarded-proto': 'https, http',
+      },
+      protocol: 'http',
+    });
+    mockGetMongodbUri.mockReturnValue('');
+
+    const ctx = await getCallContext(req, {} as Response);
+
+    expect(ctx.connectionInfo.baseUrl).toBe('https://public.example.com');
+  });
+
+  test('falls back to direct host and protocol without forwarded headers', async () => {
+    const req = createRequest({
+      headers: { host: 'localhost:3000' },
+      protocol: 'http',
+    });
+    mockGetMongodbUri.mockReturnValue('');
+
+    const ctx = await getCallContext(req, {} as Response);
+
+    expect(ctx.connectionInfo.baseUrl).toBe('http://localhost:3000');
+  });
 });
 
 describe('app/server startServer', () => {
@@ -424,6 +471,7 @@ describe('app/server startServer', () => {
     originalEnv = { ...process.env };
 
     mockApp = {
+      set: vi.fn(),
       use: vi.fn(),
       post: vi.fn(),
       get: vi.fn(),
@@ -515,6 +563,7 @@ describe('app/server startServer', () => {
       channels: [],
     });
 
+    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', true);
     expect(mockApp.use).toHaveBeenCalledWith('json-middleware');
     expect(mockApp.use).toHaveBeenCalledWith('urlencoded-middleware');
     expect(mockApp.use).toHaveBeenCalledWith('cookie-parser-middleware');

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -272,6 +272,12 @@ function handleMethodError(res: Response, methodName: string, error: unknown) {
     if (error.status >= 500 && error.status < 600) {
       console.error(`Error calling ${methodName}:`, error);
     }
+    // Surface a machine-readable code (when present) via a header so clients can
+    // branch on the error kind without parsing the human-readable message. The
+    // response body is left as the message text to preserve the existing format.
+    if (error.code) {
+      res.setHeader('X-Modelence-Error-Code', error.code);
+    }
     res.status(error.status).send(error.message);
     return;
   }

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -87,6 +87,14 @@ export async function startServer(
 ) {
   const app = express();
 
+  // Trust the reverse proxy so that req.protocol, req.ip and req.hostname
+  // reflect the X-Forwarded-Proto / X-Forwarded-For / X-Forwarded-Host
+  // headers set by the proxy, rather than the internal container connection.
+  // Defaults to `true` (trust the whole chain); self-hosted apps can tighten
+  // this via the `security.trustProxy` option. See {@link SecurityConfig}.
+  const { trustProxy = true } = getSecurityConfig();
+  app.set('trust proxy', trustProxy);
+
   app.use(cookieParser());
 
   app.use(securityHeadersMiddleware());
@@ -229,7 +237,7 @@ export async function getCallContext(req: Request, res: Response): Promise<HttpC
     userAgent: req.get('user-agent'),
     acceptLanguage: req.get('accept-language'),
     referrer: req.get('referrer'),
-    baseUrl: req.protocol + '://' + req.get('host'),
+    baseUrl: getRequestBaseUrl(req),
   };
 
   const hasDatabase = Boolean(getMongodbUri());
@@ -309,6 +317,25 @@ function securityHeadersMiddleware(): express.RequestHandler {
     }
     next();
   };
+}
+
+function getRequestBaseUrl(req: Request): string {
+  // Behind a reverse proxy the inbound Host header / connection protocol can
+  // reflect the internal container address rather than the public URL. Honor
+  // the X-Forwarded-Host / X-Forwarded-Proto headers when present (the first
+  // value in each comma-separated list is the original client-facing value),
+  // falling back to the direct request values otherwise.
+  const forwardedHost = req.headers['x-forwarded-host'];
+  const host =
+    (Array.isArray(forwardedHost) ? forwardedHost[0] : forwardedHost?.split(',')[0])?.trim() ||
+    req.get('host');
+
+  const forwardedProto = req.headers['x-forwarded-proto'];
+  const protocol =
+    (Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto?.split(',')[0])?.trim() ||
+    req.protocol;
+
+  return `${protocol}://${host}`;
 }
 
 function getClientIp(req: Request): string | undefined {

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -87,14 +87,6 @@ export async function startServer(
 ) {
   const app = express();
 
-  // Trust the reverse proxy so that req.protocol, req.ip and req.hostname
-  // reflect the X-Forwarded-Proto / X-Forwarded-For / X-Forwarded-Host
-  // headers set by the proxy, rather than the internal container connection.
-  // Defaults to `true` (trust the whole chain); self-hosted apps can tighten
-  // this via the `security.trustProxy` option. See {@link SecurityConfig}.
-  const { trustProxy = true } = getSecurityConfig();
-  app.set('trust proxy', trustProxy);
-
   app.use(cookieParser());
 
   app.use(securityHeadersMiddleware());

--- a/packages/modelence/src/auth/login.test.ts
+++ b/packages/modelence/src/auth/login.test.ts
@@ -10,6 +10,7 @@ const mockSendVerificationEmail = vi.fn();
 const mockValidateEmail = vi.fn();
 const mockGetEmailConfig = vi.fn();
 const mockGetAuthConfig = vi.fn();
+const mockGetConfig = vi.fn();
 const mockCompare = vi.fn();
 
 vi.doMock('@/server', () => ({
@@ -46,6 +47,10 @@ vi.doMock('@/app/authConfig', () => ({
   getAuthConfig: mockGetAuthConfig,
 }));
 
+vi.doMock('@/config/server', () => ({
+  getConfig: mockGetConfig,
+}));
+
 vi.doMock('bcrypt', () => ({
   default: {
     compare: mockCompare,
@@ -76,6 +81,10 @@ describe('auth/login', () => {
     vi.clearAllMocks();
     mockValidateEmail.mockImplementation((value) => value);
     mockGetEmailConfig.mockReturnValue({ provider: null });
+    // Mirror the schema default: verification is required unless explicitly disabled.
+    mockGetConfig.mockImplementation((key: string) =>
+      key === '_system.user.auth.email.verification' ? true : undefined
+    );
     mockConsumeRateLimit.mockResolvedValue(undefined as never);
     mockSendVerificationEmail.mockResolvedValue(undefined as never);
     mockCompare.mockResolvedValue(true as never);
@@ -145,14 +154,16 @@ describe('auth/login', () => {
     } as never);
     mockGetEmailConfig.mockReturnValue({ provider: 'resend' });
 
-    await expect(
-      handleLoginWithPassword(
-        { email: 'user@example.com', password: 'Secret123' },
-        baseContext as never
-      )
-    ).rejects.toThrow(
+    const error = await handleLoginWithPassword(
+      { email: 'user@example.com', password: 'Secret123' },
+      baseContext as never
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
       "Your email address hasn't been verified yet. Please check your inbox for the verification email."
     );
+    expect((error as { code?: string }).code).toBe('EMAIL_NOT_VERIFIED');
 
     expect(mockConsumeRateLimit).toHaveBeenCalledTimes(1);
     expect(mockConsumeRateLimit).toHaveBeenCalledWith({
@@ -168,6 +179,50 @@ describe('auth/login', () => {
       connectionInfo: baseContext.connectionInfo,
     });
     expect(authConfig.login.onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  test('allows unverified login when verification flag is disabled', async () => {
+    const userId = new ObjectId('507f1f77bcf86cd799439021');
+    mockFindOne.mockResolvedValue({
+      _id: userId,
+      handle: 'demo',
+      authMethods: { password: { hash: 'hashed' } },
+      emails: [{ address: 'user@example.com', verified: false }],
+    } as never);
+    mockGetEmailConfig.mockReturnValue({ provider: 'resend' });
+    // Operator explicitly disabled verification while keeping a provider.
+    mockGetConfig.mockImplementation((key: string) =>
+      key === '_system.user.auth.email.verification' ? false : undefined
+    );
+
+    const result = await handleLoginWithPassword(
+      { email: 'user@example.com', password: 'Secret123' },
+      baseContext as never
+    );
+
+    expect(mockSetSessionUser).toHaveBeenCalledWith('token-1', userId);
+    expect(result.session).toEqual({ authToken: 'token-1' });
+  });
+
+  test('allows unverified login when no email provider is configured', async () => {
+    const userId = new ObjectId('507f1f77bcf86cd799439022');
+    mockFindOne.mockResolvedValue({
+      _id: userId,
+      handle: 'demo',
+      authMethods: { password: { hash: 'hashed' } },
+      emails: [{ address: 'user@example.com', verified: false }],
+    } as never);
+    // No provider: the flag defaults to true (see beforeEach) but verification
+    // cannot be enforced without a way to deliver the email.
+    mockGetEmailConfig.mockReturnValue({ provider: null });
+
+    const result = await handleLoginWithPassword(
+      { email: 'user@example.com', password: 'Secret123' },
+      baseContext as never
+    );
+
+    expect(mockSetSessionUser).toHaveBeenCalledWith('token-1', userId);
+    expect(result.session).toEqual({ authToken: 'token-1' });
   });
 
   test('throws incorrect credentials error when password comparison fails', async () => {

--- a/packages/modelence/src/auth/login.ts
+++ b/packages/modelence/src/auth/login.ts
@@ -9,6 +9,26 @@ import { getEmailConfig } from '@/app/emailConfig';
 import { consumeRateLimit } from '@/server';
 import { validateEmail } from './validators';
 import { getAuthConfig } from '@/app/authConfig';
+import { getConfig } from '@/config/server';
+import { AuthError } from '../error';
+
+/**
+ * Whether unverified emails should be blocked from logging in.
+ *
+ * Verification can only be enforced when an email provider is configured (there
+ * is otherwise no way to deliver a verification email). When a provider exists,
+ * the `auth.email.verification` config flag acts as the actual switch — it
+ * defaults to `true`, preserving the historical behavior where configuring a
+ * provider implicitly turned verification on. Operators can now set the flag to
+ * `false` to keep a provider while allowing unverified users to sign in.
+ */
+function isEmailVerificationRequired(): boolean {
+  if (!getEmailConfig()?.provider) {
+    return false;
+  }
+
+  return Boolean(getConfig('_system.user.auth.email.verification'));
+}
 
 export async function handleLoginWithPassword(
   args: Args,
@@ -50,9 +70,10 @@ export async function handleLoginWithPassword(
 
     const emailDoc = userDoc.emails?.find((e) => e.address.toLowerCase() === email);
 
-    if (!emailDoc?.verified && getEmailConfig()?.provider) {
-      throw new Error(
-        "Your email address hasn't been verified yet. Please check your inbox for the verification email."
+    if (!emailDoc?.verified && isEmailVerificationRequired()) {
+      throw new AuthError(
+        "Your email address hasn't been verified yet. Please check your inbox for the verification email.",
+        'EMAIL_NOT_VERIFIED'
       );
     }
 

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -161,7 +161,7 @@ export default new Module('_system.user', {
     'auth.email.verification': {
       type: 'boolean',
       isPublic: true,
-      default: false,
+      default: true,
     },
     'auth.google.enabled': {
       type: 'boolean',

--- a/packages/modelence/src/auth/verification.test.ts
+++ b/packages/modelence/src/auth/verification.test.ts
@@ -324,6 +324,44 @@ describe('auth/verification', () => {
 
       expect(mockTokensInsertOne).not.toHaveBeenCalled();
     });
+
+    test('prefers _system.site.url over the request-derived baseUrl', async () => {
+      const provider = { sendEmail: vi.fn() };
+      mockGetEmailConfig.mockReturnValue({ provider, verification: {} });
+      mockGetConfig.mockReturnValue('https://app.example.com');
+
+      await sendVerificationEmail({
+        userId: 'user123' as never,
+        email: 'user@example.com',
+        // Simulates the internal container host seen behind a reverse proxy.
+        baseUrl: 'http://10.1.118.6:3000',
+      });
+
+      expect(mockTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          verificationUrl: 'https://app.example.com/api/_internal/auth/verify-email?token=token123',
+        })
+      );
+    });
+
+    test('falls back to the request-derived baseUrl when config is unset', async () => {
+      const provider = { sendEmail: vi.fn() };
+      mockGetEmailConfig.mockReturnValue({ provider, verification: {} });
+      mockGetConfig.mockReturnValue(undefined);
+
+      await sendVerificationEmail({
+        userId: 'user123' as never,
+        email: 'user@example.com',
+        baseUrl: 'https://custom-domain.example.com',
+      });
+
+      expect(mockTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          verificationUrl:
+            'https://custom-domain.example.com/api/_internal/auth/verify-email?token=token123',
+        })
+      );
+    });
   });
 
   describe('handleResendEmailVerification', () => {

--- a/packages/modelence/src/auth/verification.ts
+++ b/packages/modelence/src/auth/verification.ts
@@ -133,12 +133,14 @@ export async function handleVerifyEmail(params: RouteParams): Promise<RouteRespo
 export async function sendVerificationEmail({
   userId,
   email,
-  baseUrl = getConfig('_system.site.url') as string | undefined,
+  baseUrl: requestBaseUrl,
 }: {
   userId: ObjectId;
   email: string;
   baseUrl?: string;
 }) {
+  const baseUrl = (getConfig('_system.site.url') as string | undefined) || requestBaseUrl;
+
   if (getEmailConfig().provider) {
     const emailProvider = getEmailConfig().provider;
 

--- a/packages/modelence/src/client/method.test.ts
+++ b/packages/modelence/src/client/method.test.ts
@@ -76,15 +76,33 @@ describe('client/method', () => {
       ok: false,
       status: 402,
       text: async () => 'Payment required',
+      headers: {
+        get: (name: string) => (name === 'X-Modelence-Error-Code' ? 'PAYMENT_REQUIRED' : null),
+      },
     } as unknown as Response);
 
     await expect(callMethod('test.method')).rejects.toThrow('Payment required');
     expect(mockHandleError).toHaveBeenCalledWith(expect.any(MethodError), 'test.method');
 
-    // Verify the error has the correct status
+    // Verify the error has the correct status and propagated code
     const thrownError = mockHandleError.mock.calls[0][0] as InstanceType<typeof MethodError>;
     expect(thrownError.status).toBe(402);
     expect(thrownError.name).toBe('MethodError');
+    expect(thrownError.code).toBe('PAYMENT_REQUIRED');
+  });
+
+  test('callMethod leaves code undefined when error code header is absent', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'Server error',
+      headers: { get: () => null },
+    } as unknown as Response);
+
+    const thrownError = await callMethod('test.method').catch((e: unknown) => e);
+
+    expect(thrownError).toBeInstanceOf(MethodError);
+    expect((thrownError as InstanceType<typeof MethodError>).code).toBeUndefined();
   });
 
   test('callMethod throws when response lacks data', async () => {

--- a/packages/modelence/src/client/method.ts
+++ b/packages/modelence/src/client/method.ts
@@ -14,11 +14,19 @@ import { reviveResponseTypes } from '@/methods/serialize';
 
 export class MethodError extends Error {
   status: number;
+  /**
+   * Machine-readable error code set by the server (when available), so callers
+   * can branch on the error kind without matching the human-readable message.
+   * For example, a login attempt with an unverified email yields
+   * `code === 'EMAIL_NOT_VERIFIED'`.
+   */
+  code?: string;
 
-  constructor(message: string, status: number) {
+  constructor(message: string, status: number, code?: string) {
     super(message);
     this.name = 'MethodError';
     this.status = status;
+    this.code = code;
   }
 }
 
@@ -88,7 +96,8 @@ async function call<T = unknown>(endpoint: string, args: MethodArgs): Promise<T>
 
   if (!response.ok) {
     const error = await response.text();
-    throw new MethodError(error, response.status);
+    const code = response.headers?.get('X-Modelence-Error-Code') ?? undefined;
+    throw new MethodError(error, response.status, code);
   }
 
   const text = await response.text();

--- a/packages/modelence/src/error.ts
+++ b/packages/modelence/src/error.ts
@@ -1,13 +1,19 @@
 export abstract class ModelenceError extends Error {
   abstract status: number;
+  /**
+   * Optional machine-readable error code so clients can branch on the kind of
+   * error without string-matching `message` (which may be reworded or localized).
+   */
+  code?: string;
 }
 
 export class AuthError extends ModelenceError {
   status = 401;
 
-  constructor(message: string) {
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'AuthError';
+    this.code = code;
   }
 }
 


### PR DESCRIPTION
* Fixed email verification URL
* Add error codes to responses
* `_system.user.auth.email.verification` was ignored before 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes login gating defaults and trusts forwarded headers for base URLs; misconfigured proxies or the new verification default could block logins or affect link generation until `_system.site.url` or config is set correctly.
> 
> **Overview**
> Fixes **email verification links** and **public base URLs** when the app runs behind a reverse proxy, and makes **email verification at login** honor system config with **machine-readable error codes** for clients.
> 
> **Proxy / URL handling:** `connectionInfo.baseUrl` now comes from `getRequestBaseUrl`, which prefers `X-Forwarded-Host` and `X-Forwarded-Proto` (first value in comma-separated lists) instead of the internal `Host` / `req.protocol`. Verification emails build links with `_system.site.url` when set, otherwise the request-derived `baseUrl`.
> 
> **Login verification:** Password login no longer blocks unverified users solely because an email provider exists. `isEmailVerificationRequired()` requires a provider **and** `_system.user.auth.email.verification` (schema default changed from `false` to `true`). Unverified login when required throws `AuthError` with code `EMAIL_NOT_VERIFIED`.
> 
> **Error codes:** `ModelenceError` / `AuthError` accept an optional `code`; method errors set `X-Modelence-Error-Code` when present. The client `MethodError` reads that header so UIs can branch without parsing message text.
> 
> Package version bumped to **0.19.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3af6f333b710ba19fc75301868a0ef4415e12e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->