### PR TITLE
Update: Added User schema extended fields to auth user object

### DIFF
--- a/packages/modelence/src/auth/index.ts
+++ b/packages/modelence/src/auth/index.ts
@@ -16,21 +16,27 @@ export async function authenticate(
         status: { $nin: ['deleted', 'disabled'] },
       })
     : null;
+  //Destructure unsafe fields
   const user = userDoc
-    ? {
-        id: userDoc._id.toString(),
-        handle: userDoc.handle,
-        roles: userDoc.roles || [],
-        hasRole: (role: string) => (userDoc.roles || []).includes(role),
-        requireRole: (role: string) => {
-          if (!(userDoc.roles || []).includes(role)) {
-            throw new Error(`Access denied - role '${role}' required`);
-          }
-        },
-        firstName: userDoc.firstName ?? undefined,
-        lastName: userDoc.lastName ?? undefined,
-        avatarUrl: userDoc.avatarUrl ?? undefined,
-      }
+    ? (() => {
+        const { _id, authMethods, ...safeUser } = userDoc;
+
+        return {
+          ...safeUser,
+          id: userDoc._id.toString(),
+          handle: userDoc.handle,
+          roles: userDoc.roles || [],
+          hasRole: (role: string) => (userDoc.roles || []).includes(role),
+          requireRole: (role: string) => {
+            if (!(userDoc.roles || []).includes(role)) {
+              throw new Error(`Access denied - role '${role}' required`);
+            }
+          },
+          firstName: userDoc.firstName ?? undefined,
+          lastName: userDoc.lastName ?? undefined,
+          avatarUrl: userDoc.avatarUrl ?? undefined,
+        };
+      })()
     : null;
 
   const roles = user ? getDefaultAuthenticatedRoles() : getUnauthenticatedRoles();


### PR DESCRIPTION
```ts
import { schema, dbUsers } from 'modelence/server';

export const extendedDbUsers = dbUsers.extend({
  schema: {
    companyId: schema.string().optional(),
  },
  indexes: [
    { key: { companyId: 1 } },
  ],
});
```

When used `extend` to extend schema of system users collection with custom fields, the `authenticate()` function in `modelence/src/auth/index.ts` returned user object by manually listing a fixed set of fields (firstName, lastName, avatarUrl, etc.) instead of relying on the full document.

So any custom field added through schema extension was present in the database document (userDoc) but not in the user object returned to the app via this `authenticate()`

PR:
`authenticate()` now spreads the full safeUser object (the userDoc with only the unsafe _id and authMethods fields stripped) as the base of the returned user.

Ensures any field present on the document, including ones added via schema extension, is automatically forwarded.

## For
```ts
 async getChats(args:any, { user }:{user: any}) {
      console.log(user);
}
```

### Before: 
extending the schema and saving a new field (e.g. companyId) → field exists in MongoDB, but missing from the user object returned by authenticate().

<img width="685" height="321" alt="Screenshot (769)" src="https://github.com/user-attachments/assets/3525662a-d4bb-4f4e-8b20-97aee94e116a" />

---
### After: 
same extended field is present on the user object as expected.

<img width="791" height="337" alt="Screenshot (768)" src="https://github.com/user-attachments/assets/773e7618-48f0-42b7-b524-faaa4d4f4ab8" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the authentication user-mapping path and exposes additional stored user fields to request context, though sensitive `authMethods` remain excluded.
> 
> **Overview**
> **`authenticate()`** now builds the returned user from the MongoDB document instead of a fixed field list. It strips **`_id`** and **`authMethods`**, spreads the remaining document (including fields added via **`dbUsers.extend`**), then applies the same **`id`**, role helpers, and optional name/avatar overrides as before.
> 
> Custom schema fields such as **`companyId`** are now available on **`user`** in method handlers without changing auth code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6c5076457e9ef1db2f3b3d5e76be53a331cad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->