### PR TITLE
MOD-442: feat: server-side token exchange for password reset

### DIFF
--- a/docs/web/authentication/index.mdx
+++ b/docs/web/authentication/index.mdx
@@ -187,7 +187,7 @@ function MyComponent() {
 - [useSession](/api-reference/modelence/client/functions/useSession) - Access current user session
 - [verifyEmail](/api-reference/modelence/client/functions/verifyEmail) - Verify email with token
 - [sendResetPasswordToken](/api-reference/modelence/client/functions/sendResetPasswordToken) - Request password reset
-- [resetPassword](/api-reference/modelence/client/functions/resetPassword) - Reset password with token
+- [resetPassword](/api-reference/modelence/client/functions/resetPassword) - Set a new password (token is exchanged server-side via cookie)
 
 ### Server Types
 

--- a/docs/web/authentication/password-reset.mdx
+++ b/docs/web/authentication/password-reset.mdx
@@ -26,17 +26,27 @@ startApp({
 });
 ```
 
+`redirectUrl` is the page in your app where the user enters their new password. Modelence redirects here **after** validating the token and storing it in an `httpOnly` cookie, so this URL never carries the token. This is also where you call [`resetPassword({ password })`](#reset-password).
+
 ## How It Works
 
 1. User requests a password reset by providing their email
-2. A secure reset token is generated and stored in the database
+2. A secure reset token is generated, hashed, and stored in the database (only the hash is stored, never the raw token)
 3. An email with a reset link is sent to the user
-4. The link redirects to your app with the token as a query parameter
-5. User enters their new password along with the token
-6. Password is updated and token is invalidated
+4. The link points at a Modelence server route, **not** your SPA page. That route validates the token, stores it in a short-lived `httpOnly` cookie, and redirects to your configured `redirectUrl` **without the token in the URL**
+5. On that page, the user enters their new password and you call `resetPassword({ password })` — the token is read server-side from the cookie, so it never reaches client JavaScript
+6. Password is updated and the token is invalidated (single-use)
 7. If the user's email was not yet verified, it is automatically marked as verified
 
 Since the user must receive the reset email to complete the flow, a successful password reset proves ownership of the email address.
+
+<Note>
+The reset token never reaches your client code or appears in a browser URL — it is exchanged server-side through an `httpOnly` cookie. This closes the window where a token could leak via the address bar, browser history, or the `Referer` header.
+</Note>
+
+### Base URL requirement
+
+The reset email link is built from your site's base URL, so you must set it via the `_system.site.url` config (or the `MODELENCE_SITE_URL` environment variable). If it isn't set, sending a reset token fails with a clear error rather than emailing a broken link.
 
 ## Client Implementation
 
@@ -55,20 +65,26 @@ async function handleForgotPassword(email: string) {
 }
 ```
 
-### Reset Password with Token
+### Reset Password
+
+The user lands on your `redirectUrl` page after clicking the email link. The token is already held in an `httpOnly` cookie, so you only collect the new password — don't pass a token:
 
 ```typescript
 import { resetPassword } from 'modelence/client';
 
-async function handleResetPassword(token: string, newPassword: string) {
+async function handleResetPassword(newPassword: string) {
   try {
-    await resetPassword({ token, password: newPassword });
+    await resetPassword({ password: newPassword });
     console.log('Password reset successful');
   } catch (error) {
     console.error('Reset failed:', error.message);
   }
 }
 ```
+
+<Warning>
+Passing a `token` to `resetPassword({ token, password })` is **deprecated**. It exists only for legacy flows that still carry the token client-side and will be removed. New apps should rely on the server-side cookie exchange and submit just the password.
+</Warning>
 
 ## Custom Reset Email Template
 

--- a/docs/web/authentication/password-reset.mdx
+++ b/docs/web/authentication/password-reset.mdx
@@ -44,6 +44,10 @@ Since the user must receive the reset email to complete the flow, a successful p
 The reset token never reaches your client code or appears in a browser URL — it is exchanged server-side through an `httpOnly` cookie. This closes the window where a token could leak via the address bar, browser history, or the `Referer` header.
 </Note>
 
+<Note>
+The token cookie is sent with credentialed requests, so it works even when your SPA and Modelence API are on different origins. For that cross-origin case, the API must respond with `Access-Control-Allow-Credentials: true` and a specific (non-wildcard) allowed origin, otherwise the browser drops the cookie and the reset fails.
+</Note>
+
 ### Base URL requirement
 
 The reset email link is built from your site's base URL, so you must set it via the `_system.site.url` config (or the `MODELENCE_SITE_URL` environment variable). If it isn't set, sending a reset token fails with a clear error rather than emailing a broken link.

--- a/packages/modelence/src/auth/client/index.test.ts
+++ b/packages/modelence/src/auth/client/index.test.ts
@@ -90,11 +90,19 @@ describe('auth/client', () => {
     });
   });
 
