### PR TITLE
fix: restrict built-in file access to managed user paths

### DIFF
--- a/docs/web/files.mdx
+++ b/docs/web/files.mdx
@@ -10,6 +10,10 @@ Each file operation is available in two forms:
 - **Client (`modelence/client`)** — call directly from the browser via built-in methods
 - **Server (`modelence/server`)** — call from your server-side code (e.g. inside a mutation or cron job)
 
+<Warning>
+The browser-facing built-in methods are authenticated, managed file APIs. Uploads are automatically namespaced under `users/<user-id>/...`, and private file reads/deletes are restricted to the authenticated user's own managed paths.
+</Warning>
+
 ## Uploading a File
 
 <Tabs>
@@ -26,11 +30,13 @@ Each file operation is available in two forms:
       visibility: 'public',
     });
 
-    console.log(filePath); // e.g. 'public/photo.png'
+    console.log(filePath); // e.g. 'public/users/<user-id>/photo.png'
     ```
   </Tab>
   <Tab title="Server">
-    `getUploadUrl` returns a presigned URL and form fields. POST these together as `FormData` to upload the file directly to storage:
+    `getUploadUrl` returns a presigned URL and form fields. POST these together as `FormData` to upload the file directly to storage.
+
+    Since the server helper is low-level, apply your own auth/authorization rules before calling it:
 
     ```ts
     import { getUploadUrl } from 'modelence/server';
@@ -64,15 +70,19 @@ The `visibility` field controls access:
 
 Returns a URL for displaying or linking to a file. For public files this is a permanent URL; for private files it is a time-limited presigned URL.
 
+For the built-in browser methods:
+- public file URLs can be resolved by path
+- private file URLs require an authenticated user and only work for that user's own managed `private/users/<user-id>/...` paths
+
 <Tabs>
   <Tab title="Client">
     ```ts
     import { getFileUrl } from 'modelence/client';
 
-    const { url } = await getFileUrl('public/photo.png');
+    const { url } = await getFileUrl('public/users/<user-id>/photo.png');
     console.log(url); // Permanent public URL
 
-    const { url: privateUrl } = await getFileUrl('private/report.pdf');
+    const { url: privateUrl } = await getFileUrl('private/users/<user-id>/report.pdf');
     console.log(privateUrl); // Time-limited presigned URL
     ```
   </Tab>
@@ -93,12 +103,14 @@ Returns a URL for displaying or linking to a file. For public files this is a pe
 
 Returns a presigned download URL for a private file.
 
+For the built-in browser methods, downloads are only supported for the authenticated user's own managed private paths.
+
 <Tabs>
   <Tab title="Client">
     ```ts
     import { downloadFile } from 'modelence/client';
 
-    const { downloadUrl } = await downloadFile('private/report.pdf');
+    const { downloadUrl } = await downloadFile('private/users/<user-id>/report.pdf');
     // Redirect the user to downloadUrl or fetch it client-side
     ```
   </Tab>
@@ -114,13 +126,15 @@ Returns a presigned download URL for a private file.
 
 ## Deleting a File
 
+For the built-in browser methods, deletes require an authenticated user and are limited to that user's own managed paths.
+
 <Tabs>
   <Tab title="Client">
     ```ts
     import { deleteFile } from 'modelence/client';
 
-    await deleteFile('public/photo.png');
-    await deleteFile('private/report.pdf');
+    await deleteFile('public/users/<user-id>/photo.png');
+    await deleteFile('private/users/<user-id>/report.pdf');
     ```
   </Tab>
   <Tab title="Server">
@@ -145,7 +159,14 @@ const { filePath } = await uploadFile(file, {
   contentType: 'image/png',
   visibility: 'private',
 });
