### PR TITLE
docs: ssr

### DIFF
--- a/docs/web/core-concepts/mutations.mdx
+++ b/docs/web/core-concepts/mutations.mdx
@@ -68,7 +68,7 @@ const todoId = await callMethod('todo.create', {
 
 ```typescript
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { modelenceMutation } from '@modelence/react-query';
+import { modelenceMutation } from 'modelence/client';
 
 function CreateTodo() {
   const queryClient = useQueryClient();

--- a/docs/web/core-concepts/queries.mdx
+++ b/docs/web/core-concepts/queries.mdx
@@ -69,13 +69,22 @@ const todo = await callMethod('todo.getOne', { id: '123' });
 
 ```typescript
 import { useQuery } from '@tanstack/react-query';
-import { modelenceQuery } from '@modelence/react-query';
+import { modelenceQuery } from 'modelence/client';
 
 function TodoList() {
   const { data: todos } = useQuery(modelenceQuery('todo.getAll'));
   return <div>{/* render todos */}</div>;
 }
 ```
+
+<Note>
+Since `modelence@0.15.0`, the query helpers (`modelenceQuery`,
+`modelenceLiveQuery`, `modelenceMutation`, `createQueryKey`) are available
+directly from `modelence/client` — this is the recommended import. The
+`@modelence/react-query` package still exports the same helpers and continues to
+work, but new code should import from `modelence/client`. See
+[Migrating from @modelence/react-query](/live-queries#migrating-from-modelence-react-query).
+</Note>
 
 ### `createClientModule(...).query()` (typed client modules)
 

--- a/docs/web/docs.json
+++ b/docs/web/docs.json
@@ -63,6 +63,7 @@
               "stores",
               "indexes",
               "live-queries",
+              "ssr",
               "configuration",
               "websockets",
               "telemetry",

--- a/docs/web/live-queries.mdx
+++ b/docs/web/live-queries.mdx
@@ -18,35 +18,57 @@ Live Queries are available with the following minimum package versions:
 The live query system consists of three parts:
 
 1. **Server-side `LiveData`** - Defines how to fetch data and watch for changes
-2. **`ModelenceQueryClient`** - Connects Modelence's live query system to TanStack Query
+2. **`ModelenceQueryProvider`** (or `connectModelenceQueryClient`) - Connects Modelence's live query system to TanStack Query
 3. **`modelenceLiveQuery`** - Creates live query options for `useQuery`
 
 ## Client Setup
 
-### 1. Connect ModelenceQueryClient
+### 1. Provide a connected QueryClient
 
-Before using live queries, you must connect a `ModelenceQueryClient` to your TanStack Query `QueryClient`. This is required for `modelenceLiveQuery` to work.
+`modelenceLiveQuery` needs a TanStack Query `QueryClient` connected to Modelence's
+live-query layer. The simplest way is to let `renderApp` handle it: if you don't
+mount your own provider, `renderApp` automatically wraps your app in
+`ModelenceQueryProvider`, which creates a `QueryClient` and connects it for you.
+
+```tsx
+// src/client/index.tsx
+import { renderApp } from 'modelence/client';
+import routes from './routes';
+
+renderApp({
+  loadingElement: <div>Loading…</div>,
+  routesElement: routes,
+});
+// No provider wiring needed — renderApp injects ModelenceQueryProvider.
+```
+
+If you need your own `QueryClient` (for example, to configure defaults or share it
+with other libraries), connect it yourself with `connectModelenceQueryClient` and
+mount your own `QueryClientProvider`. `renderApp` detects the already-connected
+client and will not inject a second provider.
 
 ```tsx
 // src/client/index.tsx
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ModelenceQueryClient } from '@modelence/react-query';
-import { renderApp } from 'modelence/client';
+import { connectModelenceQueryClient, renderApp } from 'modelence/client';
+import routes from './routes';
 
 const queryClient = new QueryClient();
-new ModelenceQueryClient().connect(queryClient);
+connectModelenceQueryClient(queryClient);
 
 renderApp({
-  app: () => (
-    <QueryClientProvider client={queryClient}>
-      <YourApp />
-    </QueryClientProvider>
+  loadingElement: <div>Loading…</div>,
+  routesElement: (
+    <QueryClientProvider client={queryClient}>{routes}</QueryClientProvider>
   ),
 });
 ```
 
 <Warning>
-If you skip the `ModelenceQueryClient().connect()` step, `modelenceLiveQuery` will throw an error: `ModelenceQueryClient must be connected before using modelenceLiveQuery()`.
+If you mount your own `QueryClientProvider` but never call
+`connectModelenceQueryClient(queryClient)`, `modelenceLiveQuery` throws:
+`Modelence: connect a QueryClient before using modelenceLiveQuery(). Mount
+<ModelenceQueryProvider> or call connectModelenceQueryClient().`
 </Warning>
 
 ### 2. Use modelenceLiveQuery in Components
@@ -55,7 +77,7 @@ Use `modelenceLiveQuery` with TanStack Query's `useQuery` hook. It works just li
 
 ```tsx
 import { useQuery } from '@tanstack/react-query';
-import { modelenceLiveQuery } from '@modelence/react-query';
+import { modelenceLiveQuery } from 'modelence/client';
 
 function TodoList({ userId }: { userId: string }) {
   const { data: todos, isLoading } = useQuery(
@@ -243,27 +265,20 @@ export default new Module('todo', {
 
 ```tsx
 // src/client/index.tsx
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ModelenceQueryClient } from '@modelence/react-query';
 import { renderApp } from 'modelence/client';
 import TodoList from './pages/TodoList';
 
-const queryClient = new QueryClient();
-new ModelenceQueryClient().connect(queryClient);
-
+// renderApp injects ModelenceQueryProvider automatically — no manual wiring.
 renderApp({
-  app: () => (
-    <QueryClientProvider client={queryClient}>
-      <TodoList />
-    </QueryClientProvider>
-  ),
+  loadingElement: <div>Loading…</div>,
+  routesElement: <TodoList />,
 });
 ```
 
 ```tsx
 // src/client/pages/TodoList.tsx
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { modelenceLiveQuery, modelenceMutation } from '@modelence/react-query';
+import { modelenceLiveQuery, modelenceMutation } from 'modelence/client';
 import { useSession } from 'modelence/client';
 
 export default function TodoList() {
@@ -326,13 +341,18 @@ Live queries are built on top of WebSockets internally, but provide a higher-lev
 
 ## Common Pitfalls
 
-### Missing ModelenceQueryClient setup
+### Missing QueryClient connection
 
-If you see `ModelenceQueryClient must be connected before using modelenceLiveQuery()`, add the setup code to your client entry point:
+If you see `Modelence: connect a QueryClient before using modelenceLiveQuery()`,
+you mounted your own `QueryClientProvider` without connecting it. Either drop your
+custom provider and let `renderApp` inject `ModelenceQueryProvider`, or connect
+your client explicitly:
 
 ```tsx
+import { connectModelenceQueryClient } from 'modelence/client';
+
 const queryClient = new QueryClient();
-new ModelenceQueryClient().connect(queryClient);
+connectModelenceQueryClient(queryClient);
 ```
 
 ### Returning plain data instead of LiveData
@@ -370,8 +390,49 @@ watch: ({ publish }) => {
 },
 ```
 
+## Migrating from @modelence/react-query
+
+Since `modelence@0.15.0`, the query helpers live in `modelence/client`, and
+`renderApp` connects a `QueryClient` for you. Existing apps using
+`@modelence/react-query` keep working — this migration is optional — but new code
+should use the core imports.
+
+**1. Swap the import source.** The helpers are drop-in identical:
+
+```diff
+- import { modelenceQuery, modelenceLiveQuery, modelenceMutation } from '@modelence/react-query';
++ import { modelenceQuery, modelenceLiveQuery, modelenceMutation } from 'modelence/client';
+```
+
+**2. Drop the manual provider wiring (optional).** If you connected the client
+only to satisfy live queries, you can let `renderApp` inject
+`ModelenceQueryProvider` and remove the boilerplate:
+
+```diff
+- import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+- import { ModelenceQueryClient } from '@modelence/react-query';
+  import { renderApp } from 'modelence/client';
+
+- const queryClient = new QueryClient();
+- new ModelenceQueryClient().connect(queryClient);
+
+  renderApp({
+-   routesElement: (
+-     <QueryClientProvider client={queryClient}>{routes}</QueryClientProvider>
+-   ),
++   loadingElement: <div>Loading…</div>,
++   routesElement: routes,
+  });
+```
+
+If you still need your own `QueryClient`, replace
+`new ModelenceQueryClient().connect(queryClient)` with
+`connectModelenceQueryClient(queryClient)` (the `ModelenceQueryClient` class is
+deprecated but still exported for compatibility).
+
 ## API Reference
 
-- [modelenceQuery](/api-reference/@modelence/react-query/functions/modelenceQuery) - Standard (non-live) query helper
-- [modelenceMutation](/api-reference/@modelence/react-query/functions/modelenceMutation) - Mutation helper
+- [modelenceQuery](/api-reference/modelence/client/functions/modelenceQuery) - Standard (non-live) query helper
+- [modelenceLiveQuery](/api-reference/modelence/client/functions/modelenceLiveQuery) - Live query helper
+- [ModelenceQueryProvider](/api-reference/modelence/client/functions/ModelenceQueryProvider) - Auto-connecting provider
 - [Store](/api-reference/modelence/server/classes/Store) - Database store with `watch()` support

--- a/docs/web/ssr.mdx
+++ b/docs/web/ssr.mdx
@@ -1,0 +1,88 @@
+---
+title: 'Server-Side Rendering'
+description: 'Render your React tree on the server for faster first paint and hydrate on the client. Available since modelence@0.15.0.'
+icon: 'server'
+---
+
+Server-side rendering (SSR) renders your React application to HTML on the server,
+sends that HTML to the browser, and then hydrates it on the client. This improves
+first-paint performance and lets crawlers see fully rendered markup.
+
+SSR in Modelence is **opt-in**. Existing client-only apps keep working unchanged —
+you only get SSR after you explicitly enable it.
+
+## Enabling SSR
+
+Set `ssr: true` in `startApp`:
+
+```typescript title="src/server/app.ts"
+import { startApp } from 'modelence/server';
+import todoModule from './todo';
+
+startApp({
+  modules: [todoModule],
+  ssr: true,
+});
+```
+
+That's the only required change. The Modelence build always emits SSR artifacts,
+so there is no separate build flag — `startApp({ ssr: true })` decides whether they
+are used at runtime.
+
+<Note>
+When `ssr` is omitted or `false`, Modelence renders on the client only, exactly as
+before. Nothing about your existing app changes until you opt in.
+</Note>
+
+## Routing with SSR
+
+For the server and client to resolve the same route, a location-driven router must
+be told which URL to render. Pass a `router` function to `renderApp`. Modelence
+calls it with the current `location` on the server and again on the client during
+hydration, so both produce the same tree:
+
+```tsx title="src/client/index.tsx"
+import { renderApp } from 'modelence/client';
+import { StaticRouter } from 'react-router-dom/server';
+import { BrowserRouter } from 'react-router-dom';
+import routes from './routes';
+
+renderApp({
+  loadingElement: <div>Loading…</div>,
+  routesElement: routes,
+  router: ({ children, location }) =>
+    typeof window === 'undefined'
+      ? <StaticRouter location={location ?? '/'}>{children}</StaticRouter>
+      : <BrowserRouter>{children}</BrowserRouter>,
+});
+```
+
+The `location` passed to the router is `path + search` (the hash is never sent to
+the server), matching what the browser sees on hydration. This avoids hydration
+mismatches.
+
+<Warning>
+Without a `router`, a location-driven router (like React Router) will render its
+default route on the server and a different route on the client, producing a
+hydration mismatch. Only pass `router` when your routing depends on the current
+URL.
+</Warning>
+
+## Data fetching and hydration
+
+- **Session** is rendered on the server and hydrated on the client, so
+  `useSession()` returns the correct value on the very first render with no flash
+  of logged-out UI.
+- **Queries** (`modelenceQuery`) run on the server and their results are serialized
+  into the HTML, so cached data is available immediately after hydration.
+- **Live queries** (`modelenceLiveQuery`) are WebSocket subscriptions with no server
+  snapshot — they stay pending during SSR and connect after hydration on the client.
+
+See [Queries](/core-concepts/queries) and [Live Queries](/live-queries) for how to
+call methods from the client.
+
+## Related
+
+- [Queries](/core-concepts/queries)
+- [Live Queries](/live-queries)
+- [Project Structure](/core-concepts/project-structure)

--- a/docs/web/tutorial.mdx
+++ b/docs/web/tutorial.mdx
@@ -191,7 +191,7 @@ import {
   modelenceQuery,
   modelenceMutation,
   createQueryKey
-} from '@modelence/react-query';
+} from 'modelence/client';
 
 // Helper: Store `methods` only live on server-side document instances and
 // are stripped when results are serialized over the wire. Reimplement

--- a/docs/web/voyage-ai.mdx
+++ b/docs/web/voyage-ai.mdx
@@ -320,7 +320,7 @@ Create a React component to interact with your semantic search backend:
 ```tsx title="src/client/pages/VoyageSearchPage.tsx"
 import { useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { modelenceMutation, modelenceQuery } from '@modelence/react-query';
+import { modelenceMutation, modelenceQuery } from 'modelence/client';
 
 interface Document {
   _id: string;

--- a/docs/web/websockets.mdx
+++ b/docs/web/websockets.mdx
@@ -311,7 +311,7 @@ renderApp({
 // src/client/pages/ChatPage.tsx
 import { useEffect, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { modelenceMutation } from '@modelence/react-query';
+import { modelenceMutation } from 'modelence/client';
 import chatClientChannel from '../channels/chatClientChannel';
 
 export default function ChatPage() {


### PR DESCRIPTION
* Improve SSR docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code impact.
> 
> **Overview**
> Adds a new **Server-Side Rendering** guide (`ssr.mdx`) and links it in the docs nav. It documents opt-in SSR via `startApp({ ssr: true })`, the `renderApp` `router` callback for URL-aligned hydration with React Router, and how session, `modelenceQuery`, and `modelenceLiveQuery` behave during SSR.
> 
> **Live Queries** and related guides are updated for `modelence@0.15.0`: examples import `modelenceQuery` / `modelenceLiveQuery` / `modelenceMutation` from `modelence/client` instead of `@modelence/react-query`, client setup centers on **`ModelenceQueryProvider`** and **`connectModelenceQueryClient`** (with `renderApp` auto-injecting a provider when you don’t bring your own `QueryClient`), and a new **Migrating from @modelence/react-query** section plus API links to `modelence/client`. The same import swap is applied in mutations, queries (with a recommended-import note), tutorial, voyage-ai, and websockets pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 991680b43e24db1dfd143fb6f7784273fcaec3d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->