-  test('resetPassword submits token and password', async () => {
+  test('resetPassword submits token and password when token is provided', async () => {
     await authClient.resetPassword({ token: 'token123', password: 'newpass' });
 
     expect(mockCallMethod).toHaveBeenCalledWith('_system.user.resetPassword', {
       token: 'token123',
+      password: 'newpass',
+    });
+  });
+
+  test('resetPassword submits only the password when token is omitted (cookie exchange)', async () => {
+    await authClient.resetPassword({ password: 'newpass' });
+
+    expect(mockCallMethod).toHaveBeenCalledWith('_system.user.resetPassword', {
       password: 'newpass',
     });
   });

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -171,13 +171,20 @@ export async function sendResetPasswordToken(options: { email: string }) {
 
 /**
  * Reset password.
- * @param options.token - The password reset token.
+ *
+ * The reset token is normally exchanged server-side: the password reset email
+ * links to a server route that stores the token in an httpOnly cookie, so the
+ * client only needs to submit the new password. Pass `token` explicitly only for
+ * legacy flows that still carry it in the client (deprecated).
+ *
+ * @param options.token - The password reset token (optional; read from the
+ *   httpOnly cookie when omitted).
  * @param options.password - The new password.
  */
-export async function resetPassword(options: { token: string; password: string }) {
+export async function resetPassword(options: { token?: string; password: string }) {
   const { token, password } = options;
   await callMethod('_system.user.resetPassword', {
-    token,
+    ...(token ? { token } : {}),
     password,
   });
 }

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -172,13 +172,11 @@ export async function sendResetPasswordToken(options: { email: string }) {
 /**
  * Reset password.
  *
- * The reset token is normally exchanged server-side: the password reset email
- * links to a server route that stores the token in an httpOnly cookie, so the
- * client only needs to submit the new password. Pass `token` explicitly only for
- * legacy flows that still carry it in the client (deprecated).
+ * The token is normally exchanged server-side via an httpOnly cookie, so the
+ * client only submits the new password. Pass `token` only for legacy flows
+ * that still carry it client-side (deprecated).
  *
- * @param options.token - The password reset token (optional; read from the
- *   httpOnly cookie when omitted).
+ * @param options.token - Reset token (optional; read from the httpOnly cookie when omitted).
  * @param options.password - The new password.
  */
 export async function resetPassword(options: { token?: string; password: string }) {

--- a/packages/modelence/src/auth/resetPassword.test.ts
+++ b/packages/modelence/src/auth/resetPassword.test.ts
@@ -567,22 +567,23 @@ describe('auth/resetPassword', () => {
       );
       mockBcryptHash.mockResolvedValue(hashedPassword);
 
-      // The token is claimed atomically (single-use) via findOneAndDelete.
-      mockResetTokensFindOneAndDelete.mockResolvedValue(
-        createMockResetToken({
-          userId,
-          email,
-          token,
-          expiresAt: new Date(Date.now() + 1000000),
-          createdAt: new Date(),
-        })
-      );
+      // Token is found read-only, then claimed atomically by _id at the commit point.
+      const tokenDoc = createMockResetToken({
+        userId,
+        email,
+        token,
+        expiresAt: new Date(Date.now() + 1000000),
+        createdAt: new Date(),
+      });
+      mockResetTokensFindOne.mockResolvedValue(tokenDoc);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(tokenDoc);
 
       const result = await handleResetPassword({ token, password }, createContext());
 
       expect(mockValidatePassword).toHaveBeenCalledWith(password);
-      // Atomic claim is keyed by the hashed token, not the raw value.
-      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ token: sha256(token) });
+      // Lookup is keyed by the hashed token; the claim is keyed by _id.
+      expect(mockResetTokensFindOne).toHaveBeenCalledWith({ token: sha256(token) });
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ _id: tokenDoc!._id });
       expect(mockUsersFindOne).toHaveBeenCalledWith({ _id: userId });
       expect(mockBcryptHash).toHaveBeenCalledWith(password, 10);
       expect(mockUsersUpdateOne).toHaveBeenNthCalledWith(
@@ -596,7 +597,6 @@ describe('auth/resetPassword', () => {
         { $set: { 'emails.$.verified': true } }
       );
       expect(mockInvalidateAllUserSessions).toHaveBeenCalledWith(userId);
-      // No separate delete — consumption happened atomically during the claim.
       expect(mockResetTokensDeleteOne).not.toHaveBeenCalled();
       expect(result).toEqual({
         success: true,
@@ -610,14 +610,16 @@ describe('auth/resetPassword', () => {
       const userId = new ObjectId();
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOneAndDelete.mockResolvedValue({
+      const legacyDoc = {
         _id: new ObjectId(),
         userId,
         token,
         expiresAt: new Date(Date.now() + 1000000),
         createdAt: new Date(),
         // no email field — simulates a legacy token
-      } as never);
+      };
+      mockResetTokensFindOne.mockResolvedValue(legacyDoc as never);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(legacyDoc as never);
       mockUsersFindOne.mockResolvedValue(
         createMockUser({ _id: userId, authMethods: { password: { hash: 'oldHash' } } })
       );
@@ -638,12 +640,14 @@ describe('auth/resetPassword', () => {
       const password = 'NewP@ssw0rd!';
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOneAndDelete.mockResolvedValue(null);
+      mockResetTokensFindOne.mockResolvedValue(null);
 
       await expect(handleResetPassword({ token, password }, createContext())).rejects.toThrow(
         'Invalid or expired reset token'
       );
 
+      // Nothing was consumed and the password was never touched.
+      expect(mockResetTokensFindOneAndDelete).not.toHaveBeenCalled();
       expect(mockBcryptHash).not.toHaveBeenCalled();
       expect(mockUsersUpdateOne).not.toHaveBeenCalled();
     });
@@ -660,25 +664,26 @@ describe('auth/resetPassword', () => {
         expiresAt: new Date(Date.now() - 1000), // Expired 1 second ago
         createdAt: new Date(Date.now() - 4000000),
       });
-      // The expired token is claimed (and thus removed) atomically, then rejected.
+      mockResetTokensFindOne.mockResolvedValue(expiredDoc);
       mockResetTokensFindOneAndDelete.mockResolvedValue(expiredDoc);
 
       await expect(handleResetPassword({ token, password }, createContext())).rejects.toThrow(
         'Reset token has expired'
       );
 
-      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ token: sha256(token) });
+      // Expired token is removed (claimed by _id) and the password never touched.
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ _id: expiredDoc!._id });
       expect(mockBcryptHash).not.toHaveBeenCalled();
       expect(mockUsersUpdateOne).not.toHaveBeenCalled();
     });
 
-    test('throws error if user not found', async () => {
+    test('throws error if user not found and does NOT consume the token', async () => {
       const token = 'validtoken';
       const password = 'NewP@ssw0rd!';
       const userId = new ObjectId();
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOneAndDelete.mockResolvedValue(
+      mockResetTokensFindOne.mockResolvedValue(
         createMockResetToken({
           userId,
           token,
@@ -694,6 +699,8 @@ describe('auth/resetPassword', () => {
 
       expect(mockBcryptHash).not.toHaveBeenCalled();
       expect(mockUsersUpdateOne).not.toHaveBeenCalled();
+      // The link stays valid so the user can retry — token must NOT be consumed.
+      expect(mockResetTokensFindOneAndDelete).not.toHaveBeenCalled();
     });
 
     test('validates password before resetting', async () => {
@@ -704,7 +711,7 @@ describe('auth/resetPassword', () => {
       mockValidatePassword.mockImplementation(() => {
         throw new Error('Password must be at least 8 characters');
       });
-      mockResetTokensFindOneAndDelete.mockResolvedValue(
+      mockResetTokensFindOne.mockResolvedValue(
         createMockResetToken({
           userId,
           token,
@@ -729,14 +736,14 @@ describe('auth/resetPassword', () => {
       const userId = new ObjectId();
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOneAndDelete.mockResolvedValue(
-        createMockResetToken({
-          userId,
-          token,
-          expiresAt: new Date(Date.now() + 1000000),
-          createdAt: new Date(),
-        })
-      );
+      const tokenDoc = createMockResetToken({
+        userId,
+        token,
+        expiresAt: new Date(Date.now() + 1000000),
+        createdAt: new Date(),
+      });
+      mockResetTokensFindOne.mockResolvedValue(tokenDoc);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(tokenDoc);
       mockUsersFindOne.mockResolvedValue(
         createMockUser({
           _id: userId,
@@ -750,20 +757,20 @@ describe('auth/resetPassword', () => {
       expect(mockBcryptHash).toHaveBeenCalledWith(password, 10);
     });
 
-    test('consumes the reset token atomically (single-use) on success', async () => {
+    test('consumes the reset token atomically by _id (single-use) on success', async () => {
       const token = 'onetimetoken';
       const password = 'NewP@ssw0rd!';
       const userId = new ObjectId();
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOneAndDelete.mockResolvedValue(
-        createMockResetToken({
-          userId,
-          token,
-          expiresAt: new Date(Date.now() + 1000000),
-          createdAt: new Date(),
-        })
-      );
+      const tokenDoc = createMockResetToken({
+        userId,
+        token,
+        expiresAt: new Date(Date.now() + 1000000),
+        createdAt: new Date(),
+      });
+      mockResetTokensFindOne.mockResolvedValue(tokenDoc);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(tokenDoc);
       mockUsersFindOne.mockResolvedValue(
         createMockUser({
           _id: userId,
@@ -774,10 +781,34 @@ describe('auth/resetPassword', () => {
 
       await handleResetPassword({ token, password }, createContext());
 
-      // findOneAndDelete is the single point of consumption; no separate deleteOne.
+      // Exactly one atomic claim by _id; no separate deleteOne.
       expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledTimes(1);
-      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ token: sha256(token) });
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ _id: tokenDoc!._id });
       expect(mockResetTokensDeleteOne).not.toHaveBeenCalled();
+    });
+
+    test('aborts without changing the password if the token was already claimed', async () => {
+      // Simulates a concurrent request that consumed the token between the
+      // read and the commit: findOne returns the doc, but the claim returns null.
+      const token = 'racedtoken';
+      const password = 'NewP@ssw0rd!';
+      const userId = new ObjectId();
+
+      mockValidatePassword.mockReturnValue(password);
+      mockResetTokensFindOne.mockResolvedValue(
+        createMockResetToken({ userId, token, expiresAt: new Date(Date.now() + 1e6) })
+      );
+      mockUsersFindOne.mockResolvedValue(createMockUser({ _id: userId }));
+      mockBcryptHash.mockResolvedValue('hashedPassword');
+      mockResetTokensFindOneAndDelete.mockResolvedValue(null); // lost the race
+
+      await expect(handleResetPassword({ token, password }, createContext())).rejects.toThrow(
+        'Invalid or expired reset token'
+      );
+
+      // Password must not be updated when the claim is lost.
+      expect(mockUsersUpdateOne).not.toHaveBeenCalled();
+      expect(mockInvalidateAllUserSessions).not.toHaveBeenCalled();
     });
 
     test('reads the token from the httpOnly cookie when present, ignoring args', async () => {
@@ -786,9 +817,13 @@ describe('auth/resetPassword', () => {
       const userId = new ObjectId();
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOneAndDelete.mockResolvedValue(
-        createMockResetToken({ userId, token: cookieToken, expiresAt: new Date(Date.now() + 1e6) })
-      );
+      const tokenDoc = createMockResetToken({
+        userId,
+        token: cookieToken,
+        expiresAt: new Date(Date.now() + 1e6),
+      });
+      mockResetTokensFindOne.mockResolvedValue(tokenDoc);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(tokenDoc);
       mockUsersFindOne.mockResolvedValue(createMockUser({ _id: userId }));
       mockBcryptHash.mockResolvedValue('hashedPassword');
 
@@ -802,8 +837,8 @@ describe('auth/resetPassword', () => {
       // args.token is a decoy — the cookie value must win.
       await handleResetPassword({ token: 'decoy-arg-token', password }, httpContext as never);
 
-      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ token: sha256(cookieToken) });
-      expect(mockResetTokensFindOneAndDelete).not.toHaveBeenCalledWith({
+      expect(mockResetTokensFindOne).toHaveBeenCalledWith({ token: sha256(cookieToken) });
+      expect(mockResetTokensFindOne).not.toHaveBeenCalledWith({
         token: sha256('decoy-arg-token'),
       });
       // Cookie is cleared after a successful reset.
@@ -821,15 +856,18 @@ describe('auth/resetPassword', () => {
       });
 
       mockValidatePassword.mockReturnValue(password);
-      // First atomic claim (hashed) misses, second (plaintext) hits.
-      mockResetTokensFindOneAndDelete.mockResolvedValueOnce(null).mockResolvedValueOnce(legacyDoc);
+      // First lookup (hashed) misses, second (plaintext) hits; claim succeeds.
+      mockResetTokensFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(legacyDoc);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(legacyDoc);
       mockUsersFindOne.mockResolvedValue(createMockUser({ _id: userId }));
       mockBcryptHash.mockResolvedValue('hashedPassword');
 
       const result = await handleResetPassword({ token, password }, createContext());
 
-      expect(mockResetTokensFindOneAndDelete).toHaveBeenNthCalledWith(1, { token: sha256(token) });
-      expect(mockResetTokensFindOneAndDelete).toHaveBeenNthCalledWith(2, { token });
+      expect(mockResetTokensFindOne).toHaveBeenNthCalledWith(1, { token: sha256(token) });
+      expect(mockResetTokensFindOne).toHaveBeenNthCalledWith(2, { token });
+      // Consumed by _id at the commit point.
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ _id: legacyDoc!._id });
       expect(result).toEqual({ success: true, message: 'Password has been reset successfully' });
     });
   });

--- a/packages/modelence/src/auth/resetPassword.test.ts
+++ b/packages/modelence/src/auth/resetPassword.test.ts
@@ -918,7 +918,7 @@ describe('auth/resetPassword', () => {
         token,
         expect.objectContaining({
           httpOnly: true,
-          sameSite: 'strict',
+          sameSite: 'lax',
           path: '/api/_internal/',
         })
       );

--- a/packages/modelence/src/auth/resetPassword.test.ts
+++ b/packages/modelence/src/auth/resetPassword.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { MockedFunction } from 'vitest';
 import { ObjectId } from 'mongodb';
+import { createHash as actualCreateHash } from 'crypto';
 import type { Context } from '@/methods/types';
 import type { usersCollection, resetPasswordTokensCollection } from './db';
+
+const sha256 = (value: string) => actualCreateHash('sha256').update(value).digest('hex');
 
 type UsersCollection = typeof usersCollection;
 type ResetPasswordTokensCollection = typeof resetPasswordTokensCollection;
@@ -14,6 +17,9 @@ const mockResetTokensInsertOne: MockedFunction<ResetPasswordTokensCollection['in
 const mockResetTokensFindOne: MockedFunction<ResetPasswordTokensCollection['findOne']> = vi.fn();
 const mockResetTokensDeleteOne: MockedFunction<ResetPasswordTokensCollection['deleteOne']> =
   vi.fn();
+const mockResetTokensFindOneAndDelete: MockedFunction<
+  ResetPasswordTokensCollection['findOneAndDelete']
+> = vi.fn();
 const mockGetEmailConfig = vi.fn();
 const mockHtmlToText: MockedFunction<(html: string) => string> = vi.fn();
 const mockValidateEmail: MockedFunction<(email: string) => string> = vi.fn();
@@ -48,6 +54,7 @@ vi.doMock('./db', () => ({
     insertOne: mockResetTokensInsertOne,
     findOne: mockResetTokensFindOne,
     deleteOne: mockResetTokensDeleteOne,
+    findOneAndDelete: mockResetTokensFindOneAndDelete,
   },
 }));
 
@@ -66,6 +73,8 @@ vi.doMock('./validators', () => ({
 
 vi.doMock('crypto', () => ({
   randomBytes: mockRandomBytes,
+  // tokenHash.ts (imported transitively) needs the real createHash.
+  createHash: actualCreateHash,
 }));
 
 vi.doMock('bcrypt', () => ({
@@ -78,7 +87,9 @@ vi.doMock('@/time', () => ({
   time: mockTime,
 }));
 
-const { handleSendResetPasswordToken, handleResetPassword } = await import('./resetPassword');
+const resetPasswordModule = await import('./resetPassword');
+const { handleSendResetPasswordToken, handleResetPassword, handleResetPasswordLanding } =
+  resetPasswordModule;
 
 const createContext = (overrides: Partial<Context> = {}): Context => ({
   session: overrides.session ?? null,
@@ -221,19 +232,23 @@ describe('auth/resetPassword', () => {
         { 'emails.address': email, status: { $nin: ['deleted', 'disabled'] } },
         { collation: { locale: 'en', strength: 2 } }
       );
+      // Token is stored hashed at rest, never as the raw value.
       expect(mockResetTokensInsertOne).toHaveBeenCalledWith({
         userId,
         email,
-        token: resetToken,
+        token: sha256(resetToken),
         createdAt: expect.any(Date),
         expiresAt: expect.any(Date),
       });
+      // Email links to the server landing route carrying the raw token, not the SPA page.
       expect(mockEmailProvider.sendEmail).toHaveBeenCalledWith({
         to: email,
         from: 'test@example.com',
         subject: 'Reset your password',
         text: expect.any(String),
-        html: expect.stringContaining(resetToken),
+        html: expect.stringContaining(
+          `https://example.com/api/_internal/auth/reset-password?token=${resetToken}`
+        ),
       });
       expect(result).toEqual({
         success: true,
@@ -378,7 +393,7 @@ describe('auth/resetPassword', () => {
 
       expect(mockEmailProvider.sendEmail).toHaveBeenCalledWith(
         expect.objectContaining({
-          html: `<p>Custom: ${email} - https://example.com/reset?token=${resetToken}</p>`,
+          html: `<p>Custom: ${email} - https://example.com/api/_internal/auth/reset-password?token=${resetToken}</p>`,
         })
       );
     });
@@ -408,7 +423,9 @@ describe('auth/resetPassword', () => {
 
       expect(mockEmailProvider.sendEmail).toHaveBeenCalledWith(
         expect.objectContaining({
-          html: expect.stringContaining('https://custom.com/reset-password?token='),
+          html: expect.stringContaining(
+            'https://custom.com/api/_internal/auth/reset-password?token='
+          ),
         })
       );
     });
@@ -438,12 +455,17 @@ describe('auth/resetPassword', () => {
 
       expect(mockEmailProvider.sendEmail).toHaveBeenCalledWith(
         expect.objectContaining({
-          html: expect.stringContaining('https://connection.com/reset-password?token='),
+          html: expect.stringContaining(
+            'https://connection.com/api/_internal/auth/reset-password?token='
+          ),
         })
       );
     });
 
-    test('handles absolute URL in redirectUrl configuration', async () => {
+    test('email always links to the server landing route regardless of redirectUrl', async () => {
+      // redirectUrl now configures only the SPA page the landing route redirects
+      // to after stashing the token; the email itself always targets the server
+      // landing route so the raw token never reaches a client-rendered URL.
       const email = 'user@example.com';
       const resetToken = 'token000';
 
@@ -474,7 +496,15 @@ describe('auth/resetPassword', () => {
 
       expect(mockEmailProvider.sendEmail).toHaveBeenCalledWith(
         expect.objectContaining({
-          html: expect.stringContaining('https://external.com/custom-reset?token='),
+          html: expect.stringContaining(
+            `https://example.com/api/_internal/auth/reset-password?token=${resetToken}`
+          ),
+        })
+      );
+      // The raw external SPA URL must not appear with the token.
+      expect(mockEmailProvider.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          html: expect.not.stringContaining('https://external.com/custom-reset?token='),
         })
       );
     });
@@ -528,15 +558,6 @@ describe('auth/resetPassword', () => {
       const email = 'user@example.com';
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOne.mockResolvedValue(
-        createMockResetToken({
-          userId,
-          email,
-          token,
-          expiresAt: new Date(Date.now() + 1000000), // Not expired
-          createdAt: new Date(),
-        })
-      );
       mockUsersFindOne.mockResolvedValue(
         createMockUser({
           _id: userId,
@@ -546,10 +567,22 @@ describe('auth/resetPassword', () => {
       );
       mockBcryptHash.mockResolvedValue(hashedPassword);
 
+      // The token is claimed atomically (single-use) via findOneAndDelete.
+      mockResetTokensFindOneAndDelete.mockResolvedValue(
+        createMockResetToken({
+          userId,
+          email,
+          token,
+          expiresAt: new Date(Date.now() + 1000000),
+          createdAt: new Date(),
+        })
+      );
+
       const result = await handleResetPassword({ token, password }, createContext());
 
       expect(mockValidatePassword).toHaveBeenCalledWith(password);
-      expect(mockResetTokensFindOne).toHaveBeenCalledWith({ token });
+      // Atomic claim is keyed by the hashed token, not the raw value.
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ token: sha256(token) });
       expect(mockUsersFindOne).toHaveBeenCalledWith({ _id: userId });
       expect(mockBcryptHash).toHaveBeenCalledWith(password, 10);
       expect(mockUsersUpdateOne).toHaveBeenNthCalledWith(
@@ -563,7 +596,8 @@ describe('auth/resetPassword', () => {
         { $set: { 'emails.$.verified': true } }
       );
       expect(mockInvalidateAllUserSessions).toHaveBeenCalledWith(userId);
-      expect(mockResetTokensDeleteOne).toHaveBeenCalledWith({ token });
+      // No separate delete — consumption happened atomically during the claim.
+      expect(mockResetTokensDeleteOne).not.toHaveBeenCalled();
       expect(result).toEqual({
         success: true,
         message: 'Password has been reset successfully',
@@ -576,7 +610,7 @@ describe('auth/resetPassword', () => {
       const userId = new ObjectId();
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOne.mockResolvedValue({
+      mockResetTokensFindOneAndDelete.mockResolvedValue({
         _id: new ObjectId(),
         userId,
         token,
@@ -604,7 +638,7 @@ describe('auth/resetPassword', () => {
       const password = 'NewP@ssw0rd!';
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOne.mockResolvedValue(null);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(null);
 
       await expect(handleResetPassword({ token, password }, createContext())).rejects.toThrow(
         'Invalid or expired reset token'
@@ -620,20 +654,20 @@ describe('auth/resetPassword', () => {
       const userId = new ObjectId();
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOne.mockResolvedValue(
-        createMockResetToken({
-          userId,
-          token,
-          expiresAt: new Date(Date.now() - 1000), // Expired 1 second ago
-          createdAt: new Date(Date.now() - 4000000),
-        })
-      );
+      const expiredDoc = createMockResetToken({
+        userId,
+        token,
+        expiresAt: new Date(Date.now() - 1000), // Expired 1 second ago
+        createdAt: new Date(Date.now() - 4000000),
+      });
+      // The expired token is claimed (and thus removed) atomically, then rejected.
+      mockResetTokensFindOneAndDelete.mockResolvedValue(expiredDoc);
 
       await expect(handleResetPassword({ token, password }, createContext())).rejects.toThrow(
         'Reset token has expired'
       );
 
-      expect(mockResetTokensDeleteOne).toHaveBeenCalledWith({ token });
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ token: sha256(token) });
       expect(mockBcryptHash).not.toHaveBeenCalled();
       expect(mockUsersUpdateOne).not.toHaveBeenCalled();
     });
@@ -644,7 +678,7 @@ describe('auth/resetPassword', () => {
       const userId = new ObjectId();
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOne.mockResolvedValue(
+      mockResetTokensFindOneAndDelete.mockResolvedValue(
         createMockResetToken({
           userId,
           token,
@@ -660,7 +694,6 @@ describe('auth/resetPassword', () => {
 
       expect(mockBcryptHash).not.toHaveBeenCalled();
       expect(mockUsersUpdateOne).not.toHaveBeenCalled();
-      expect(mockResetTokensDeleteOne).not.toHaveBeenCalled();
     });
 
     test('validates password before resetting', async () => {
@@ -671,7 +704,7 @@ describe('auth/resetPassword', () => {
       mockValidatePassword.mockImplementation(() => {
         throw new Error('Password must be at least 8 characters');
       });
-      mockResetTokensFindOne.mockResolvedValue(
+      mockResetTokensFindOneAndDelete.mockResolvedValue(
         createMockResetToken({
           userId,
           token,
@@ -686,6 +719,8 @@ describe('auth/resetPassword', () => {
 
       expect(mockBcryptHash).not.toHaveBeenCalled();
       expect(mockUsersUpdateOne).not.toHaveBeenCalled();
+      // Validation runs before the token is claimed, so the token is left intact.
+      expect(mockResetTokensFindOneAndDelete).not.toHaveBeenCalled();
     });
 
     test('uses bcrypt with salt rounds 10', async () => {
@@ -694,7 +729,7 @@ describe('auth/resetPassword', () => {
       const userId = new ObjectId();
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOne.mockResolvedValue(
+      mockResetTokensFindOneAndDelete.mockResolvedValue(
         createMockResetToken({
           userId,
           token,
@@ -715,13 +750,13 @@ describe('auth/resetPassword', () => {
       expect(mockBcryptHash).toHaveBeenCalledWith(password, 10);
     });
 
-    test('deletes reset token after successful password reset', async () => {
+    test('consumes the reset token atomically (single-use) on success', async () => {
       const token = 'onetimetoken';
       const password = 'NewP@ssw0rd!';
       const userId = new ObjectId();
 
       mockValidatePassword.mockReturnValue(password);
-      mockResetTokensFindOne.mockResolvedValue(
+      mockResetTokensFindOneAndDelete.mockResolvedValue(
         createMockResetToken({
           userId,
           token,
@@ -739,8 +774,139 @@ describe('auth/resetPassword', () => {
 
       await handleResetPassword({ token, password }, createContext());
 
-      expect(mockResetTokensDeleteOne).toHaveBeenCalledWith({ token });
-      expect(mockResetTokensDeleteOne).toHaveBeenCalledTimes(1);
+      // findOneAndDelete is the single point of consumption; no separate deleteOne.
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledTimes(1);
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ token: sha256(token) });
+      expect(mockResetTokensDeleteOne).not.toHaveBeenCalled();
+    });
+
+    test('reads the token from the httpOnly cookie when present, ignoring args', async () => {
+      const cookieToken = 'cookie-token';
+      const password = 'NewP@ssw0rd!';
+      const userId = new ObjectId();
+
+      mockValidatePassword.mockReturnValue(password);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(
+        createMockResetToken({ userId, token: cookieToken, expiresAt: new Date(Date.now() + 1e6) })
+      );
+      mockUsersFindOne.mockResolvedValue(createMockUser({ _id: userId }));
+      mockBcryptHash.mockResolvedValue('hashedPassword');
+
+      const clearCookie = vi.fn();
+      const httpContext = {
+        ...createContext(),
+        req: { cookies: { resetPasswordToken: cookieToken } },
+        res: { clearCookie },
+      };
+
+      // args.token is a decoy — the cookie value must win.
+      await handleResetPassword({ token: 'decoy-arg-token', password }, httpContext as never);
+
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ token: sha256(cookieToken) });
+      expect(mockResetTokensFindOneAndDelete).not.toHaveBeenCalledWith({
+        token: sha256('decoy-arg-token'),
+      });
+      // Cookie is cleared after a successful reset.
+      expect(clearCookie).toHaveBeenCalledWith('resetPasswordToken', { path: '/api/_internal/' });
+    });
+
+    test('falls back to a legacy plaintext token when no hashed match exists', async () => {
+      const token = 'legacy-plaintext-token';
+      const password = 'NewP@ssw0rd!';
+      const userId = new ObjectId();
+      const legacyDoc = createMockResetToken({
+        userId,
+        token, // stored as plaintext (pre-hashing)
+        expiresAt: new Date(Date.now() + 1e6),
+      });
+
+      mockValidatePassword.mockReturnValue(password);
+      // First atomic claim (hashed) misses, second (plaintext) hits.
+      mockResetTokensFindOneAndDelete.mockResolvedValueOnce(null).mockResolvedValueOnce(legacyDoc);
+      mockUsersFindOne.mockResolvedValue(createMockUser({ _id: userId }));
+      mockBcryptHash.mockResolvedValue('hashedPassword');
+
+      const result = await handleResetPassword({ token, password }, createContext());
+
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenNthCalledWith(1, { token: sha256(token) });
+      expect(mockResetTokensFindOneAndDelete).toHaveBeenNthCalledWith(2, { token });
+      expect(result).toEqual({ success: true, message: 'Password has been reset successfully' });
+    });
+  });
+
+  describe('handleResetPasswordLanding', () => {
+    const makeParams = (token: string | undefined, cookie = vi.fn()) => ({
+      query: token === undefined ? {} : { token },
+      res: { cookie },
+      req: { protocol: 'https', get: () => 'app.example.com' },
+    });
+
+    test('sets an httpOnly cookie and redirects to the tokenless SPA page when valid', async () => {
+      mockGetConfig.mockReturnValue('https://example.com');
+      mockGetEmailConfig.mockReturnValue({ passwordReset: { redirectUrl: '/new-password' } });
+      const token = 'valid-landing-token';
+      mockResetTokensFindOne.mockResolvedValue(
+        createMockResetToken({ token, expiresAt: new Date(Date.now() + 1e6) })
+      );
+
+      const cookie = vi.fn();
+      const result = await handleResetPasswordLanding(makeParams(token, cookie) as never);
+
+      expect(cookie).toHaveBeenCalledWith(
+        'resetPasswordToken',
+        token,
+        expect.objectContaining({
+          httpOnly: true,
+          sameSite: 'strict',
+          path: '/api/_internal/',
+        })
+      );
+      // No token in the redirect target — it lives only in the cookie.
+      expect(result).toEqual({
+        status: 302,
+        headers: { 'Referrer-Policy': 'no-referrer' },
+        redirect: 'https://example.com/new-password',
+      });
+      expect(result?.redirect).not.toContain(token);
+    });
+
+    test('redirects with an error and sets no cookie when the token is invalid', async () => {
+      mockGetConfig.mockReturnValue('https://example.com');
+      mockGetEmailConfig.mockReturnValue({ passwordReset: { redirectUrl: '/new-password' } });
+      mockResetTokensFindOne.mockResolvedValue(null);
+
+      const cookie = vi.fn();
+      const result = await handleResetPasswordLanding(makeParams('bad-token', cookie) as never);
+
+      expect(cookie).not.toHaveBeenCalled();
+      expect(result?.status).toBe(302);
+      expect(result?.redirect).toContain('status=error');
+      expect(result?.redirect).not.toContain('bad-token');
+    });
+
+    test('redirects with an error when the token is expired', async () => {
+      mockGetConfig.mockReturnValue('https://example.com');
+      mockGetEmailConfig.mockReturnValue({ passwordReset: { redirectUrl: '/new-password' } });
+      mockResetTokensFindOne.mockResolvedValue(
+        createMockResetToken({ token: 'expired', expiresAt: new Date(Date.now() - 1000) })
+      );
+
+      const cookie = vi.fn();
+      const result = await handleResetPasswordLanding(makeParams('expired', cookie) as never);
+
+      expect(cookie).not.toHaveBeenCalled();
+      expect(result?.redirect).toContain('status=error');
+    });
+
+    test('redirects with an error when the token query param is missing', async () => {
+      mockGetConfig.mockReturnValue('https://example.com');
+      mockGetEmailConfig.mockReturnValue({ passwordReset: { redirectUrl: '/new-password' } });
+
+      const cookie = vi.fn();
+      const result = await handleResetPasswordLanding(makeParams(undefined, cookie) as never);
+
+      expect(cookie).not.toHaveBeenCalled();
+      expect(result?.redirect).toContain('status=error');
     });
   });
 });

--- a/packages/modelence/src/auth/resetPassword.test.ts
+++ b/packages/modelence/src/auth/resetPassword.test.ts
@@ -462,6 +462,29 @@ describe('auth/resetPassword', () => {
       );
     });
 
+    test('throws (no email sent) when no base URL can be resolved', async () => {
+      const email = 'user@example.com';
+
+      mockGetConfig.mockReturnValue(undefined); // no _system.site.url
+      mockValidateEmail.mockReturnValue(email);
+      mockUsersFindOne.mockResolvedValue(
+        createMockUser({
+          emails: [{ address: email, verified: true }],
+          authMethods: { password: { hash: 'hash' } },
+          status: 'active',
+        })
+      );
+      mockRandomBytes.mockReturnValue({ toString: () => 'tok' });
+
+      await expect(
+        // connectionInfo.baseUrl also absent
+        handleSendResetPasswordToken({ email }, createContext({ connectionInfo: {} }))
+      ).rejects.toThrow(/site\.url|MODELENCE_SITE_URL/);
+
+      // A broken link must never be emailed.
+      expect(mockEmailProvider.sendEmail).not.toHaveBeenCalled();
+    });
+
     test('email always links to the server landing route regardless of redirectUrl', async () => {
       // redirectUrl now configures only the SPA page the landing route redirects
       // to after stashing the token; the email itself always targets the server

--- a/packages/modelence/src/auth/resetPassword.test.ts
+++ b/packages/modelence/src/auth/resetPassword.test.ts
@@ -870,30 +870,48 @@ describe('auth/resetPassword', () => {
       expect(clearCookie).toHaveBeenCalledWith('resetPasswordToken', { path: '/api/_internal/' });
     });
 
-    test('falls back to a legacy plaintext token when no hashed match exists', async () => {
-      const token = 'legacy-plaintext-token';
+    test('looks up the token only by its hash (no plaintext fallback)', async () => {
+      const token = 'a'.repeat(64);
       const password = 'NewP@ssw0rd!';
       const userId = new ObjectId();
-      const legacyDoc = createMockResetToken({
+      const tokenDoc = createMockResetToken({
         userId,
-        token, // stored as plaintext (pre-hashing)
+        token: sha256(token),
         expiresAt: new Date(Date.now() + 1e6),
       });
 
       mockValidatePassword.mockReturnValue(password);
-      // First lookup (hashed) misses, second (plaintext) hits; claim succeeds.
-      mockResetTokensFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(legacyDoc);
-      mockResetTokensFindOneAndDelete.mockResolvedValue(legacyDoc);
+      mockResetTokensFindOne.mockResolvedValue(tokenDoc);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(tokenDoc);
       mockUsersFindOne.mockResolvedValue(createMockUser({ _id: userId }));
       mockBcryptHash.mockResolvedValue('hashedPassword');
 
-      const result = await handleResetPassword({ token, password }, createContext());
+      await handleResetPassword({ token, password }, createContext());
 
-      expect(mockResetTokensFindOne).toHaveBeenNthCalledWith(1, { token: sha256(token) });
-      expect(mockResetTokensFindOne).toHaveBeenNthCalledWith(2, { token });
-      // Consumed by _id at the commit point.
-      expect(mockResetTokensFindOneAndDelete).toHaveBeenCalledWith({ _id: legacyDoc!._id });
-      expect(result).toEqual({ success: true, message: 'Password has been reset successfully' });
+      // Exactly one lookup, by hash — never a plaintext match against the column.
+      expect(mockResetTokensFindOne).toHaveBeenCalledTimes(1);
+      expect(mockResetTokensFindOne).toHaveBeenCalledWith({ token: sha256(token) });
+    });
+
+    test('rejects a leaked stored hash replayed as the bearer token', async () => {
+      // An attacker who leaks the DB knows the stored value (the SHA-256 digest).
+      // Submitting that digest as the token must NOT match: the lookup hashes it
+      // again, so it can never equal the stored hash. This is the regression the
+      // removed plaintext fallback would have allowed.
+      const rawToken = 'b'.repeat(64);
+      const storedHash = sha256(rawToken);
+      const password = 'NewP@ssw0rd!';
+
+      mockValidatePassword.mockReturnValue(password);
+      // The DB only contains the stored hash; no doc has token === sha256(storedHash).
+      mockResetTokensFindOne.mockResolvedValue(null);
+
+      await expect(
+        handleResetPassword({ token: storedHash, password }, createContext())
+      ).rejects.toThrow('Invalid or expired reset token');
+
+      expect(mockResetTokensFindOne).toHaveBeenCalledWith({ token: sha256(storedHash) });
+      expect(mockResetTokensFindOneAndDelete).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/modelence/src/auth/resetPassword.test.ts
+++ b/packages/modelence/src/auth/resetPassword.test.ts
@@ -866,8 +866,14 @@ describe('auth/resetPassword', () => {
       expect(mockResetTokensFindOne).not.toHaveBeenCalledWith({
         token: sha256('decoy-arg-token'),
       });
-      // Cookie is cleared after a successful reset.
-      expect(clearCookie).toHaveBeenCalledWith('resetPasswordToken', { path: '/api/_internal/' });
+      // Cookie is cleared after a successful reset, with the same flags it was
+      // set with so the browser actually removes the httpOnly cookie.
+      expect(clearCookie).toHaveBeenCalledWith('resetPasswordToken', {
+        httpOnly: true,
+        secure: false,
+        sameSite: 'lax',
+        path: '/api/_internal/',
+      });
     });
 
     test('looks up the token only by its hash (no plaintext fallback)', async () => {

--- a/packages/modelence/src/auth/resetPassword.test.ts
+++ b/packages/modelence/src/auth/resetPassword.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { MockedFunction } from 'vitest';
 import { ObjectId } from 'mongodb';
 import { createHash as actualCreateHash } from 'crypto';
@@ -931,7 +931,16 @@ describe('auth/resetPassword', () => {
       expect(result?.redirect).not.toContain(token);
     });
 
-    test('redirects with an error and sets no cookie when the token is invalid', async () => {
+    // The single user-facing message every error case must surface.
+    const FRIENDLY_MESSAGE = 'This password reset link is invalid or has expired.';
+    const friendlyParam = `message=${encodeURIComponent(FRIENDLY_MESSAGE)}`;
+
+    // The catch logs the real cause server-side; silence it in these tests.
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    afterEach(() => consoleErrorSpy.mockClear());
+    afterAll(() => consoleErrorSpy.mockRestore());
+
+    test('redirects with the friendly error and sets no cookie when the token is invalid', async () => {
       mockGetConfig.mockReturnValue('https://example.com');
       mockGetEmailConfig.mockReturnValue({ passwordReset: { redirectUrl: '/new-password' } });
       mockResetTokensFindOne.mockResolvedValue(null);
@@ -942,10 +951,11 @@ describe('auth/resetPassword', () => {
       expect(cookie).not.toHaveBeenCalled();
       expect(result?.status).toBe(302);
       expect(result?.redirect).toContain('status=error');
+      expect(result?.redirect).toContain(friendlyParam);
       expect(result?.redirect).not.toContain('bad-token');
     });
 
-    test('redirects with an error when the token is expired', async () => {
+    test('redirects with the friendly error when the token is expired', async () => {
       mockGetConfig.mockReturnValue('https://example.com');
       mockGetEmailConfig.mockReturnValue({ passwordReset: { redirectUrl: '/new-password' } });
       mockResetTokensFindOne.mockResolvedValue(
@@ -957,9 +967,10 @@ describe('auth/resetPassword', () => {
 
       expect(cookie).not.toHaveBeenCalled();
       expect(result?.redirect).toContain('status=error');
+      expect(result?.redirect).toContain(friendlyParam);
     });
 
-    test('redirects with an error when the token query param is missing', async () => {
+    test('redirects with the friendly error (not a ZodError) when the token is missing', async () => {
       mockGetConfig.mockReturnValue('https://example.com');
       mockGetEmailConfig.mockReturnValue({ passwordReset: { redirectUrl: '/new-password' } });
 
@@ -968,6 +979,10 @@ describe('auth/resetPassword', () => {
 
       expect(cookie).not.toHaveBeenCalled();
       expect(result?.redirect).toContain('status=error');
+      // The friendly message — NOT the raw ZodError issues array.
+      expect(result?.redirect).toContain(friendlyParam);
+      expect(result?.redirect).not.toContain('Required');
+      expect(result?.redirect).not.toContain('invalid_type');
     });
   });
 });

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -21,6 +21,18 @@ const RESET_PASSWORD_COOKIE = 'resetPasswordToken';
 // Scope the cookie to the API surface so it's only sent on the resetPassword request.
 const RESET_PASSWORD_COOKIE_PATH = '/api/_internal/';
 
+// Attributes shared by the set and clear calls. Browsers only remove a cookie
+// when the clearing Set-Cookie matches the same path/secure/sameSite/httpOnly,
+// so both sites must use these identical flags or the httpOnly cookie can linger.
+const RESET_PASSWORD_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  // `lax` so the cookie survives the email-link navigation; `strict` can drop
+  // it when the SPA is reached cross-site (some webviews).
+  sameSite: 'lax',
+  path: RESET_PASSWORD_COOKIE_PATH,
+} as const;
+
 /**
  * Looks up a reset token without consuming it. Only matches the hashed form:
  * tokens are stored as `hashToken(rawToken)`, and the caller must present the
@@ -173,12 +185,7 @@ export async function handleResetPasswordLanding(params: RouteParams): Promise<R
     }
 
     params.res.cookie(RESET_PASSWORD_COOKIE, token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      // `lax` so the cookie survives the email-link navigation; `strict` can drop
-      // it when the SPA is reached cross-site (some webviews).
-      sameSite: 'lax',
-      path: RESET_PASSWORD_COOKIE_PATH,
+      ...RESET_PASSWORD_COOKIE_OPTIONS,
       maxAge: time.hours(1),
     });
 
@@ -222,7 +229,9 @@ export async function handleResetPassword(args: Args, context: Context) {
 
   const clearCookie = () => {
     // `res` is null for in-process invocations (no response to mutate).
-    context.res?.clearCookie(RESET_PASSWORD_COOKIE, { path: RESET_PASSWORD_COOKIE_PATH });
+    // Clear with the same flags used to set it; browsers ignore a clear whose
+    // attributes don't match, which would leave the httpOnly cookie behind.
+    context.res?.clearCookie(RESET_PASSWORD_COOKIE, RESET_PASSWORD_COOKIE_OPTIONS);
   };
 
   // Look up WITHOUT consuming: if validation/hashing fails (or the user is

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -2,7 +2,8 @@ import { z } from 'zod';
 import bcrypt from 'bcrypt';
 import { randomBytes } from 'crypto';
 
-import { Args, Context } from '@/methods/types';
+import { Args, Context, HttpContext } from '@/methods/types';
+import { RouteParams, RouteResponse } from '@/server';
 import { usersCollection, resetPasswordTokensCollection } from './db';
 import { getEmailConfig } from '@/app/emailConfig';
 import { time } from '@/time';
@@ -11,6 +12,54 @@ import { validateEmail, validatePassword } from './validators';
 import { consumeRateLimit } from '@/server';
 import { getConfig } from '@/config/server';
 import { invalidateAllUserSessions } from './session';
+import { hashToken } from './tokenHash';
+
+/**
+ * Name of the short-lived, httpOnly cookie that carries the reset token from the
+ * server landing route to the `resetPassword` mutation. The token never appears
+ * on a client-rendered (SPA) URL, so analytics/ad scripts cannot read it from
+ * `location.href`.
+ */
+const RESET_PASSWORD_COOKIE = 'resetPasswordToken';
+
+/**
+ * Scope the cookie to the API surface so it is only ever sent on the
+ * `resetPassword` mutation request, never on SPA navigations.
+ */
+const RESET_PASSWORD_COOKIE_PATH = '/api/_internal/';
+
+/**
+ * Looks up a reset token without consuming it, accepting either the
+ * hashed-at-rest form (new tokens) or a legacy plaintext match (tokens emailed
+ * before hashing was introduced). Used by the landing route, which validates the
+ * token but must not consume it (no new password has been submitted yet).
+ *
+ * The plaintext fallback can be removed once one max-TTL window (1 hour) has
+ * elapsed after deploying token hashing.
+ */
+async function findResetTokenDoc(rawToken: string) {
+  const hashedDoc = await resetPasswordTokensCollection.findOne({ token: hashToken(rawToken) });
+  if (hashedDoc) {
+    return hashedDoc;
+  }
+  return resetPasswordTokensCollection.findOne({ token: rawToken });
+}
+
+/**
+ * Atomically claims (finds and deletes) a reset token so that concurrent
+ * requests with the same token cannot both succeed. Returns the consumed doc, or
+ * null if no matching token exists. Tries the hashed form first, then the legacy
+ * plaintext form. This is the single-use enforcement point for password reset.
+ */
+async function consumeResetTokenDoc(rawToken: string) {
+  const hashedDoc = await resetPasswordTokensCollection.findOneAndDelete({
+    token: hashToken(rawToken),
+  });
+  if (hashedDoc) {
+    return hashedDoc;
+  }
+  return resetPasswordTokensCollection.findOneAndDelete({ token: rawToken });
+}
 
 function resolveUrl(baseUrl: string, configuredUrl?: string): string {
   if (!configuredUrl) {
@@ -86,19 +135,21 @@ export async function handleSendResetPasswordToken(args: Args, { connectionInfo 
   const createdAt = new Date(now);
   const expiresAt = new Date(now + time.hours(1)); // 1 hour expiry
 
-  // Store reset token
+  // Store only the hash of the token, never the raw value (defense against db leaks)
   await resetPasswordTokensCollection.insertOne({
     userId: userDoc._id,
     email,
-    token: resetToken,
+    token: hashToken(resetToken),
     createdAt,
     expiresAt,
   });
 
-  // Build reset URL
+  // Point the email at the server-side landing route rather than the SPA page.
+  // The landing route validates the token, moves it into an httpOnly cookie, and
+  // redirects to the tokenless SPA page — so the raw token never reaches a
+  // client-rendered URL where analytics/ad scripts could read it.
   const baseUrl = (getConfig('_system.site.url') as string | undefined) || connectionInfo?.baseUrl;
-  const resetPasswordUrl = resolveUrl(baseUrl!, getEmailConfig().passwordReset?.redirectUrl);
-  const resetUrl = `${resetPasswordUrl}?token=${resetToken}`;
+  const resetUrl = `${baseUrl}/api/_internal/auth/reset-password?token=${resetToken}`;
 
   // Send email
   const template = getEmailConfig()?.passwordReset?.template || defaultPasswordResetTemplate;
@@ -116,19 +167,97 @@ export async function handleSendResetPasswordToken(args: Args, { connectionInfo 
   return passwordResetSent;
 }
 
-export async function handleResetPassword(args: Args, {}: Context) {
-  const token = z.string().parse(args.token);
+/**
+ * Server landing route for password reset.
+ *
+ * The reset email links here (a server route that runs before the SPA catch-all)
+ * instead of directly to the SPA page. We validate the token, stash it in a
+ * short-lived httpOnly cookie, and 302-redirect to the tokenless SPA page where
+ * the user enters a new password. The token is never exposed to client-side JS,
+ * closing the leak where analytics/ad scripts read it from `location.href`.
+ */
+export async function handleResetPasswordLanding(params: RouteParams): Promise<RouteResponse> {
+  const baseUrl =
+    (getConfig('_system.site.url') as string | undefined) ||
+    `${params.req.protocol}://${params.req.get('host')}`;
+  const resetPasswordUrl = resolveUrl(baseUrl, getEmailConfig().passwordReset?.redirectUrl);
+
+  try {
+    const token = z.string().parse(params.query.token);
+
+    const resetTokenDoc = await findResetTokenDoc(token);
+    if (!resetTokenDoc || resetTokenDoc.expiresAt < new Date()) {
+      throw new Error('This password reset link is invalid or has expired.');
+    }
+
+    // Hand the token to the SPA via an httpOnly cookie scoped to the API path,
+    // so it is only ever sent back on the resetPassword mutation request.
+    params.res.cookie(RESET_PASSWORD_COOKIE, token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      path: RESET_PASSWORD_COOKIE_PATH,
+      maxAge: time.hours(1),
+    });
+
+    return {
+      status: 302,
+      // Suppress the Referer so the token-bearing landing URL never leaks via the
+      // Referer header on any request that follows this navigation.
+      headers: { 'Referrer-Policy': 'no-referrer' },
+      redirect: resetPasswordUrl,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'This password reset link is invalid or has expired.';
+    return {
+      status: 302,
+      headers: { 'Referrer-Policy': 'no-referrer' },
+      redirect: `${resetPasswordUrl}?status=error&message=${encodeURIComponent(message)}`,
+    };
+  }
+}
+
+export async function handleResetPassword(args: Args, context: Context | HttpContext) {
+  // Prefer the token from the httpOnly cookie set by the landing route.
+  const cookieToken = 'req' in context ? context.req?.cookies?.[RESET_PASSWORD_COOKIE] : undefined;
+
+  // DEPRECATED fallback: accept the token from the request body for older clients
+  // that submit it directly. This reintroduces the URL/body-leak risk the cookie
+  // exchange was designed to eliminate, so it is intended only for the rollout
+  // window and should be removed once all clients link via the landing route.
+  // TODO(reset-token-arg-fallback): remove the `args.token` path.
+  if (!cookieToken && args.token) {
+    console.warn(
+      '[modelence] resetPassword received a token via request args instead of the httpOnly ' +
+        'cookie. This path is deprecated and will be removed; ensure password reset emails link ' +
+        'to /api/_internal/auth/reset-password so the token is exchanged server-side.'
+    );
+  }
+
+  const token = z.string().parse(cookieToken ?? args.token);
   const password = validatePassword(args.password as string);
 
-  // Find the reset token
-  const resetTokenDoc = await resetPasswordTokensCollection.findOne({ token });
+  const clearCookie = () => {
+    if ('res' in context) {
+      context.res?.clearCookie(RESET_PASSWORD_COOKIE, { path: RESET_PASSWORD_COOKIE_PATH });
+    }
+  };
+
+  // Atomically claim the token (single-use): even under concurrent requests with
+  // the same token, only one caller gets the doc; the rest see null.
+  const resetTokenDoc = await consumeResetTokenDoc(token);
   if (!resetTokenDoc) {
+    clearCookie();
     throw new Error('Invalid or expired reset token');
   }
 
-  // Check if token is expired
+  // Check if token is expired (it has already been consumed above, so an expired
+  // token is simply rejected without leaving a reusable record behind).
   if (resetTokenDoc.expiresAt < new Date()) {
-    await resetPasswordTokensCollection.deleteOne({ token });
+    clearCookie();
     throw new Error('Reset token has expired');
   }
 
@@ -159,8 +288,9 @@ export async function handleResetPassword(args: Args, {}: Context) {
   // are forced to re-authenticate with the new password
   await invalidateAllUserSessions(userDoc._id);
 
-  // Delete the used reset token
-  await resetPasswordTokensCollection.deleteOne({ token });
+  // The token was already consumed atomically at the start (single-use). Drop the
+  // short-lived reset cookie now that the flow has completed.
+  clearCookie();
 
   return { success: true, message: 'Password has been reset successfully' };
 }

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -213,10 +213,12 @@ export async function handleResetPasswordLanding(params: RouteParams): Promise<R
       redirect: resetPasswordUrl,
     };
   } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : 'This password reset link is invalid or has expired.';
+    // Always surface a single fixed, friendly message to the user. The raw error
+    // (a ZodError for a missing/non-string token, or an internal DB error) must
+    // not be forwarded into the redirect URL — it would be unfriendly at best and
+    // leak internals at worst. Log the real cause server-side instead.
+    console.error('Error handling password reset landing:', error);
+    const message = 'This password reset link is invalid or has expired.';
     return {
       status: 302,
       headers: { 'Referrer-Policy': 'no-referrer' },

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -147,6 +147,13 @@ export async function handleSendResetPasswordToken(args: Args, { connectionInfo 
   // redirects to the tokenless SPA page — so the raw token never reaches a
   // client-rendered URL where analytics/ad scripts could read it.
   const baseUrl = (getConfig('_system.site.url') as string | undefined) || connectionInfo?.baseUrl;
+  if (!baseUrl) {
+    // Without a base URL we'd email a broken `undefined/...` link. Fail loudly
+    // instead of sending a dead reset link.
+    throw new Error(
+      'Unable to build password reset link: set _system.site.url (MODELENCE_SITE_URL)'
+    );
+  }
   const resetUrl = `${baseUrl}/api/_internal/auth/reset-password?token=${resetToken}`;
 
   // Send email

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -3,7 +3,7 @@ import bcrypt from 'bcrypt';
 import { randomBytes } from 'crypto';
 
 import { Args, Context, HttpContext } from '@/methods/types';
-import { RouteParams, RouteResponse } from '@/server';
+import { ObjectId, RouteParams, RouteResponse } from '@/server';
 import { usersCollection, resetPasswordTokensCollection } from './db';
 import { getEmailConfig } from '@/app/emailConfig';
 import { time } from '@/time';
@@ -46,19 +46,17 @@ async function findResetTokenDoc(rawToken: string) {
 }
 
 /**
- * Atomically claims (finds and deletes) a reset token so that concurrent
- * requests with the same token cannot both succeed. Returns the consumed doc, or
- * null if no matching token exists. Tries the hashed form first, then the legacy
- * plaintext form. This is the single-use enforcement point for password reset.
+ * Atomically claims a previously-found reset token by `_id`. This is the
+ * single-use enforcement point: of any concurrent requests holding the same
+ * token, exactly one `findOneAndDelete` returns the doc and the rest get null.
+ *
+ * It is called only AFTER the token has been validated and the new password
+ * hashed, so a failure earlier in the flow never consumes the token (the user
+ * can retry the same link). Returns the deleted doc, or null if another request
+ * already claimed it.
  */
-async function consumeResetTokenDoc(rawToken: string) {
-  const hashedDoc = await resetPasswordTokensCollection.findOneAndDelete({
-    token: hashToken(rawToken),
-  });
-  if (hashedDoc) {
-    return hashedDoc;
-  }
-  return resetPasswordTokensCollection.findOneAndDelete({ token: rawToken });
+async function claimResetTokenById(id: ObjectId) {
+  return resetPasswordTokensCollection.findOneAndDelete({ _id: id });
 }
 
 function resolveUrl(baseUrl: string, configuredUrl?: string): string {
@@ -246,17 +244,18 @@ export async function handleResetPassword(args: Args, context: Context | HttpCon
     }
   };
 
-  // Atomically claim the token (single-use): even under concurrent requests with
-  // the same token, only one caller gets the doc; the rest see null.
-  const resetTokenDoc = await consumeResetTokenDoc(token);
+  // Look up the token WITHOUT consuming it. Validation and password hashing must
+  // not burn the token: if any of them fail (or the user is missing), the link
+  // stays valid so the user can simply retry instead of requesting a new email.
+  const resetTokenDoc = await findResetTokenDoc(token);
   if (!resetTokenDoc) {
     clearCookie();
     throw new Error('Invalid or expired reset token');
   }
 
-  // Check if token is expired (it has already been consumed above, so an expired
-  // token is simply rejected without leaving a reusable record behind).
   if (resetTokenDoc.expiresAt < new Date()) {
+    // Expired: remove it and reject.
+    await claimResetTokenById(resetTokenDoc._id as ObjectId);
     clearCookie();
     throw new Error('Reset token has expired');
   }
@@ -269,6 +268,14 @@ export async function handleResetPassword(args: Args, context: Context | HttpCon
 
   // Hash the new password
   const hash = await bcrypt.hash(password, 10);
+
+  // Commit point: atomically claim the token. If a concurrent request already
+  // consumed it, abort WITHOUT touching the password (single-use, no double-spend).
+  const claimedToken = await claimResetTokenById(resetTokenDoc._id as ObjectId);
+  if (!claimedToken) {
+    clearCookie();
+    throw new Error('Invalid or expired reset token');
+  }
 
   // Update user's password
   await usersCollection.updateOne(
@@ -288,8 +295,8 @@ export async function handleResetPassword(args: Args, context: Context | HttpCon
   // are forced to re-authenticate with the new password
   await invalidateAllUserSessions(userDoc._id);
 
-  // The token was already consumed atomically at the start (single-use). Drop the
-  // short-lived reset cookie now that the flow has completed.
+  // The token was consumed atomically at the commit point above (single-use).
+  // Drop the short-lived reset cookie now that the flow has completed.
   clearCookie();
 
   return { success: true, message: 'Password has been reset successfully' };

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -22,16 +22,16 @@ const RESET_PASSWORD_COOKIE = 'resetPasswordToken';
 const RESET_PASSWORD_COOKIE_PATH = '/api/_internal/';
 
 /**
- * Looks up a reset token without consuming it, accepting either the hashed form
- * (new tokens) or a legacy plaintext match. The plaintext fallback can be removed
- * one max-TTL window (1 hour) after deploying token hashing.
+ * Looks up a reset token without consuming it. Only matches the hashed form:
+ * tokens are stored as `hashToken(rawToken)`, and the caller must present the
+ * raw token. There is deliberately no plaintext fallback — matching the raw
+ * value against the stored column would let a leaked SHA-256 digest be replayed
+ * as a bearer token (submit the digest, it equals the stored value), defeating
+ * the point of hashing at rest. Tokens expire within 1 hour (TTL index), so no
+ * migration fallback is needed for tokens issued before hashing was deployed.
  */
 async function findResetTokenDoc(rawToken: string) {
-  const hashedDoc = await resetPasswordTokensCollection.findOne({ token: hashToken(rawToken) });
-  if (hashedDoc) {
-    return hashedDoc;
-  }
-  return resetPasswordTokensCollection.findOne({ token: rawToken });
+  return resetPasswordTokensCollection.findOne({ token: hashToken(rawToken) });
 }
 
 /**

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -14,28 +14,17 @@ import { getConfig } from '@/config/server';
 import { invalidateAllUserSessions } from './session';
 import { hashToken } from './tokenHash';
 
-/**
- * Name of the short-lived, httpOnly cookie that carries the reset token from the
- * server landing route to the `resetPassword` mutation. The token never appears
- * on a client-rendered (SPA) URL, so analytics/ad scripts cannot read it from
- * `location.href`.
- */
+// Short-lived httpOnly cookie carrying the reset token from the landing route to
+// the `resetPassword` mutation, so it never appears on a client-rendered URL.
 const RESET_PASSWORD_COOKIE = 'resetPasswordToken';
 
-/**
- * Scope the cookie to the API surface so it is only ever sent on the
- * `resetPassword` mutation request, never on SPA navigations.
- */
+// Scope the cookie to the API surface so it's only sent on the resetPassword request.
 const RESET_PASSWORD_COOKIE_PATH = '/api/_internal/';
 
 /**
- * Looks up a reset token without consuming it, accepting either the
- * hashed-at-rest form (new tokens) or a legacy plaintext match (tokens emailed
- * before hashing was introduced). Used by the landing route, which validates the
- * token but must not consume it (no new password has been submitted yet).
- *
- * The plaintext fallback can be removed once one max-TTL window (1 hour) has
- * elapsed after deploying token hashing.
+ * Looks up a reset token without consuming it, accepting either the hashed form
+ * (new tokens) or a legacy plaintext match. The plaintext fallback can be removed
+ * one max-TTL window (1 hour) after deploying token hashing.
  */
 async function findResetTokenDoc(rawToken: string) {
   const hashedDoc = await resetPasswordTokensCollection.findOne({ token: hashToken(rawToken) });
@@ -46,14 +35,9 @@ async function findResetTokenDoc(rawToken: string) {
 }
 
 /**
- * Atomically claims a previously-found reset token by `_id`. This is the
- * single-use enforcement point: of any concurrent requests holding the same
- * token, exactly one `findOneAndDelete` returns the doc and the rest get null.
- *
- * It is called only AFTER the token has been validated and the new password
- * hashed, so a failure earlier in the flow never consumes the token (the user
- * can retry the same link). Returns the deleted doc, or null if another request
- * already claimed it.
+ * Atomically claims a reset token by `_id` — the single-use enforcement point.
+ * Of concurrent requests holding the same token, exactly one gets the doc back;
+ * the rest get null. Returns the deleted doc, or null if already claimed.
  */
 async function claimResetTokenById(id: ObjectId) {
   return resetPasswordTokensCollection.findOneAndDelete({ _id: id });
@@ -133,7 +117,7 @@ export async function handleSendResetPasswordToken(args: Args, { connectionInfo 
   const createdAt = new Date(now);
   const expiresAt = new Date(now + time.hours(1)); // 1 hour expiry
 
-  // Store only the hash of the token, never the raw value (defense against db leaks)
+  // Store only the hash, never the raw token (defense against db leaks).
   await resetPasswordTokensCollection.insertOne({
     userId: userDoc._id,
     email,
@@ -142,14 +126,11 @@ export async function handleSendResetPasswordToken(args: Args, { connectionInfo 
     expiresAt,
   });
 
-  // Point the email at the server-side landing route rather than the SPA page.
-  // The landing route validates the token, moves it into an httpOnly cookie, and
-  // redirects to the tokenless SPA page — so the raw token never reaches a
-  // client-rendered URL where analytics/ad scripts could read it.
+  // Point the email at the server landing route, not the SPA page, so the raw
+  // token never reaches a client-rendered URL.
   const baseUrl = (getConfig('_system.site.url') as string | undefined) || connectionInfo?.baseUrl;
   if (!baseUrl) {
-    // Without a base URL we'd email a broken `undefined/...` link. Fail loudly
-    // instead of sending a dead reset link.
+    // Without a base URL we'd email a broken `undefined/...` link — fail loudly.
     throw new Error(
       'Unable to build password reset link: set _system.site.url (MODELENCE_SITE_URL)'
     );
@@ -173,13 +154,9 @@ export async function handleSendResetPasswordToken(args: Args, { connectionInfo 
 }
 
 /**
- * Server landing route for password reset.
- *
- * The reset email links here (a server route that runs before the SPA catch-all)
- * instead of directly to the SPA page. We validate the token, stash it in a
- * short-lived httpOnly cookie, and 302-redirect to the tokenless SPA page where
- * the user enters a new password. The token is never exposed to client-side JS,
- * closing the leak where analytics/ad scripts read it from `location.href`.
+ * Server landing route for password reset. The email links here instead of the
+ * SPA page: we validate the token, stash it in a short-lived httpOnly cookie, and
+ * 302-redirect to the tokenless SPA page — so the token never reaches client JS.
  */
 export async function handleResetPasswordLanding(params: RouteParams): Promise<RouteResponse> {
   const baseUrl =
@@ -195,28 +172,25 @@ export async function handleResetPasswordLanding(params: RouteParams): Promise<R
       throw new Error('This password reset link is invalid or has expired.');
     }
 
-    // Hand the token to the SPA via an httpOnly cookie scoped to the API path,
-    // so it is only ever sent back on the resetPassword mutation request.
     params.res.cookie(RESET_PASSWORD_COOKIE, token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      // `lax` so the cookie survives the email-link navigation; `strict` can drop
+      // it when the SPA is reached cross-site (some webviews).
+      sameSite: 'lax',
       path: RESET_PASSWORD_COOKIE_PATH,
       maxAge: time.hours(1),
     });
 
     return {
       status: 302,
-      // Suppress the Referer so the token-bearing landing URL never leaks via the
-      // Referer header on any request that follows this navigation.
+      // Suppress the Referer so the token-bearing landing URL never leaks.
       headers: { 'Referrer-Policy': 'no-referrer' },
       redirect: resetPasswordUrl,
     };
   } catch (error) {
-    // Always surface a single fixed, friendly message to the user. The raw error
-    // (a ZodError for a missing/non-string token, or an internal DB error) must
-    // not be forwarded into the redirect URL — it would be unfriendly at best and
-    // leak internals at worst. Log the real cause server-side instead.
+    // Surface a fixed, friendly message; never forward the raw error (ZodError or
+    // DB error) into the redirect URL. Log the real cause server-side instead.
     console.error('Error handling password reset landing:', error);
     const message = 'This password reset link is invalid or has expired.';
     return {
@@ -231,10 +205,8 @@ export async function handleResetPassword(args: Args, context: Context | HttpCon
   // Prefer the token from the httpOnly cookie set by the landing route.
   const cookieToken = 'req' in context ? context.req?.cookies?.[RESET_PASSWORD_COOKIE] : undefined;
 
-  // DEPRECATED fallback: accept the token from the request body for older clients
-  // that submit it directly. This reintroduces the URL/body-leak risk the cookie
-  // exchange was designed to eliminate, so it is intended only for the rollout
-  // window and should be removed once all clients link via the landing route.
+  // DEPRECATED fallback: token from request args, for older clients that submit it
+  // directly. Reintroduces the leak risk the cookie exchange closes — rollout only.
   // TODO(reset-token-arg-fallback): remove the `args.token` path.
   if (!cookieToken && args.token) {
     console.warn(
@@ -253,9 +225,8 @@ export async function handleResetPassword(args: Args, context: Context | HttpCon
     }
   };
 
-  // Look up the token WITHOUT consuming it. Validation and password hashing must
-  // not burn the token: if any of them fail (or the user is missing), the link
-  // stays valid so the user can simply retry instead of requesting a new email.
+  // Look up WITHOUT consuming: if validation/hashing fails (or the user is
+  // missing), the link stays valid so the user can retry the same link.
   const resetTokenDoc = await findResetTokenDoc(token);
   if (!resetTokenDoc) {
     clearCookie();
@@ -304,8 +275,7 @@ export async function handleResetPassword(args: Args, context: Context | HttpCon
   // are forced to re-authenticate with the new password
   await invalidateAllUserSessions(userDoc._id);
 
-  // The token was consumed atomically at the commit point above (single-use).
-  // Drop the short-lived reset cookie now that the flow has completed.
+  // Token already consumed at the commit point; just drop the cookie.
   clearCookie();
 
   return { success: true, message: 'Password has been reset successfully' };

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import bcrypt from 'bcrypt';
 import { randomBytes } from 'crypto';
 
-import { Args, Context, HttpContext } from '@/methods/types';
+import { Args, Context } from '@/methods/types';
 import { ObjectId, RouteParams, RouteResponse } from '@/server';
 import { usersCollection, resetPasswordTokensCollection } from './db';
 import { getEmailConfig } from '@/app/emailConfig';
@@ -201,9 +201,10 @@ export async function handleResetPasswordLanding(params: RouteParams): Promise<R
   }
 }
 
-export async function handleResetPassword(args: Args, context: Context | HttpContext) {
+export async function handleResetPassword(args: Args, context: Context) {
   // Prefer the token from the httpOnly cookie set by the landing route.
-  const cookieToken = 'req' in context ? context.req?.cookies?.[RESET_PASSWORD_COOKIE] : undefined;
+  // `req` is null for in-process invocations (no cookie to read).
+  const cookieToken = context.req?.cookies?.[RESET_PASSWORD_COOKIE];
 
   // DEPRECATED fallback: token from request args, for older clients that submit it
   // directly. Reintroduces the leak risk the cookie exchange closes — rollout only.
@@ -220,9 +221,8 @@ export async function handleResetPassword(args: Args, context: Context | HttpCon
   const password = validatePassword(args.password as string);
 
   const clearCookie = () => {
-    if ('res' in context) {
-      context.res?.clearCookie(RESET_PASSWORD_COOKIE, { path: RESET_PASSWORD_COOKIE_PATH });
-    }
+    // `res` is null for in-process invocations (no response to mutate).
+    context.res?.clearCookie(RESET_PASSWORD_COOKIE, { path: RESET_PASSWORD_COOKIE_PATH });
   };
 
   // Look up WITHOUT consuming: if validation/hashing fails (or the user is

--- a/packages/modelence/src/auth/tokenHash.test.ts
+++ b/packages/modelence/src/auth/tokenHash.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest';
+import { createHash } from 'crypto';
+import { hashToken } from './tokenHash';
+
+describe('auth/tokenHash', () => {
+  test('produces a SHA-256 hex digest of the input', () => {
+    const raw = 'abc123';
+    const expected = createHash('sha256').update(raw).digest('hex');
+    expect(hashToken(raw)).toBe(expected);
+  });
+
+  test('is deterministic for the same input', () => {
+    expect(hashToken('same-token')).toBe(hashToken('same-token'));
+  });
+
+  test('differs for different inputs', () => {
+    expect(hashToken('token-a')).not.toBe(hashToken('token-b'));
+  });
+
+  test('does not return the raw token', () => {
+    const raw = 'super-secret-reset-token';
+    expect(hashToken(raw)).not.toContain(raw);
+  });
+
+  test('output is a 64-char hex string', () => {
+    expect(hashToken('whatever')).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/modelence/src/auth/tokenHash.ts
+++ b/packages/modelence/src/auth/tokenHash.ts
@@ -1,0 +1,14 @@
+import { createHash } from 'crypto';
+
+/**
+ * Hashes a token for storage at rest.
+ *
+ * Reset/verification tokens are bearer secrets: anyone holding the raw value can
+ * consume the flow. Storing only a hash means a database leak does not expose
+ * usable tokens. We use SHA-256 (not bcrypt) because these tokens are already
+ * high-entropy (256-bit random), so a fast hash is sufficient and keeps lookups
+ * cheap — there is nothing to brute-force.
+ */
+export function hashToken(rawToken: string): string {
+  return createHash('sha256').update(rawToken).digest('hex');
+}

--- a/packages/modelence/src/auth/tokenHash.ts
+++ b/packages/modelence/src/auth/tokenHash.ts
@@ -1,13 +1,9 @@
 import { createHash } from 'crypto';
 
 /**
- * Hashes a token for storage at rest.
- *
- * Reset/verification tokens are bearer secrets: anyone holding the raw value can
- * consume the flow. Storing only a hash means a database leak does not expose
- * usable tokens. We use SHA-256 (not bcrypt) because these tokens are already
- * high-entropy (256-bit random), so a fast hash is sufficient and keeps lookups
- * cheap — there is nothing to brute-force.
+ * Hashes a bearer token for storage at rest, so a db leak exposes no usable
+ * tokens. SHA-256 (not bcrypt): these tokens are already 256-bit random, so
+ * there's nothing to brute-force and a fast hash keeps lookups cheap.
  */
 export function hashToken(rawToken: string): string {
   return createHash('sha256').update(rawToken).digest('hex');

--- a/packages/modelence/src/auth/user.test.ts
+++ b/packages/modelence/src/auth/user.test.ts
@@ -14,6 +14,7 @@ const mockHandleVerifyEmail = vi.fn();
 const mockHandleResendEmailVerification = vi.fn();
 const mockHandleSendResetPasswordToken = vi.fn();
 const mockHandleResetPassword = vi.fn();
+const mockHandleResetPasswordLanding = vi.fn();
 const mockGetOwnProfile = vi.fn();
 const mockHandleUpdateProfile = vi.fn();
 
@@ -58,6 +59,7 @@ vi.doMock('./verification', () => ({
 vi.doMock('./resetPassword', () => ({
   handleSendResetPasswordToken: mockHandleSendResetPasswordToken,
   handleResetPassword: mockHandleResetPassword,
+  handleResetPasswordLanding: mockHandleResetPasswordLanding,
 }));
 
 const mockTime = {
@@ -151,6 +153,12 @@ describe('auth/user', () => {
             path: '/api/_internal/auth/verify-email',
             handlers: {
               get: mockHandleVerifyEmail,
+            },
+          },
+          {
+            path: '/api/_internal/auth/reset-password',
+            handlers: {
+              get: mockHandleResetPasswordLanding,
             },
           },
         ],

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -16,7 +16,11 @@ import { getOwnProfile, handleUpdateProfile } from './profile';
 import { handleUnlinkOAuthProvider } from './unlinkOAuthProvider';
 import { handleSignupWithPassword } from './signup';
 import { handleVerifyEmail, handleResendEmailVerification } from './verification';
-import { handleResetPassword, handleSendResetPasswordToken } from './resetPassword';
+import {
+  handleResetPassword,
+  handleResetPasswordLanding,
+  handleSendResetPasswordToken,
+} from './resetPassword';
 
 function ruleKey(rule: Pick<RateLimitRule, 'bucket' | 'type' | 'window'>): string {
   return `${rule.bucket}\n${rule.type}\n${rule.window}`;
@@ -199,6 +203,15 @@ export default new Module('_system.user', {
       path: '/api/_internal/auth/verify-email',
       handlers: {
         get: handleVerifyEmail,
+      },
+    },
+    {
+      // Server-side landing for password reset: validates the token, stores it
+      // in an httpOnly cookie, and redirects to the tokenless SPA page so the
+      // token never reaches a client-rendered URL. Runs before the SPA catch-all.
+      path: '/api/_internal/auth/reset-password',
+      handlers: {
+        get: handleResetPasswordLanding,
       },
     },
   ],

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -206,9 +206,8 @@ export default new Module('_system.user', {
       },
     },
     {
-      // Server-side landing for password reset: validates the token, stores it
-      // in an httpOnly cookie, and redirects to the tokenless SPA page so the
-      // token never reaches a client-rendered URL. Runs before the SPA catch-all.
+      // Server landing for password reset (see handleResetPasswordLanding).
+      // Runs before the SPA catch-all.
       path: '/api/_internal/auth/reset-password',
       handlers: {
         get: handleResetPasswordLanding,

--- a/packages/modelence/src/auth/verification.test.ts
+++ b/packages/modelence/src/auth/verification.test.ts
@@ -209,6 +209,7 @@ describe('auth/verification', () => {
       });
       expect(result).toEqual({
         status: 301,
+        headers: { 'Referrer-Policy': 'no-referrer' },
         redirect: '/verified?status=verified',
       });
     });
@@ -237,6 +238,7 @@ describe('auth/verification', () => {
       });
       expect(result).toEqual({
         status: 301,
+        headers: { 'Referrer-Policy': 'no-referrer' },
         redirect: '/verified?status=error&message=Invalid%20or%20expired%20verification%20token',
       });
     });
@@ -273,6 +275,7 @@ describe('auth/verification', () => {
       });
       expect(result).toEqual({
         status: 301,
+        headers: { 'Referrer-Policy': 'no-referrer' },
         redirect: '/verified?status=error&message=User%20not%20found',
       });
     });

--- a/packages/modelence/src/auth/verification.ts
+++ b/packages/modelence/src/auth/verification.ts
@@ -102,6 +102,8 @@ export async function handleVerifyEmail(params: RouteParams): Promise<RouteRespo
 
     return {
       status: 301,
+      // Suppress the Referer so the token-bearing verification URL never leaks.
+      headers: { 'Referrer-Policy': 'no-referrer' },
       redirect: `${emailVerifiedRedirectUrl}?status=verified`,
     };
   } catch (error) {
@@ -125,6 +127,7 @@ export async function handleVerifyEmail(params: RouteParams): Promise<RouteRespo
 
     return {
       status: 301,
+      headers: { 'Referrer-Policy': 'no-referrer' },
       redirect: `${emailVerifiedRedirectUrl}?status=error&message=${encodeURIComponent(message)}`,
     };
   }

--- a/packages/modelence/src/client/method.test.ts
+++ b/packages/modelence/src/client/method.test.ts
@@ -59,6 +59,9 @@ describe('client/method', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/_internal/method/test.method', expect.any(Object));
     const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
     expect(requestInit?.method).toBe('POST');
+    // Cookies (e.g. the password-reset httpOnly cookie) must ride along even
+    // when the SPA and API are on different origins.
+    expect(requestInit?.credentials).toBe('include');
     const payload = JSON.parse(requestInit?.body as string);
     expect(payload.args).toEqual({ foo: 'bar' });
     expect(payload.authToken).toBe('token');

--- a/packages/modelence/src/client/method.ts
+++ b/packages/modelence/src/client/method.ts
@@ -119,6 +119,13 @@ export async function callMethod<T = unknown>(
 async function call<T = unknown>(endpoint: string, args: MethodArgs): Promise<T> {
   const response = await fetch(endpoint, {
     method: 'POST',
+    // Send cookies even when the SPA and API are on different origins. The
+    // password-reset flow relies on the httpOnly `resetPasswordToken` cookie
+    // set by the server landing route; with the default `same-origin` policy
+    // the cookie would be dropped on cross-origin POSTs and the reset would
+    // fail. (Cross-origin use also requires the server to emit
+    // `Access-Control-Allow-Credentials: true` and a non-wildcard origin.)
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },

--- a/packages/modelence/src/methods/index.test.ts
+++ b/packages/modelence/src/methods/index.test.ts
@@ -12,6 +12,7 @@ vi.doMock('../utils', () => ({
 
 vi.doMock('@/telemetry', () => ({
   startTransaction: mockStartTransaction,
+  redactSensitive: (v: unknown) => v,
 }));
 
 vi.doMock('../auth/role', () => ({

--- a/packages/modelence/src/methods/index.ts
+++ b/packages/modelence/src/methods/index.ts
@@ -1,5 +1,5 @@
 import { requireServer } from '../utils';
-import { startTransaction } from '@/telemetry';
+import { startTransaction, redactSensitive } from '@/telemetry';
 import { requireAccess } from '../auth/role';
 import { Method, MethodDefinition, MethodType, Args, Context, HttpContext } from './types';
 import { LiveData } from '../live-query';
@@ -73,7 +73,10 @@ export async function runMethod(name: string, args: Args, context: HttpContext) 
   }
   const { type, handler } = method;
 
-  const transaction = startTransaction('method', `method:${name}`, { type, args });
+  const transaction = startTransaction('method', `method:${name}`, {
+    type,
+    args: redactSensitive(args),
+  });
 
   let response;
   try {
@@ -107,7 +110,10 @@ export async function runLiveMethod(name: string, args: Args, context: Context):
     throw new Error(`Live methods are only supported for queries`);
   }
 
-  const transaction = startTransaction('method', `method:${name}:live`, { type, args });
+  const transaction = startTransaction('method', `method:${name}:live`, {
+    type,
+    args: redactSensitive(args),
+  });
 
   let result;
   try {

--- a/packages/modelence/src/routes/handler.test.ts
+++ b/packages/modelence/src/routes/handler.test.ts
@@ -88,6 +88,38 @@ describe('routes/handler', () => {
     expect(transactionEnd).toHaveBeenCalledWith();
   });
 
+  test('applies custom headers before redirecting and does not send a body', async () => {
+    const handler = createRouteHandler('GET', '/landing', async () => ({
+      status: 302,
+      headers: { 'Referrer-Policy': 'no-referrer' },
+      redirect: '/destination',
+    }));
+
+    await handler(baseReq, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(302);
+    // Header must be set before redirect flushes the response, otherwise it is lost.
+    const setHeaderOrder = (res.setHeader as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    const redirectOrder = (res.redirect as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    expect(res.setHeader).toHaveBeenCalledWith('Referrer-Policy', 'no-referrer');
+    expect(setHeaderOrder).toBeLessThan(redirectOrder);
+    expect(res.redirect).toHaveBeenCalledWith('/destination');
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  test('applies custom headers on a non-redirect response', async () => {
+    const handler = createRouteHandler('GET', '/test', async () => ({
+      status: 200,
+      headers: { 'X-Custom': 'value' },
+      data: { ok: true },
+    }));
+
+    await handler(baseReq, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith('X-Custom', 'value');
+    expect(res.send).toHaveBeenCalledWith({ ok: true });
+  });
+
   test('handles ModelenceError gracefully', async () => {
     const handler = createRouteHandler('GET', '/test', async () => {
       throw new ValidationError('fail');

--- a/packages/modelence/src/routes/handler.test.ts
+++ b/packages/modelence/src/routes/handler.test.ts
@@ -15,8 +15,24 @@ vi.doMock('../db/client', () => ({
   connect: vi.fn(),
 }));
 
+// Faithful copy of the real redactSensitive (kept in sync with telemetry/index.ts)
+// so the redaction test exercises the same logic without pulling APM deps.
+const SENSITIVE_KEYS = ['token', 'password', 'secret', 'nonce', 'code'];
+function redactSensitive(value: unknown): unknown {
+  if (!value || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(redactSensitive);
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    result[key] = SENSITIVE_KEYS.some((k) => key.toLowerCase().includes(k))
+      ? '[redacted]'
+      : redactSensitive(val);
+  }
+  return result;
+}
+
 vi.doMock('../telemetry', () => ({
   startTransaction: mockStartTransaction,
+  redactSensitive,
 }));
 
 const { ValidationError } = await import('../error');
@@ -86,6 +102,30 @@ describe('routes/handler', () => {
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.send).toHaveBeenCalledWith({ ok: true });
     expect(transactionEnd).toHaveBeenCalledWith();
+  });
+
+  test('redacts secrets from the telemetry transaction context', async () => {
+    const handler = createRouteHandler('GET', '/landing', async () => ({ status: 200 }));
+    const req = createRequest({
+      query: { token: 'raw-secret', status: 'ok' } as never,
+      body: { password: 'hunter2', email: 'a@b.com' } as never,
+      params: { linkNonce: 'nonce-value' } as never,
+    });
+
+    await handler(req, res, next);
+
+    const ctx = mockStartTransaction.mock.calls[0][2] as {
+      query: Record<string, unknown>;
+      body: Record<string, unknown>;
+      params: Record<string, unknown>;
+    };
+    // Sensitive keys redacted...
+    expect(ctx.query.token).toBe('[redacted]');
+    expect(ctx.body.password).toBe('[redacted]');
+    expect(ctx.params.linkNonce).toBe('[redacted]');
+    // ...non-sensitive values preserved.
+    expect(ctx.query.status).toBe('ok');
+    expect(ctx.body.email).toBe('a@b.com');
   });
 
   test('applies custom headers before redirecting and does not send a body', async () => {

--- a/packages/modelence/src/routes/handler.ts
+++ b/packages/modelence/src/routes/handler.ts
@@ -51,17 +51,19 @@ export function createRouteHandler(method: string, path: string, handler: RouteH
       if (response) {
         res.status(response.status || 200);
 
-        if (response.redirect) {
-          res.redirect(response.redirect);
-        }
-
+        // Apply custom headers before sending the body/redirect, otherwise
+        // res.redirect()/res.send() flush the response and the headers are lost.
         if (response.headers) {
           Object.entries(response.headers).forEach(([key, value]) => {
             res.setHeader(key, value);
           });
         }
 
-        res.send(response.data);
+        if (response.redirect) {
+          res.redirect(response.redirect);
+        } else {
+          res.send(response.data);
+        }
       }
     } catch (error) {
       transaction.end('error');

--- a/packages/modelence/src/routes/handler.ts
+++ b/packages/modelence/src/routes/handler.ts
@@ -4,7 +4,7 @@ import { ModelenceError } from '../error';
 import { authenticate } from '../auth';
 import { getMongodbUri } from '../db/client';
 import type { Context } from '../methods/types';
-import { startTransaction } from '../telemetry';
+import { startTransaction, redactSensitive } from '../telemetry';
 
 // TODO: Use cookies for authentication and automatically add session/user to context if accessing from browser
 export function createRouteHandler(method: string, path: string, handler: RouteHandler) {
@@ -24,9 +24,11 @@ export function createRouteHandler(method: string, path: string, handler: RouteH
     const transaction = startTransaction('route', `route:${method.toLowerCase()}:${path}`, {
       method,
       path,
-      query: req.query,
-      body: req.body,
-      params: req.params,
+      // Redact secrets before they reach telemetry/APM — token-bearing links put
+      // these in the URL, which would otherwise persist in plaintext at the sink.
+      query: redactSensitive(req.query),
+      body: redactSensitive(req.body),
+      params: redactSensitive(req.params),
     });
 
     try {

--- a/packages/modelence/src/routes/handler.ts
+++ b/packages/modelence/src/routes/handler.ts
@@ -24,8 +24,7 @@ export function createRouteHandler(method: string, path: string, handler: RouteH
     const transaction = startTransaction('route', `route:${method.toLowerCase()}:${path}`, {
       method,
       path,
-      // Redact secrets before they reach telemetry/APM — token-bearing links put
-      // these in the URL, which would otherwise persist in plaintext at the sink.
+      // Redact secrets (e.g. tokens in the URL) before they reach the APM sink.
       query: redactSensitive(req.query),
       body: redactSensitive(req.body),
       params: redactSensitive(req.params),

--- a/packages/modelence/src/telemetry.ts
+++ b/packages/modelence/src/telemetry.ts
@@ -1,1 +1,8 @@
-export { startTransaction, captureError, logInfo, logError, logDebug } from './telemetry/index';
+export {
+  startTransaction,
+  captureError,
+  logInfo,
+  logError,
+  logDebug,
+  redactSensitive,
+} from './telemetry/index';

--- a/packages/modelence/src/telemetry/index.test.ts
+++ b/packages/modelence/src/telemetry/index.test.ts
@@ -27,6 +27,40 @@ describe('telemetry/index', () => {
     delete process.env.MODELENCE_LOG_LEVEL;
   });
 
+  describe('redactSensitive', () => {
+    test('redacts sensitive keys (substring, case-insensitive) and preserves others', () => {
+      const input = {
+        token: 'raw',
+        Password: 'pw',
+        linkNonce: 'n',
+        verificationCode: 'c',
+        apiSecret: 's',
+        email: 'a@b.com',
+        nested: { authToken: 't', label: 'keep' },
+      };
+
+      expect(telemetry.redactSensitive(input)).toEqual({
+        token: '[redacted]',
+        Password: '[redacted]',
+        linkNonce: '[redacted]',
+        verificationCode: '[redacted]',
+        apiSecret: '[redacted]',
+        email: 'a@b.com',
+        nested: { authToken: '[redacted]', label: 'keep' },
+      });
+    });
+
+    test('redacts inside arrays and passes through primitives', () => {
+      expect(telemetry.redactSensitive([{ token: 'x' }, { ok: 1 }])).toEqual([
+        { token: '[redacted]' },
+        { ok: 1 },
+      ]);
+      expect(telemetry.redactSensitive('plain')).toBe('plain');
+      expect(telemetry.redactSensitive(null)).toBe(null);
+      expect(telemetry.redactSensitive(42)).toBe(42);
+    });
+  });
+
   afterEach(() => {
     consoleDebug.mockClear();
     consoleInfo.mockClear();

--- a/packages/modelence/src/telemetry/index.ts
+++ b/packages/modelence/src/telemetry/index.ts
@@ -3,19 +3,13 @@ import { isTelemetryEnabled } from '@/app/state';
 
 type LogLevel = 'error' | 'info' | 'debug' | '';
 
-/**
- * Keys whose values are secrets and must never be recorded in telemetry/APM
- * context. Matched case-insensitively as a substring (e.g. `linkNonce` matches
- * `nonce`, `authToken` matches `token`). Used to scrub request args/query/body
- * before they are sent to the APM sink, where they would otherwise persist in
- * plaintext — the same "readable secret at rest" risk hashing-at-rest avoids.
- */
+// Secret-bearing keys to scrub before request args/query/body reach the APM sink.
+// Matched case-insensitively as a substring (`authToken` matches `token`).
 const SENSITIVE_KEYS = ['token', 'password', 'secret', 'nonce', 'code'];
 
 /**
- * Returns a deep copy of `value` with any sensitive keys (see
- * {@link SENSITIVE_KEYS}) replaced by `'[redacted]'`. Non-object values pass
- * through unchanged.
+ * Deep-copies `value`, replacing any {@link SENSITIVE_KEYS} match with
+ * `'[redacted]'`. Non-object values pass through unchanged.
  */
 export function redactSensitive(value: unknown): unknown {
   if (!value || typeof value !== 'object') {

--- a/packages/modelence/src/telemetry/index.ts
+++ b/packages/modelence/src/telemetry/index.ts
@@ -4,6 +4,35 @@ import { isTelemetryEnabled } from '@/app/state';
 type LogLevel = 'error' | 'info' | 'debug' | '';
 
 /**
+ * Keys whose values are secrets and must never be recorded in telemetry/APM
+ * context. Matched case-insensitively as a substring (e.g. `linkNonce` matches
+ * `nonce`, `authToken` matches `token`). Used to scrub request args/query/body
+ * before they are sent to the APM sink, where they would otherwise persist in
+ * plaintext — the same "readable secret at rest" risk hashing-at-rest avoids.
+ */
+const SENSITIVE_KEYS = ['token', 'password', 'secret', 'nonce', 'code'];
+
+/**
+ * Returns a deep copy of `value` with any sensitive keys (see
+ * {@link SENSITIVE_KEYS}) replaced by `'[redacted]'`. Non-object values pass
+ * through unchanged.
+ */
+export function redactSensitive(value: unknown): unknown {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(redactSensitive);
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    const isSensitive = SENSITIVE_KEYS.some((k) => key.toLowerCase().includes(k));
+    result[key] = isSensitive ? '[redacted]' : redactSensitive(val);
+  }
+  return result;
+}
+
+/**
  * Gets the logging level for console logs based on the MODELENCE_LOG_LEVEL environment variable.
  *
  * @returns The log level ('error' | 'info' | 'debug' | '')


### PR DESCRIPTION
Move the password-reset token out of client-rendered URLs to close a class of leak where analytics/ad scripts (e.g. gtag) read document.location.href and ship the token to third parties.

- Add GET /api/_internal/auth/reset-password landing route: validates the token, stores it in a short-TTL httpOnly+Secure+SameSite cookie, and 302-redirects to the tokenless SPA page. Reset emails link here instead of to the SPA page directly.
- resetPassword mutation reads the token from the cookie (token arg now optional, kept for backwards compat with a deprecation warning).
- Hash reset tokens at rest (SHA-256) with a legacy plaintext fallback; consume atomically via findOneAndDelete (single-use, no TOCTOU race).
- Set Referrer-Policy: no-referrer inline on the reset-password and verify-email landing redirects so the token URL can't leak via Referer.
- Fix createRouteHandler applying response.headers after res.redirect() (headers were silently dropped on redirects).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core password-reset and session-invalidation behavior, cookie/CORS requirements for cross-origin SPAs, and breaks in-flight plaintext reset tokens after deploy (new tokens are hash-only).
> 
> **Overview**
> Password reset no longer puts the raw token on SPA URLs or in client JS. Reset emails link to **`GET /api/_internal/auth/reset-password`**, which validates the token, stores it in a short-lived **httpOnly** cookie, and **302**s to the configured **`redirectUrl`** without the token. **`resetPassword({ password })`** reads the token from that cookie; an optional **`token`** argument remains for legacy clients (deprecated).
> 
> **At rest and consumption:** new tokens are stored as **SHA-256** digests only (no plaintext DB match / hash-replay path). Consumption is **`findOneAndDelete` by `_id`** at commit time for single-use and concurrent-request safety. Sending reset mail **requires** a resolvable site base URL (`_system.site.url` / `MODELENCE_SITE_URL`).
> 
> **Plumbing:** client **`callMethod`** uses **`credentials: 'include'`** so the reset cookie works cross-origin (with proper CORS). **`createRouteHandler`** sets response headers **before** redirects and skips a body on redirect; reset and verify-email landings add **`Referrer-Policy: no-referrer`**. Telemetry **`redactSensitive`** scrubs tokens/passwords from method and route transaction context. Docs describe the new flow and cookie/CORS notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6758cb1acb036b8c32317c123115f208ac204fa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->