-// filePath === 'private/avatars/user-123.png'
+// filePath === 'private/users/<user-id>/avatars/user-123.png'
 
 const { url } = await getFileUrl(filePath);
 ```
+
+For browser-side built-in methods, `filePath` is always passed as a **relative** path on upload and returned as a **managed stored path**:
+
+- upload input: `'avatars/user-123.png'`
+- upload result: `'private/users/<user-id>/avatars/user-123.png'`
+
+If you need a different storage layout or custom authorization policy, use the server helpers inside your own authenticated query/mutation and enforce your policy there.

--- a/packages/modelence/src/files/index.test.ts
+++ b/packages/modelence/src/files/index.test.ts
@@ -1,10 +1,21 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { AuthError, ValidationError } from '../error';
 import { deleteFile, downloadFile, getFileUrl, getUploadUrl } from './index';
+import filesModule from './index';
 
 describe('files', () => {
   const originalEnv = process.env;
   const originalFetch = global.fetch;
   const fetchMock = vi.fn<typeof fetch>();
+  const authenticatedUser = {
+    id: 'user-123',
+    handle: 'demo',
+    roles: [],
+    hasRole: () => false,
+    requireRole: () => {
+      throw new Error('unused');
+    },
+  };
 
   beforeEach(() => {
     process.env = { ...originalEnv };
@@ -83,6 +94,77 @@ describe('files', () => {
         getUploadUrl({ filePath: '../escape.png', contentType: 'image/png', visibility: 'private' })
       ).rejects.toThrow('HTTP status: 400');
     });
+
+    test('built-in mutation requires an authenticated user', async () => {
+      await expect(
+        filesModule.mutations.getUploadUrl.call(
+          filesModule,
+          {
+            filePath: 'photo.png',
+            contentType: 'image/png',
+            visibility: 'public',
+          },
+          {
+            user: null,
+          } as never
+        )
+      ).rejects.toBeInstanceOf(AuthError);
+    });
+
+    test('built-in mutation scopes uploads to the authenticated user path', async () => {
+      const uploadResult = {
+        url: 'https://s3.amazonaws.com/',
+        fields: {
+          key: 'public/users/user-123/photo.png',
+        },
+        filePath: 'public/users/user-123/photo.png',
+      };
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => uploadResult,
+      } as unknown as Response);
+
+      const result = await filesModule.mutations.getUploadUrl.call(
+        filesModule,
+        {
+          filePath: 'photo.png',
+          contentType: 'image/png',
+          visibility: 'public',
+        },
+        {
+          user: authenticatedUser,
+        } as never
+      );
+
+      expect(result).toEqual(uploadResult);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://cloud.modelence.test/api/files/upload',
+        expect.objectContaining({
+          body: JSON.stringify({
+            filePath: 'public/users/user-123/photo.png',
+            contentType: 'image/png',
+            visibility: 'public',
+          }),
+        })
+      );
+    });
+
+    test('built-in mutation rejects prefixed upload paths', async () => {
+      await expect(
+        filesModule.mutations.getUploadUrl.call(
+          filesModule,
+          {
+            filePath: 'private/report.pdf',
+            contentType: 'application/pdf',
+            visibility: 'private',
+          },
+          {
+            user: authenticatedUser,
+          } as never
+        )
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
   });
 
   describe('deleteFile', () => {
@@ -125,6 +207,18 @@ describe('files', () => {
       } as unknown as Response);
 
       await expect(deleteFile('public/nonexistent.png')).rejects.toThrow('HTTP status: 404');
+    });
+
+    test('built-in mutation only allows deleting files owned by the authenticated user', async () => {
+      await expect(
+        filesModule.mutations.deleteFile.call(
+          filesModule,
+          { filePath: 'private/users/other-user/report.pdf' },
+          {
+            user: authenticatedUser,
+          } as never
+        )
+      ).rejects.toBeInstanceOf(AuthError);
     });
   });
 
@@ -170,6 +264,30 @@ describe('files', () => {
 
       await expect(downloadFile('private/missing.pdf')).rejects.toThrow('HTTP status: 404');
     });
+
+    test('built-in query requires auth for private downloads and enforces ownership', async () => {
+      await expect(
+        filesModule.queries.downloadFile.call(
+          filesModule,
+          { filePath: 'private/users/other-user/report.pdf' },
+          {
+            user: authenticatedUser,
+          } as never
+        )
+      ).rejects.toBeInstanceOf(AuthError);
+    });
+
+    test('built-in query rejects public download requests', async () => {
+      await expect(
+        filesModule.queries.downloadFile.call(
+          filesModule,
+          { filePath: 'public/users/user-123/report.pdf' },
+          {
+            user: authenticatedUser,
+          } as never
+        )
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
   });
 
   describe('getFileUrl', () => {
@@ -213,6 +331,37 @@ describe('files', () => {
       } as unknown as Response);
 
       await expect(getFileUrl('public/missing.png')).rejects.toThrow('HTTP status: 404');
+    });
+
+    test('built-in query allows anonymous access to public file URLs', async () => {
+      const urlResult = { url: 'https://cdn.modelence.test/public/users/user-123/photo.png' };
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => urlResult,
+      } as unknown as Response);
+
+      const result = await filesModule.queries.getFileUrl.call(
+        filesModule,
+        { filePath: 'public/users/user-123/photo.png' },
+        {
+          user: null,
+        } as never
+      );
+
+      expect(result).toEqual(urlResult);
+    });
+
+    test('built-in query requires ownership for private file URLs', async () => {
+      await expect(
+        filesModule.queries.getFileUrl.call(
+          filesModule,
+          { filePath: 'private/users/other-user/report.pdf' },
+          {
+            user: authenticatedUser,
+          } as never
+        )
+      ).rejects.toBeInstanceOf(AuthError);
     });
   });
 });

--- a/packages/modelence/src/files/index.ts
+++ b/packages/modelence/src/files/index.ts
@@ -1,7 +1,10 @@
+import path from 'path';
 import { Module } from '../app/module';
 import { callCloudApi } from '../app/backendApi';
+import { AuthError, ValidationError } from '../error';
 export type { FileVisibility, GetUploadUrlResult } from './types';
 import type { FileVisibility, GetUploadUrlResult } from './types';
+import type { UserInfo } from '@/auth/types';
 
 type DownloadFileResult = {
   downloadUrl: string;
@@ -10,6 +13,99 @@ type DownloadFileResult = {
 type GetFileUrlResult = {
   url: string;
 };
+
+const MANAGED_FILE_ROOT = 'users';
+
+function normalizeRelativeFilePath(filePath: string): string {
+  const trimmed = filePath.trim();
+
+  if (!trimmed) {
+    throw new ValidationError('File path is required');
+  }
+
+  if (trimmed.startsWith('public/') || trimmed.startsWith('private/')) {
+    throw new ValidationError(
+      'Upload file paths must be relative. Pass visibility separately instead of prefixing the path.'
+    );
+  }
+
+  const normalized = path.posix.normalize(trimmed.replace(/\\/g, '/'));
+  if (
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    normalized.startsWith('/')
+  ) {
+    throw new ValidationError('File path must be a safe relative path');
+  }
+
+  return normalized;
+}
+
+function normalizeStoredFilePath(filePath: string): string {
+  const trimmed = filePath.trim();
+
+  if (!trimmed) {
+    throw new ValidationError('File path is required');
+  }
+
+  const normalized = path.posix.normalize(trimmed.replace(/\\/g, '/'));
+  if (
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    normalized.startsWith('/')
+  ) {
+    throw new ValidationError('File path must be a safe stored path');
+  }
+
+  return normalized;
+}
+
+function parseStoredFilePath(filePath: string): { visibility: FileVisibility; filePath: string } {
+  const normalized = normalizeStoredFilePath(filePath);
+
+  if (normalized.startsWith('public/')) {
+    return { visibility: 'public', filePath: normalized };
+  }
+
+  if (normalized.startsWith('private/')) {
+    return { visibility: 'private', filePath: normalized };
+  }
+
+  throw new ValidationError("Stored file paths must start with 'public/' or 'private/'");
+}
+
+function requireAuthenticatedUserId(user: UserInfo | null): string {
+  if (!user?.id) {
+    throw new AuthError('Not authenticated');
+  }
+
+  return user.id;
+}
+
+function buildOwnedPrefix(visibility: FileVisibility, userId: string): string {
+  return `${visibility}/${MANAGED_FILE_ROOT}/${userId}/`;
+}
+
+function scopeManagedUploadPath(
+  relativeFilePath: string,
+  visibility: FileVisibility,
+  userId: string
+): string {
+  return `${visibility}/${MANAGED_FILE_ROOT}/${userId}/${relativeFilePath}`;
+}
+
+function assertOwnedStoredPath(
+  storedFilePath: string,
+  visibility: FileVisibility,
+  userId: string,
+  action: string
+) {
+  if (!storedFilePath.startsWith(buildOwnedPrefix(visibility, userId))) {
+    throw new AuthError(`Not authorized to ${action} this file`);
+  }
+}
 
 export async function getUploadUrl({
   filePath,
@@ -41,23 +137,51 @@ export async function getFileUrl(filePath: string): Promise<GetFileUrlResult> {
 
 export default new Module('_system.files', {
   queries: {
-    async downloadFile({ filePath }) {
-      return downloadFile(filePath as string);
+    async downloadFile({ filePath }, { user }) {
+      const userId = requireAuthenticatedUserId(user);
+      const parsed = parseStoredFilePath(filePath as string);
+
+      if (parsed.visibility !== 'private') {
+        throw new ValidationError('downloadFile only supports private files');
+      }
+
+      assertOwnedStoredPath(parsed.filePath, parsed.visibility, userId, 'download');
+      return downloadFile(parsed.filePath);
     },
-    async getFileUrl({ filePath }) {
-      return getFileUrl(filePath as string);
+    async getFileUrl({ filePath }, { user }) {
+      const parsed = parseStoredFilePath(filePath as string);
+
+      if (parsed.visibility === 'public') {
+        return getFileUrl(parsed.filePath);
+      }
+
+      const userId = requireAuthenticatedUserId(user);
+      assertOwnedStoredPath(parsed.filePath, parsed.visibility, userId, 'access');
+      return getFileUrl(parsed.filePath);
     },
   },
   mutations: {
-    async getUploadUrl({ filePath, contentType, visibility }) {
+    async getUploadUrl({ filePath, contentType, visibility }, { user }) {
+      const userId = requireAuthenticatedUserId(user);
+      const relativeFilePath = normalizeRelativeFilePath(filePath as string);
+      const scopedFilePath = scopeManagedUploadPath(
+        relativeFilePath,
+        visibility as FileVisibility,
+        userId
+      );
+
       return getUploadUrl({
-        filePath: filePath as string,
+        filePath: scopedFilePath,
         contentType: contentType as string,
         visibility: visibility as FileVisibility,
       });
     },
-    async deleteFile({ filePath }) {
-      return deleteFile(filePath as string);
+    async deleteFile({ filePath }, { user }) {
+      const userId = requireAuthenticatedUserId(user);
+      const parsed = parseStoredFilePath(filePath as string);
+
+      assertOwnedStoredPath(parsed.filePath, parsed.visibility, userId, 'delete');
+      return deleteFile(parsed.filePath);
     },
   },
 });


### PR DESCRIPTION
Fixes modelence/modelence#286

## Summary

Built-in `_system.files` methods were forwarding storage operations with the app service token without checking who requested them. This scopes the browser-facing file APIs to authenticated users and managed per-user paths so private file access no longer depends on path secrecy.

Uploads through the built-in module now accept relative paths and are stored under `<visibility>/users/<user-id>/...`. Private file URL resolution and downloads require the authenticated owner, and deletes are limited to the caller's managed public and private paths.

The low-level server file helpers still exist for custom storage flows, but the docs now call out that callers must enforce their own auth and authorization when using those helpers directly.

## Tests

- `npm test -- --run src/files/index.test.ts`
- `npm test -- --run src/app/server.test.ts src/client/session.test.ts src/auth/session.test.ts`
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization for file storage APIs (prior path-based access could be abused); client apps may break if they used unprefixed stored paths or cross-user private paths.
> 
> **Overview**
> **Security fix for browser-facing `_system.files` operations:** built-in queries/mutations no longer forward arbitrary paths to Modelence Cloud with only the service token. They now require authentication where appropriate, normalize paths, and enforce per-user managed storage under `<visibility>/users/<user-id>/...`.
> 
> **Uploads** through the built-in mutation accept **relative** paths only (reject `public/`/`private/` prefixes and unsafe paths), require a signed-in user, and rewrite the cloud path to the caller’s managed namespace.
> 
> **Reads/deletes:** private `getFileUrl` and `downloadFile` require the authenticated owner; `downloadFile` rejects public paths. Public `getFileUrl` stays callable without a user. Deletes require auth and ownership for both public and private managed paths.
> 
> Low-level **`modelence/server`** helpers are unchanged; **docs** add a warning and updated client examples (managed paths, auth rules) and note that server callers must enforce their own authorization.
> 
> **Tests** cover auth failures, upload scoping, prefixed-path rejection, ownership checks, and public URL behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8111303cb07be74aca79a9fb46b98ac3aa74d90d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->