### PR TITLE
fix: hash session auth tokens at rest to prevent credential exposure …

### DIFF
--- a/packages/modelence/src/auth/session.test.ts
+++ b/packages/modelence/src/auth/session.test.ts
@@ -6,10 +6,14 @@ const mockRandomBytes = vi.fn(() => ({
   toString: () => 'auth-token',
 }));
 
+const mockDigest = vi.fn(() => 'hashed-auth-token');
+const mockUpdate = vi.fn(() => ({ digest: mockDigest }));
+const mockCreateHash = vi.fn(() => ({ update: mockUpdate }));
 const mockDays = vi.fn(() => 7 * 24 * 60 * 60 * 1000);
 
 vi.doMock('crypto', () => ({
   randomBytes: mockRandomBytes,
+  createHash: mockCreateHash,
 }));
 
 vi.doMock('@/time', () => ({
@@ -48,8 +52,11 @@ describe('auth/session', () => {
     const result = await createSession(userId);
 
     expect((mockRandomBytes as Mock).mock.calls[0]?.[0]).toBe(32);
+    expect(mockCreateHash).toHaveBeenCalledWith('sha256');
+    expect(mockUpdate).toHaveBeenCalledWith('auth-token');
+    expect(mockDigest).toHaveBeenCalledWith('hex');
     expect(insertOneMock).toHaveBeenCalledWith({
-      authToken: 'auth-token',
+      authToken: 'hashed-auth-token',
       createdAt: expect.any(Date),
       expiresAt: expect.any(Date),
       userId,
@@ -69,11 +76,44 @@ describe('auth/session', () => {
 
     const result = await obtainSession('token');
 
-    expect(findOneMock).toHaveBeenCalledWith({ authToken: 'token' });
+    // Should look up by hashed token first
+    expect(findOneMock).toHaveBeenCalledWith({ authToken: 'hashed-auth-token' });
+    // Returns the raw (unhashed) token to the caller
     expect(result).toEqual({
       authToken: 'token',
       expiresAt: existing.expiresAt,
       userId: existing.userId,
+    });
+  });
+
+  test('obtainSession falls back to raw token lookup for legacy sessions', async () => {
+    const legacy = {
+      _id: new ObjectId(),
+      authToken: 'legacy-raw-token',
+      expiresAt: new Date(),
+      userId: new ObjectId(),
+    };
+    // First call (hashed) returns null; second call (raw) returns legacy
+    findOneMock.mockResolvedValueOnce(null as never);
+    findOneMock.mockResolvedValueOnce(legacy as never);
+    insertOneMock.mockResolvedValue({ acknowledged: true } as never);
+    const updateOneMockLocal = vi.fn().mockResolvedValue({ acknowledged: true } as never);
+    (sessionsCollection as unknown as { updateOne: typeof updateOneMockLocal }).updateOne =
+      updateOneMockLocal;
+
+    const result = await obtainSession('legacy-raw-token');
+
+    expect(findOneMock).toHaveBeenNthCalledWith(1, { authToken: 'hashed-auth-token' });
+    expect(findOneMock).toHaveBeenNthCalledWith(2, { authToken: 'legacy-raw-token' });
+    // Should migrate the legacy session to hashed
+    expect(updateOneMockLocal).toHaveBeenCalledWith(
+      { _id: legacy._id },
+      { $set: { authToken: 'hashed-auth-token' } }
+    );
+    expect(result).toEqual({
+      authToken: 'legacy-raw-token',
+      expiresAt: legacy.expiresAt,
+      userId: legacy.userId,
     });
   });
 
@@ -94,7 +134,7 @@ describe('auth/session', () => {
     await setSessionUser('token', userId);
 
     expect(updateOneMock).toHaveBeenCalledWith(
-      { authToken: 'token' },
+      { authToken: 'hashed-auth-token' },
       {
         $set: { userId },
       }
@@ -107,7 +147,7 @@ describe('auth/session', () => {
     await clearSessionUser('token');
 
     expect(updateOneMock).toHaveBeenCalledWith(
-      { authToken: 'token' },
+      { authToken: 'hashed-auth-token' },
       {
         $set: { userId: null },
       }

--- a/packages/modelence/src/auth/session.test.ts
+++ b/packages/modelence/src/auth/session.test.ts
@@ -127,6 +127,26 @@ describe('auth/session', () => {
     expect(result.authToken).toBe('auth-token');
   });
 
+  test('obtainSession does not fall back to raw token lookup if input is a 64-char hex string (hash replay protection)', async () => {
+    const leakedHash = 'a'.repeat(64);
+
+    findOneMock.mockResolvedValue(null as never);
+    insertOneMock.mockResolvedValue({ acknowledged: true } as never);
+
+    const result = await obtainSession(leakedHash);
+
+    // Should only look up by hashed token (which is the mock hashed token in tests)
+    expect(findOneMock).toHaveBeenCalledTimes(1);
+    expect(findOneMock).toHaveBeenCalledWith({ authToken: 'hashed-auth-token' });
+
+    // Should NOT look up by the raw leakedHash string via legacy fallback
+    expect(findOneMock).not.toHaveBeenCalledWith({ authToken: leakedHash });
+
+    // Should result in a newly created session instead
+    expect(insertOneMock).toHaveBeenCalled();
+    expect(result.authToken).toBe('auth-token');
+  });
+
   test('setSessionUser stores user id for session', async () => {
     updateOneMock.mockResolvedValue({ acknowledged: true } as never);
     const userId = new ObjectId();

--- a/packages/modelence/src/auth/session.ts
+++ b/packages/modelence/src/auth/session.ts
@@ -59,7 +59,10 @@ export async function obtainSession(authToken: string | null): Promise<Session> 
     : null;
 
   // Legacy fallback: try raw token lookup (pre-hash sessions)
-  if (!existingSession && authToken) {
+  // Ensure the authToken is not a hex-encoded SHA-256 hash to prevent
+  // replay attacks using leaked hashed tokens.
+  const isHex64 = authToken && /^[0-9a-f]{64}$/i.test(authToken);
+  if (!existingSession && authToken && !isHex64) {
     existingSession = await sessionsCollection.findOne({ authToken });
     if (existingSession) {
       await sessionsCollection.updateOne(

--- a/packages/modelence/src/auth/session.ts
+++ b/packages/modelence/src/auth/session.ts
@@ -6,6 +6,7 @@ import { getPublicConfigs } from '../config/server';
 import { Store } from '../data/store';
 import { schema } from '../data/types';
 import { time } from '../time';
+import { hashToken } from './tokenHash';
 import { Session } from './types';
 
 export const linkNoncesCollection = new Store('_modelenceLinkNonces', {
@@ -51,11 +52,26 @@ export const sessionsCollection = new Store('_modelenceSessions', {
 });
 
 export async function obtainSession(authToken: string | null): Promise<Session> {
-  const existingSession = authToken ? await sessionsCollection.findOne({ authToken }) : null;
+  const hashedToken = authToken ? hashToken(authToken) : null;
+
+  let existingSession = hashedToken
+    ? await sessionsCollection.findOne({ authToken: hashedToken })
+    : null;
+
+  // Legacy fallback: try raw token lookup (pre-hash sessions)
+  if (!existingSession && authToken) {
+    existingSession = await sessionsCollection.findOne({ authToken });
+    if (existingSession) {
+      await sessionsCollection.updateOne(
+        { _id: existingSession._id as ObjectId },
+        { $set: { authToken: hashedToken } }
+      );
+    }
+  }
 
   if (existingSession) {
     return {
-      authToken: String(existingSession.authToken),
+      authToken,
       expiresAt: new Date(existingSession.expiresAt),
       userId: existingSession.userId ?? null,
     };
@@ -66,7 +82,7 @@ export async function obtainSession(authToken: string | null): Promise<Session> 
 
 export async function setSessionUser(authToken: string, userId: ObjectId) {
   await sessionsCollection.updateOne(
-    { authToken },
+    { authToken: hashToken(authToken) },
     {
       $set: { userId },
     }
@@ -75,7 +91,7 @@ export async function setSessionUser(authToken: string, userId: ObjectId) {
 
 export async function clearSessionUser(authToken: string) {
   await sessionsCollection.updateOne(
-    { authToken },
+    { authToken: hashToken(authToken) },
     {
       $set: { userId: null },
     }
@@ -94,7 +110,7 @@ export async function createSession(userId: ObjectId | null = null): Promise<Ses
   const expiresAt = new Date(now + time.days(7));
 
   await sessionsCollection.insertOne({
-    authToken,
+    authToken: hashToken(authToken),
     createdAt: new Date(now),
     expiresAt,
     userId,
@@ -112,7 +128,7 @@ async function processSessionHeartbeat(session: Session) {
   const newExpiresAt = new Date(now + time.days(7));
 
   await sessionsCollection.updateOne(
-    { authToken: session.authToken },
+    { authToken: hashToken(session.authToken) },
     {
       $set: {
         lastActiveDate: new Date(now),

--- a/packages/modelence/src/auth/session.ts
+++ b/packages/modelence/src/auth/session.ts
@@ -52,32 +52,31 @@ export const sessionsCollection = new Store('_modelenceSessions', {
 });
 
 export async function obtainSession(authToken: string | null): Promise<Session> {
-  const hashedToken = authToken ? hashToken(authToken) : null;
+  if (authToken) {
+    const hashedToken = hashToken(authToken);
+    let existingSession = await sessionsCollection.findOne({ authToken: hashedToken });
 
-  let existingSession = hashedToken
-    ? await sessionsCollection.findOne({ authToken: hashedToken })
-    : null;
-
-  // Legacy fallback: try raw token lookup (pre-hash sessions)
-  // Ensure the authToken is not a hex-encoded SHA-256 hash to prevent
-  // replay attacks using leaked hashed tokens.
-  const isHex64 = authToken && /^[0-9a-f]{64}$/i.test(authToken);
-  if (!existingSession && authToken && !isHex64) {
-    existingSession = await sessionsCollection.findOne({ authToken });
-    if (existingSession) {
-      await sessionsCollection.updateOne(
-        { _id: existingSession._id as ObjectId },
-        { $set: { authToken: hashedToken } }
-      );
+    // Legacy fallback: try raw token lookup (pre-hash sessions)
+    // Ensure the authToken is not a hex-encoded SHA-256 hash to prevent
+    // replay attacks using leaked hashed tokens.
+    const isHex64 = /^[0-9a-f]{64}$/i.test(authToken);
+    if (!existingSession && !isHex64) {
+      existingSession = await sessionsCollection.findOne({ authToken });
+      if (existingSession) {
+        await sessionsCollection.updateOne(
+          { _id: existingSession._id as ObjectId },
+          { $set: { authToken: hashedToken } }
+        );
+      }
     }
-  }
 
-  if (existingSession) {
-    return {
-      authToken,
-      expiresAt: new Date(existingSession.expiresAt),
-      userId: existingSession.userId ?? null,
-    };
+    if (existingSession) {
+      return {
+        authToken,
+        expiresAt: new Date(existingSession.expiresAt),
+        userId: existingSession.userId ?? null,
+      };
+    }
   }
 
   return await createSession();


### PR DESCRIPTION
…from DB leaks

Session auth tokens (256-bit random bearer tokens) were previously stored as plaintext in the _modelenceSessions MongoDB collection. A database breach would expose all active bearer tokens, allowing session hijacking.

The existing hashToken utility (SHA-256) was already defined but unused for sessions. This change applies it consistently:

- createSession: stores hashToken(authToken) instead of the raw value
- obtainSession: looks up by hashToken(authToken), with a legacy fallback that migrates any pre-hash sessions on access
- setSessionUser: queries by hashToken(authToken)
- clearSessionUser: queries by hashToken(authToken)
- processSessionHeartbeat: queries by hashToken(authToken)

The raw token is always returned to callers (for cookies, client responses); only the at-rest DB value is hashed. The unique index on authToken remains effective since SHA-256 digests are collision-free for this use case.

Backward compatibility: existing raw-token sessions in the DB are migrated to their hashed form on the next obtainSession call via a findOne-and-update fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core session authentication and token storage; mistakes could break logins or weaken session security.
> 
> **Overview**
> Session bearer tokens are now stored in `_modelenceSessions` as **SHA-256 hashes** via `hashToken`, while cookies and API responses still use the raw token. **createSession**, **obtainSession**, **setSessionUser**, **clearSessionUser**, and **processSessionHeartbeat** all query or write hashed values.
> 
> **obtainSession** looks up by hash first. If nothing matches, it falls back to a raw-token lookup for pre-change sessions, then **migrates** that row to the hashed form on access. Legacy fallback is **skipped** when the incoming token matches a 64-character hex string, so a leaked DB hash cannot be replayed as a bearer credential.
> 
> Tests mock `createHash` and cover hashed inserts/lookups, legacy migration, and hash-replay protection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a994c624c6c3c2d356d5f5fb7e622aa1a6885fe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->