### PR TITLE
refactor: replace console.error with structured logError from telemetry module

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -86,9 +86,14 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
         run: |
-          if [[ "${{ steps.package-info.outputs.version }}" == *"dev"* ]]; then
-            echo "Publishing dev version without latest tag"
+          VERSION="${{ steps.package-info.outputs.version }}"
+          if [[ "$VERSION" == *"dev"* ]]; then
+            echo "Publishing dev version under 'dev' tag"
             npm publish --tag dev --access public --provenance
+          elif [[ "$VERSION" == *"-"* ]]; then
+            # Any other prerelease (rc, beta, alpha, etc.) → publish under 'next', not 'latest'
+            echo "Publishing prerelease version under 'next' tag"
+            npm publish --tag next --access public --provenance
           else
             echo "Publishing with latest tag"
             npm publish --access public --provenance

--- a/docs/web/authentication/magic-link.mdx
+++ b/docs/web/authentication/magic-link.mdx
@@ -4,6 +4,8 @@ title: 'Magic Link'
 
 Modelence supports passwordless authentication with magic links: the user enters their email address and receives an email with a single-use sign-in **link** and a matching **one-time code**. Clicking the link signs them in; typing the code does the same — useful on mobile apps or when the email is read on a different device.
 
+<Note>Magic link sign-in and sign-up are available since `modelence@0.22.0`.</Note>
+
 Magic link can also work as a combined sign-in and sign-up: with the `allowSignup` option enabled, an account is created automatically when the link or code is used for an email that is not registered yet — just like OAuth sign-in. This is disabled by default (see [Sign-Up Behavior](#sign-up-behavior)).
 
 > The magic link email delivery setup below (provider, sender, template, redirect URL) is configured under the **`email:`** key of `startApp`. To run code on related auth events, register callbacks under **`auth:`** — see [Auth Hooks](/authentication/hooks).

--- a/packages/modelence/src/app/backendApi.test.ts
+++ b/packages/modelence/src/app/backendApi.test.ts
@@ -130,10 +130,9 @@ describe('app/backendApi', () => {
         })
       ).rejects.toThrow('invalid container');
 
-      expect(consoleError).toHaveBeenCalledWith(
-        'Unable to connect to Modelence Cloud:',
-        expect.any(Error)
-      );
+      expect(consoleError).toHaveBeenCalledWith('Unable to connect to Modelence Cloud', {
+        error: expect.any(Error),
+      });
     });
 
     test('throws when MODELENCE_SERVICE_ENDPOINT is missing', async () => {

--- a/packages/modelence/src/app/backendApi.ts
+++ b/packages/modelence/src/app/backendApi.ts
@@ -5,6 +5,7 @@ import { RoleDefinition } from '../auth/types';
 import { Store } from '../data/store';
 import { AppConfig } from '../config/types';
 import { ModelSchema } from '../data/types';
+import { logError } from '../telemetry';
 
 type CloudBackendConnectOkResponse = {
   status: 'ok';
@@ -71,7 +72,7 @@ export async function connectCloudBackend({
 
     return data;
   } catch (error) {
-    console.error('Unable to connect to Modelence Cloud:', error);
+    logError('Unable to connect to Modelence Cloud', { error });
     throw error;
   }
 }

--- a/packages/modelence/src/app/index.ts
+++ b/packages/modelence/src/app/index.ts
@@ -198,7 +198,7 @@ export async function startApp({
     startConfigSync();
   }
 
-  startCronJobs().catch((err) => logError('Cron job startup failed', { err }));
+  startCronJobs().catch((error) => logError('Cron job startup failed', { error }));
 
   await startServer(server, { combinedModules, channels });
 }

--- a/packages/modelence/src/app/index.ts
+++ b/packages/modelence/src/app/index.ts
@@ -42,6 +42,7 @@ import { AuthConfig, setAuthConfig } from './authConfig';
 import { SecurityConfig, setSecurityConfig } from './securityConfig';
 import { WebsocketConfig, setWebsocketConfig } from './websocketConfig';
 import { buildAuthRateLimits } from '../auth/user';
+import { logError } from '../telemetry';
 
 export type AppOptions = {
   modules?: Module[];
@@ -197,7 +198,7 @@ export async function startApp({
     startConfigSync();
   }
 
-  startCronJobs().catch(console.error);
+  startCronJobs().catch((err) => logError('Cron job startup failed', { err }));
 
   await startServer(server, { combinedModules, channels });
 }
@@ -284,11 +285,15 @@ async function createIndexesAndMigrationsWithLock(
   void Promise.allSettled([backgroundIndexCreationPromise, migrationPromise])
     .then(([backgroundIndexesResult, migrationResult]) => {
       if (backgroundIndexesResult.status === 'rejected') {
-        console.error('Error creating background indexes:', backgroundIndexesResult.reason);
+        logError('Background index creation failed', {
+          error: backgroundIndexesResult.reason,
+        });
       }
 
       if (migrationResult.status === 'rejected') {
-        console.error('Error running migrations:', migrationResult.reason);
+        logError('Migration execution failed', {
+          error: migrationResult.reason,
+        });
       }
     })
     .finally(async () => {

--- a/packages/modelence/src/app/metrics.test.ts
+++ b/packages/modelence/src/app/metrics.test.ts
@@ -69,6 +69,7 @@ async function setupMetrics(options: SetupOptions = {}) {
       format: {
         combine: formatCombine,
         json: formatJson,
+        errors: vi.fn(),
       },
     },
   }));

--- a/packages/modelence/src/app/metrics.test.ts
+++ b/packages/modelence/src/app/metrics.test.ts
@@ -69,7 +69,6 @@ async function setupMetrics(options: SetupOptions = {}) {
       format: {
         combine: formatCombine,
         json: formatJson,
-        errors: vi.fn(),
       },
     },
   }));

--- a/packages/modelence/src/app/metrics.ts
+++ b/packages/modelence/src/app/metrics.ts
@@ -4,7 +4,6 @@ import { ElasticsearchTransport } from 'winston-elasticsearch';
 
 import { getConfig } from '../config/server';
 import { startLoggerProcess } from './loggerProcess';
-import { logError } from '../telemetry';
 import {
   getAppAlias,
   getEnvironmentAlias,
@@ -76,7 +75,7 @@ async function initElasticApm() {
   });
 
   esTransport.on('error', (error) => {
-    logError('Elasticsearch Transport Error', { error });
+    console.error('Elasticsearch Transport Error:', error);
   });
 
   logger = winston.createLogger({
@@ -84,7 +83,7 @@ async function initElasticApm() {
     defaultMeta: {
       serviceName,
     },
-    format: winston.format.combine(winston.format.json()),
+    format: winston.format.combine(winston.format.errors({ stack: true }), winston.format.json()),
     transports: [esTransport],
   });
 

--- a/packages/modelence/src/app/metrics.ts
+++ b/packages/modelence/src/app/metrics.ts
@@ -4,6 +4,7 @@ import { ElasticsearchTransport } from 'winston-elasticsearch';
 
 import { getConfig } from '../config/server';
 import { startLoggerProcess } from './loggerProcess';
+import { logError } from '../telemetry';
 import {
   getAppAlias,
   getEnvironmentAlias,
@@ -75,7 +76,7 @@ async function initElasticApm() {
   });
 
   esTransport.on('error', (error) => {
-    console.error('Elasticsearch Transport Error:', error);
+    logError('Elasticsearch Transport Error', { error });
   });
 
   logger = winston.createLogger({

--- a/packages/modelence/src/app/metrics.ts
+++ b/packages/modelence/src/app/metrics.ts
@@ -83,7 +83,7 @@ async function initElasticApm() {
     defaultMeta: {
       serviceName,
     },
-    format: winston.format.combine(winston.format.errors({ stack: true }), winston.format.json()),
+    format: winston.format.combine(winston.format.json()),
     transports: [esTransport],
   });
 

--- a/packages/modelence/src/app/server.test.ts
+++ b/packages/modelence/src/app/server.test.ts
@@ -106,6 +106,7 @@ vi.doMock('@/auth/providers/github', () => ({
 
 vi.doMock('@/telemetry', () => ({
   logInfo: mockLogInfo,
+  logError: mockLogInfo,
 }));
 
 vi.doMock('./securityConfig', () => ({

--- a/packages/modelence/src/app/server.test.ts
+++ b/packages/modelence/src/app/server.test.ts
@@ -56,6 +56,7 @@ const mockCreateRouteHandler =
 const mockGoogleAuthRouter = vi.fn();
 const mockGithubAuthRouter = vi.fn();
 const mockLogInfo = vi.fn();
+const mockLogError = vi.fn();
 const mockGetSecurityConfig = vi.fn();
 const mockGetWebsocketConfig = vi.fn();
 const mockExpressJson = vi.fn();
@@ -106,7 +107,7 @@ vi.doMock('@/auth/providers/github', () => ({
 
 vi.doMock('@/telemetry', () => ({
   logInfo: mockLogInfo,
-  logError: mockLogInfo,
+  logError: mockLogError,
 }));
 
 vi.doMock('./securityConfig', () => ({

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -4,7 +4,7 @@ import { runMethod } from '@/methods';
 import { getResponseTypeMap, sanitizeResult } from '@/methods/serialize';
 import { createRouteHandler } from '@/routes/handler';
 import { HttpMethod } from '@/server';
-import { logInfo } from '@/telemetry';
+import { logInfo, logError } from '@/telemetry';
 import cookieParser from 'cookie-parser';
 import express, { Request, Response } from 'express';
 import http from 'http';
@@ -162,16 +162,15 @@ export async function startServer(
   });
 
   process.on('unhandledRejection', (reason, promise) => {
-    console.error('Unhandled Promise Rejection:');
-    console.error(reason instanceof Error ? reason.stack : reason);
-    console.error('Promise:', promise);
+    logError('Unhandled Promise Rejection', {
+      reason: reason instanceof Error ? reason.stack : reason,
+      promise,
+    });
   });
 
   // Global uncaught exceptions
   process.on('uncaughtException', (error) => {
-    console.error('Uncaught Exception:');
-    console.error(error.stack); // This gives you the full stack trace
-    console.trace('Full application stack:'); // Additional context
+    logError('Uncaught Exception', { error });
   });
 
   const websocketProvider = getWebsocketConfig()?.provider;
@@ -264,7 +263,7 @@ function handleMethodError(res: Response, methodName: string, error: unknown) {
 
   if (error instanceof ModelenceError) {
     if (error.status >= 500 && error.status < 600) {
-      console.error(`Error calling ${methodName}:`, error);
+      logError('Error calling method', { methodName, error });
     }
     // Surface a machine-readable code (when present) via a header so clients can
     // branch on the error kind without parsing the human-readable message. The
@@ -281,14 +280,14 @@ function handleMethodError(res: Response, methodName: string, error: unknown) {
     try {
       errorMessage = parseZodError(error as z.ZodError);
     } catch (parsingError) {
-      console.error(`Error parsing Zod error in ${methodName}:`, parsingError);
+      logError('Error parsing Zod error', { methodName, parsingError });
       errorMessage = 'Validation failed';
     }
     res.status(400).send(errorMessage);
     return;
   }
 
-  console.error(`Error calling ${methodName}:`, error);
+  logError('Error calling method', { methodName, error });
   res.status(500).send(error instanceof Error ? error.message : String(error));
 }
 

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -280,7 +280,7 @@ function handleMethodError(res: Response, methodName: string, error: unknown) {
     try {
       errorMessage = parseZodError(error as z.ZodError);
     } catch (parsingError) {
-      logError('Error parsing Zod error', { methodName, parsingError });
+      logError('Error parsing Zod error', { methodName, error: parsingError });
       errorMessage = 'Validation failed';
     }
     res.status(400).send(errorMessage);

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -161,11 +161,8 @@ export async function startServer(
     Promise.resolve(server.handler(req, res)).catch(next);
   });
 
-  process.on('unhandledRejection', (reason, promise) => {
-    logError('Unhandled Promise Rejection', {
-      reason: reason instanceof Error ? reason.stack : reason,
-      promise,
-    });
+  process.on('unhandledRejection', (reason) => {
+    logError('Unhandled Promise Rejection', { error: reason });
   });
 
   // Global uncaught exceptions

--- a/packages/modelence/src/auth/login.test.ts
+++ b/packages/modelence/src/auth/login.test.ts
@@ -260,4 +260,23 @@ describe('auth/login', () => {
       'Session is not initialized'
     );
   });
+
+  test('throws ValidationError and skips rate limiting when user is already authenticated', async () => {
+    const activeUser = {
+      id: new ObjectId('507f1f77bcf86cd799439099'),
+      handle: 'existinguser',
+      roles: [],
+    };
+
+    const error = await handleLoginWithPassword(
+      { email: 'user@example.com', password: 'Secret123' },
+      { ...baseContext, user: activeUser } as never
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe('ValidationError');
+    expect((error as Error).message).toBe('User is already authenticated');
+    expect((error as { code?: string }).code).toBe('ALREADY_AUTHENTICATED');
+    expect(mockConsumeRateLimit).not.toHaveBeenCalled();
+  });
 });

--- a/packages/modelence/src/auth/login.ts
+++ b/packages/modelence/src/auth/login.ts
@@ -15,7 +15,7 @@ import { consumeRateLimit } from '@/server';
 import { validateEmail } from './validators';
 import { getAuthConfig } from '@/app/authConfig';
 import { getConfig } from '@/config/server';
-import { AuthError } from '../error';
+import { AuthError, ValidationError } from '../error';
 
 /**
  * Whether unverified emails should be blocked from logging in.
@@ -44,6 +44,10 @@ export async function handleLoginWithPassword(
       throw new Error('Session is not initialized');
     }
 
+    if (user) {
+      throw new ValidationError('User is already authenticated', 'ALREADY_AUTHENTICATED');
+    }
+
     const ip = connectionInfo?.ip;
     if (ip) {
       await consumeRateLimit({
@@ -58,10 +62,6 @@ export async function handleLoginWithPassword(
     const password = z.string().parse(args.password);
 
     // TODO: add rate limiting by email (and perhaps IP address overall)
-
-    if (user) {
-      // TODO: handle cases where a user is already logged in
-    }
 
     const userDoc = await usersCollection.findOne(
       { 'emails.address': email, status: { $nin: ['deleted', 'disabled'] } },

--- a/packages/modelence/src/auth/magicLink.test.ts
+++ b/packages/modelence/src/auth/magicLink.test.ts
@@ -840,14 +840,12 @@ describe('auth/magicLink', () => {
           expect(onAfterEmailVerification).toHaveBeenCalled();
           expect(onAfterLogin).toHaveBeenCalled();
           // Both failures are logged, not swallowed silently.
-          expect(consoleErrorSpy).toHaveBeenCalledWith(
-            'Error in onAfterEmailVerification hook:',
-            expect.any(Error)
-          );
-          expect(consoleErrorSpy).toHaveBeenCalledWith(
-            'Error in onAfterLogin hook:',
-            expect.any(Error)
-          );
+          expect(consoleErrorSpy).toHaveBeenCalledWith('Error in onAfterEmailVerification hook', {
+            error: expect.any(Error),
+          });
+          expect(consoleErrorSpy).toHaveBeenCalledWith('Error in onAfterLogin hook', {
+            error: expect.any(Error),
+          });
         } finally {
           consoleErrorSpy.mockRestore();
         }

--- a/packages/modelence/src/auth/magicLink.ts
+++ b/packages/modelence/src/auth/magicLink.ts
@@ -14,6 +14,7 @@ import { getConfig } from '@/config/server';
 import { isDisposableEmail } from './disposableEmails';
 import { setAuthTokenCookie, setSessionUser } from './session';
 import { hashToken } from './tokenHash';
+import { logError } from '@/telemetry';
 import { magicLinkTemplate } from './templates/magicLinkTemplate';
 import {
   resolveUrl,
@@ -63,10 +64,10 @@ const MAX_CODE_ATTEMPTS = 5;
 function fireAuthHook(name: string, invoke: (() => void | Promise<void>) | undefined) {
   try {
     Promise.resolve(invoke?.()).catch((hookError: unknown) => {
-      console.error(`Error in ${name} hook:`, hookError);
+      logError(`Error in ${name} hook`, { error: hookError });
     });
   } catch (hookError) {
-    console.error(`Error in ${name} hook:`, hookError);
+    logError(`Error in ${name} hook`, { error: hookError });
   }
 }
 
@@ -112,7 +113,9 @@ async function restoreClaimedMagicLinkToken(
   try {
     await magicLinkTokensCollection.insertOne(claimedToken);
   } catch (restoreError) {
-    console.error('Failed to restore a magic link token after a failed signup:', restoreError);
+    logError('Failed to restore a magic link token after a failed signup', {
+      error: restoreError,
+    });
   }
 }
 
@@ -277,7 +280,7 @@ export async function handleMagicLinkLanding(params: RouteParams): Promise<Route
   } catch (error) {
     // Surface a fixed, friendly message; never forward the raw error (ZodError or
     // DB error) into the redirect URL. Log the real cause server-side instead.
-    console.error('Error handling magic link landing:', error);
+    logError('Magic link landing failed', { error });
     const message = 'This sign-in link is invalid or has expired.';
     return {
       status: 302,

--- a/packages/modelence/src/auth/providers/github.ts
+++ b/packages/modelence/src/auth/providers/github.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@/server';
 import { time } from '@/time';
 import { randomBytes } from 'crypto';
+import { logError } from '@/telemetry';
 import {
   Router,
   type Request,
@@ -174,7 +175,7 @@ async function handleGitHubAuthenticationCallback(req: Request, res: Response) {
       await handleOAuthUserAuthentication(req, res, userData);
     }
   } catch (error) {
-    console.error('GitHub OAuth error:', error);
+    logError('GitHub OAuth error', { error });
     if (mode === 'link') {
       clearOAuthLinkCookie(res);
     }

--- a/packages/modelence/src/auth/providers/google.ts
+++ b/packages/modelence/src/auth/providers/google.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@/server';
 import { time } from '@/time';
 import { randomBytes } from 'crypto';
+import { logError } from '@/telemetry';
 import {
   Router,
   type Request,
@@ -122,7 +123,7 @@ async function handleGoogleAuthenticationCallback(req: Request, res: Response) {
       await handleOAuthUserAuthentication(req, res, userData);
     }
   } catch (error) {
-    console.error('Google OAuth error:', error);
+    logError('Google OAuth error', { error });
     if (mode === 'link') {
       clearOAuthLinkCookie(res);
     }

--- a/packages/modelence/src/auth/providers/oauth-common.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.ts
@@ -40,7 +40,7 @@ export function sendOAuthError(res: Response, statusCode: number, errorMessage: 
       const html = authConfig.errorComponent({ error: errorMessage, statusCode });
       if (html) return response.send(html);
     } catch (err) {
-      logError('Unhandled error in authConfig.errorComponent', { err });
+      logError('Unhandled error in authConfig.errorComponent', { error: err });
     }
   }
   return response.json({ error: errorMessage });
@@ -376,7 +376,7 @@ function safelyCallHook(hook?: () => void) {
   try {
     hook();
   } catch (err) {
-    logError('Error executing OAuth hook', { err });
+    logError('Error executing OAuth hook', { error: err });
   }
 }
 

--- a/packages/modelence/src/auth/providers/oauth-common.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.ts
@@ -5,6 +5,7 @@ import { createSession, setAuthTokenCookie, consumeLinkNonce } from '@/auth/sess
 import { getAuthConfig } from '@/app/authConfig';
 import { getCallContext } from '@/app/server';
 import { getConfig } from '@/config/server';
+import { logError } from '@/telemetry';
 import { resolveUniqueHandle } from '../utils';
 import { User, Session, UserEmail, OAuthProvider } from '@/auth/types';
 import { ConnectionInfo } from '@/methods/types';
@@ -39,7 +40,7 @@ export function sendOAuthError(res: Response, statusCode: number, errorMessage: 
       const html = authConfig.errorComponent({ error: errorMessage, statusCode });
       if (html) return response.send(html);
     } catch (err) {
-      console.error('Unhandled error in authConfig.errorComponent:', err);
+      logError('Unhandled error in authConfig.errorComponent', { err });
     }
   }
   return response.json({ error: errorMessage });
@@ -375,7 +376,7 @@ function safelyCallHook(hook?: () => void) {
   try {
     hook();
   } catch (err) {
-    console.error('Error executing OAuth hook:', err);
+    logError('Error executing OAuth hook', { err });
   }
 }
 

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -14,6 +14,7 @@ import { getConfig } from '@/config/server';
 import { invalidateAllUserSessions } from './session';
 import { hashToken } from './tokenHash';
 import { resolveUrl } from './utils';
+import { logError } from '@/telemetry';
 
 // Short-lived httpOnly cookie carrying the reset token from the landing route to
 // the `resetPassword` mutation, so it never appears on a client-rendered URL.
@@ -189,7 +190,7 @@ export async function handleResetPasswordLanding(params: RouteParams): Promise<R
   } catch (error) {
     // Surface a fixed, friendly message; never forward the raw error (ZodError or
     // DB error) into the redirect URL. Log the real cause server-side instead.
-    console.error('Error handling password reset landing:', error);
+    logError('Password reset landing failed', { error });
     const message = 'This password reset link is invalid or has expired.';
     return {
       status: 302,

--- a/packages/modelence/src/auth/signup.test.ts
+++ b/packages/modelence/src/auth/signup.test.ts
@@ -451,4 +451,25 @@ describe('auth/signup', () => {
     expect(authConfig.onBeforeSignup).not.toHaveBeenCalled();
     expect(mockInsertOne).not.toHaveBeenCalled();
   });
+
+  test('throws ValidationError and skips rate limiting and disposable checks when user is already authenticated', async () => {
+    const activeUser = {
+      id: createObjectId('existing-user-id'),
+      handle: 'existinguser',
+      roles: [],
+    };
+
+    const error = await handleSignupWithPassword(
+      { email: 'test@example.com', password: 'Secret123' },
+      { ...baseContext, user: activeUser as never }
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe('ValidationError');
+    expect((error as Error).message).toBe('User is already authenticated');
+    expect((error as { code?: string }).code).toBe('ALREADY_AUTHENTICATED');
+    expect(mockConsumeRateLimit).not.toHaveBeenCalled();
+    expect(mockIsDisposableEmail).not.toHaveBeenCalled();
+    expect(mockFindOne).not.toHaveBeenCalled();
+  });
 });

--- a/packages/modelence/src/auth/signup.ts
+++ b/packages/modelence/src/auth/signup.ts
@@ -7,6 +7,7 @@ import { sendVerificationEmail } from './verification';
 import { validateEmail, validatePassword, validateProfileFields } from './validators';
 import { getAuthConfig } from '@/app/authConfig';
 import { resolveUniqueHandle, isDuplicateEmailError } from './utils';
+import { ValidationError } from '../error';
 
 export async function handleSignupWithPassword(
   props: Args,
@@ -14,6 +15,10 @@ export async function handleSignupWithPassword(
 ) {
   const authConfig = getAuthConfig();
   try {
+    if (user) {
+      throw new ValidationError('User is already authenticated', 'ALREADY_AUTHENTICATED');
+    }
+
     // Narrow once at the boundary
     const signupProps = props as SignupProps;
     const { firstName, lastName, avatarUrl, handle } = signupProps;
@@ -35,10 +40,6 @@ export async function handleSignupWithPassword(
     }
 
     // TODO: captcha check
-
-    if (user) {
-      // TODO: handle cases where a user is already logged in
-    }
 
     const existingUser = await usersCollection.findOne(
       { 'emails.address': email },

--- a/packages/modelence/src/auth/verification.ts
+++ b/packages/modelence/src/auth/verification.ts
@@ -14,6 +14,7 @@ import { validateEmail } from './validators';
 import { consumeRateLimit } from '@/rate-limit/rules';
 import { getConfig } from '@/config/server';
 import { createSession, setAuthTokenCookie } from './session';
+import { logError } from '@/telemetry';
 
 async function verifyEmailToken(token: string) {
   const tokenDoc = await emailVerificationTokensCollection.findOne({
@@ -122,7 +123,7 @@ export async function handleVerifyEmail(params: RouteParams): Promise<RouteRespo
           referrer: params.headers['referer'],
         },
       });
-      console.error('Error verifying email:', error);
+      logError('Email verification failed', { error });
     }
 
     return {

--- a/packages/modelence/src/config/sync.ts
+++ b/packages/modelence/src/config/sync.ts
@@ -2,6 +2,7 @@ import { time } from '../time';
 import { fetchConfigs, syncStatus } from '../app/backendApi';
 import { getLocalConfigs } from './local';
 import { loadConfigs, getSchema } from './server';
+import { logError } from '../telemetry';
 import { AppConfig } from './types';
 
 let isSyncing = false;
@@ -20,13 +21,13 @@ export function startConfigSync() {
     try {
       await syncStatus();
     } catch (error) {
-      console.error('Error syncing status', error);
+      logError('Config sync status failed', { error });
     }
 
     try {
       await syncConfig();
     } catch (error) {
-      console.error('Error syncing config', error);
+      logError('Config sync failed', { error });
     }
 
     isSyncing = false;

--- a/packages/modelence/src/cron/jobs.test.ts
+++ b/packages/modelence/src/cron/jobs.test.ts
@@ -27,6 +27,7 @@ function registerMocks() {
   vi.doMock('@/telemetry', () => ({
     startTransaction: mockStartTransaction,
     captureError: mockCaptureError,
+    logError: vi.fn(),
   }));
 
   vi.doMock('../data/store', () => ({

--- a/packages/modelence/src/cron/jobs.test.ts
+++ b/packages/modelence/src/cron/jobs.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { Mock, MockInstance } from 'vitest';
 
 const mockSeconds = vi.fn((value: number) => value * 1000);
@@ -8,11 +8,13 @@ const mockStartTransaction = vi.fn(() => ({
   end: vi.fn(),
 }));
 const mockCaptureError = vi.fn();
+const mockLogError = vi.fn();
 const mockAcquireLock: Mock = vi.fn();
+const mockGetMongodbUri = vi.fn();
 
-const cronStoreMocks: { fetch: Mock; updateOne: Mock } = {
+const cronStoreMocks: { fetch: Mock; upsertOne: Mock } = {
   fetch: vi.fn(),
-  updateOne: vi.fn(),
+  upsertOne: vi.fn(),
 };
 
 function registerMocks() {
@@ -27,7 +29,7 @@ function registerMocks() {
   vi.doMock('@/telemetry', () => ({
     startTransaction: mockStartTransaction,
     captureError: mockCaptureError,
-    logError: vi.fn(),
+    logError: mockLogError,
   }));
 
   vi.doMock('../data/store', () => ({
@@ -36,6 +38,10 @@ function registerMocks() {
 
   vi.doMock('../lock/helpers', () => ({
     acquireLock: mockAcquireLock,
+  }));
+
+  vi.doMock('@/db/client', () => ({
+    getMongodbUri: mockGetMongodbUri,
   }));
 }
 
@@ -53,8 +59,9 @@ describe('cron/jobs', () => {
     vi.resetModules();
     Object.assign(cronStoreMocks, {
       fetch: vi.fn(),
-      updateOne: vi.fn().mockResolvedValue(undefined as never),
+      upsertOne: vi.fn().mockResolvedValue(undefined as never),
     });
+    mockGetMongodbUri.mockReturnValue('mongodb://localhost:27017/test');
     mockAcquireLock.mockResolvedValue(true as never);
     intervalCallback = null;
     intervalDelay = undefined;
@@ -125,12 +132,55 @@ describe('cron/jobs', () => {
     (Date.now as Mock).mockRestore();
   });
 
+  test('startCronJobs skips starting cron jobs and logs message when MongoDB URI is not set', async () => {
+    mockGetMongodbUri.mockReturnValue('');
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    defineCronJob('noDbJob', {
+      description: 'no db',
+      interval: mockSeconds(10),
+      handler: async () => {},
+    });
+
+    await startCronJobs();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('MongoDB URI is not configured')
+    );
+    expect(cronStoreMocks.fetch).not.toHaveBeenCalled();
+    expect(setIntervalMock).not.toHaveBeenCalled();
+    consoleLogSpy.mockRestore();
+  });
+
+  test('startCronJobs uses lastStartDate from DB when present to schedule next run', async () => {
+    const now = 1_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const lastRun = new Date(now - 5_000);
+    cronStoreMocks.fetch.mockResolvedValueOnce([
+      { alias: 'existingJob', lastStartDate: lastRun },
+    ] as never);
+
+    defineCronJob('existingJob', {
+      interval: mockSeconds(10),
+      handler: async () => {},
+    });
+
+    await startCronJobs();
+
+    expect(cronStoreMocks.fetch).toHaveBeenCalledWith({
+      alias: { $in: ['existingJob'] },
+    });
+    expect(intervalDelay).toBe(mockSeconds(1));
+    (Date.now as Mock).mockRestore();
+  });
+
   test('startCronJobs no-ops when no cron jobs defined', async () => {
     await startCronJobs();
     expect(cronStoreMocks.fetch).not.toHaveBeenCalled();
     expect(setIntervalMock).not.toHaveBeenCalled();
   });
-  test('cron loop executes job handler and records completion', async () => {
+
+  test('cron loop executes job handler and records completion using upsertOne', async () => {
     const handler = vi.fn(async () => {});
     cronStoreMocks.fetch.mockResolvedValue([] as never);
     defineCronJob('hourly', {
@@ -145,10 +195,11 @@ describe('cron/jobs', () => {
 
     expect(mockAcquireLock).toHaveBeenCalled();
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(cronStoreMocks.updateOne).toHaveBeenCalledWith(
+    expect(cronStoreMocks.upsertOne).toHaveBeenCalledWith(
       { alias: 'hourly' },
       {
         $set: { lastStartDate: expect.any(Date) },
+        $setOnInsert: { alias: 'hourly' },
       }
     );
     const transactionCall = (mockStartTransaction as Mock).mock.calls.slice(-1)[0];

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -2,7 +2,7 @@
 
 import { time } from '../time';
 import { CronJob, CronJobInputParams } from './types';
-import { startTransaction, captureError } from '@/telemetry';
+import { startTransaction, captureError, logError } from '@/telemetry';
 import { Module } from '../app/module';
 import { schema } from '../data/types';
 import { Store } from '../data/store';
@@ -142,7 +142,7 @@ async function runCronJob(job: CronJob) {
     const error = err instanceof Error ? err : new Error(String(err));
     captureError(error);
     transaction.end('error');
-    console.error(`Error in cron job '${alias}':`, err);
+    logError('Cron job failed', { alias, err });
   }
 }
 

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -142,7 +142,7 @@ async function runCronJob(job: CronJob) {
     const error = err instanceof Error ? err : new Error(String(err));
     captureError(error);
     transaction.end('error');
-    logError('Cron job failed', { alias, err });
+    logError('Cron job failed', { alias, error: err });
   }
 }
 

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -7,6 +7,7 @@ import { Module } from '../app/module';
 import { schema } from '../data/types';
 import { Store } from '../data/store';
 import { acquireLock } from '../lock/helpers';
+import { getMongodbUri } from '@/db/client';
 
 const cronJobs: Record<string, CronJob> = {};
 let cronJobsInterval: NodeJS.Timeout | null = null;
@@ -64,6 +65,11 @@ export async function startCronJobs() {
 
   const aliasList = Object.keys(cronJobs);
   if (aliasList.length > 0) {
+    if (!getMongodbUri()) {
+      console.log('MongoDB URI is not configured. Skipping cron jobs.');
+      return;
+    }
+
     const aliasSelector = { alias: { $in: aliasList } };
 
     const cronJobRecords = await cronJobsCollection.fetch(aliasSelector);
@@ -77,6 +83,7 @@ export async function startCronJobs() {
         ? record.lastStartDate.getTime() + job.params.interval
         : now;
     });
+
     Object.values(cronJobs).forEach((job) => {
       if (!job.state.scheduledRunTs) {
         job.state.scheduledRunTs = now;
@@ -122,12 +129,11 @@ async function runCronJob(job: CronJob) {
   state.isRunning = true;
   state.startTs = Date.now();
 
-  await cronJobsCollection.updateOne(
+  await cronJobsCollection.upsertOne(
     { alias },
     {
-      $set: {
-        lastStartDate: new Date(state.startTs),
-      },
+      $set: { lastStartDate: new Date(state.startTs) },
+      $setOnInsert: { alias },
     }
   );
 

--- a/packages/modelence/src/data/store.test.ts
+++ b/packages/modelence/src/data/store.test.ts
@@ -208,7 +208,9 @@ describe('data/store', () => {
     await expect(store.createIndexes()).rejects.toBe(duplicateError);
 
     expect(consoleError).toHaveBeenCalledTimes(1);
-    const report = consoleError.mock.calls[0]?.[0] as string;
+    const [message, context] = consoleError.mock.calls[0] as [string, { report?: string }];
+    expect(message).toBe('Unique index creation failed on existing data');
+    const report = context?.report;
     expect(report).toContain('[modelence:index-error]');
     expect(report).toContain("collection 'testCollection'");
     expect(report).toContain('db.getCollection("testCollection").aggregate(');

--- a/packages/modelence/src/data/store.ts
+++ b/packages/modelence/src/data/store.ts
@@ -38,6 +38,7 @@ import { ModelSchema, InferDocumentType } from './types';
 import { serializeModelSchema } from './schemaSerializer';
 import { applyDefaultsToModelSchema } from './schemaDefaults';
 import { isUniqueIndexViolation, formatUniqueIndexViolationReport } from './indexErrors';
+import { logError } from '@/telemetry';
 
 /**
  * Result of {@link Store.findOneAndUpsert}: the post-op document plus whether
@@ -722,7 +723,11 @@ export class Store<
             // (the constraint stays unenforced), so log an actionable report an
             // operator or AI agent can resolve, then let the error propagate.
             if (index.unique && isUniqueIndexViolation(error)) {
-              console.error(formatUniqueIndexViolationReport(this.name, index, error));
+              logError('Unique index creation failed on existing data', {
+                store: this.name,
+                index: index.name,
+                report: formatUniqueIndexViolationReport(this.name, index, error),
+              });
             }
             throw error;
           }

--- a/packages/modelence/src/db/client.test.ts
+++ b/packages/modelence/src/db/client.test.ts
@@ -165,7 +165,9 @@ describe('db/client', () => {
       mockConnect.mockRejectedValue(connectionError);
 
       await expect(connect()).rejects.toThrow('Failed to connect');
-      expect(console.error).toHaveBeenCalledWith(connectionError);
+      expect(console.error).toHaveBeenCalledWith('MongoDB connection failed', {
+        err: connectionError,
+      });
     });
 
     test('resets client to null on connection failure', async () => {
@@ -187,7 +189,7 @@ describe('db/client', () => {
       mockCommand.mockRejectedValue(pingError);
 
       await expect(connect()).rejects.toThrow('Ping failed');
-      expect(console.error).toHaveBeenCalledWith(pingError);
+      expect(console.error).toHaveBeenCalledWith('MongoDB connection failed', { err: pingError });
     });
 
     test('connects to admin database for ping command', async () => {

--- a/packages/modelence/src/db/client.test.ts
+++ b/packages/modelence/src/db/client.test.ts
@@ -166,7 +166,7 @@ describe('db/client', () => {
 
       await expect(connect()).rejects.toThrow('Failed to connect');
       expect(console.error).toHaveBeenCalledWith('MongoDB connection failed', {
-        err: connectionError,
+        error: connectionError,
       });
     });
 
@@ -189,7 +189,7 @@ describe('db/client', () => {
       mockCommand.mockRejectedValue(pingError);
 
       await expect(connect()).rejects.toThrow('Ping failed');
-      expect(console.error).toHaveBeenCalledWith('MongoDB connection failed', { err: pingError });
+      expect(console.error).toHaveBeenCalledWith('MongoDB connection failed', { error: pingError });
     });
 
     test('connects to admin database for ping command', async () => {

--- a/packages/modelence/src/db/client.ts
+++ b/packages/modelence/src/db/client.ts
@@ -1,5 +1,6 @@
 import { MongoClient } from 'mongodb';
 import systemModule from '../system';
+import { logError } from '../telemetry';
 import packageJson from '../../package.json';
 
 let client: MongoClient | null = null;
@@ -31,7 +32,7 @@ export async function connect() {
     console.log('Pinged your deployment. You successfully connected to MongoDB!');
     return client;
   } catch (err) {
-    console.error(err);
+    logError('MongoDB connection failed', { err });
     client = null;
     throw err;
   }

--- a/packages/modelence/src/db/client.ts
+++ b/packages/modelence/src/db/client.ts
@@ -32,7 +32,7 @@ export async function connect() {
     console.log('Pinged your deployment. You successfully connected to MongoDB!');
     return client;
   } catch (err) {
-    logError('MongoDB connection failed', { err });
+    logError('MongoDB connection failed', { error: err });
     client = null;
     throw err;
   }

--- a/packages/modelence/src/error.ts
+++ b/packages/modelence/src/error.ts
@@ -20,9 +20,10 @@ export class AuthError extends ModelenceError {
 export class ValidationError extends ModelenceError {
   status = 400;
 
-  constructor(message: string) {
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'ValidationError';
+    this.code = code;
   }
 }
 

--- a/packages/modelence/src/live-query/handlers.ts
+++ b/packages/modelence/src/live-query/handlers.ts
@@ -5,6 +5,7 @@ import { runLiveMethod } from '../methods';
 import { getResponseTypeMap, sanitizeResult } from '../methods/serialize';
 import { LiveQueryCleanup } from './context';
 import { Context } from '@/methods/types';
+import { logError } from '@/telemetry';
 
 interface ActiveSubscription {
   cleanup: LiveQueryCleanup | null;
@@ -59,7 +60,7 @@ export async function handleSubscribeLiveQuery(socket: Socket, payload: unknown)
       try {
         existingSub.cleanup();
       } catch (err) {
-        console.error('[LiveQuery] Error cleaning up existing subscription:', err);
+        logError('LiveQuery cleanup of existing subscription failed', { method, error: err });
       }
     } else {
       // Subscription is still initializing - mark it for abort so it cleans up when ready
@@ -123,7 +124,7 @@ export async function handleSubscribeLiveQuery(socket: Socket, payload: unknown)
           if (subscription.aborted) {
             return;
           }
-          console.error(`[LiveQuery] Error fetching data for ${method}:`, err);
+          logError('LiveQuery data fetch failed', { method, error: err });
           socket.emit('liveQueryError', {
             subscriptionId,
             error: err instanceof Error ? err.message : String(err),
@@ -154,7 +155,10 @@ export async function handleSubscribeLiveQuery(socket: Socket, payload: unknown)
         try {
           cleanup();
         } catch (err) {
-          console.error('[LiveQuery] Error cleaning up after disconnect during setup:', err);
+          logError('LiveQuery cleanup after disconnect during setup failed', {
+            method,
+            error: err,
+          });
         }
       }
       return;
@@ -166,7 +170,7 @@ export async function handleSubscribeLiveQuery(socket: Socket, payload: unknown)
     processPendingPublish();
   } catch (error) {
     subs.delete(subscriptionId);
-    console.error(`[LiveQuery] Error in ${method}:`, error);
+    logError('LiveQuery subscription failed', { method, error });
     socket.emit('liveQueryError', {
       subscriptionId,
       error: error instanceof Error ? error.message : String(error),
@@ -195,7 +199,7 @@ export function handleUnsubscribeLiveQuery(socket: Socket, payload: unknown) {
       try {
         sub.cleanup();
       } catch (err) {
-        console.error('[LiveQuery] Error in cleanup:', err);
+        logError('LiveQuery cleanup failed', { error: err });
       }
     } else {
       sub.aborted = true;
@@ -213,7 +217,7 @@ export function handleLiveQueryDisconnect(socket: Socket) {
         try {
           sub.cleanup();
         } catch (err) {
-          console.error('[LiveQuery] Error in cleanup on disconnect:', err);
+          logError('LiveQuery cleanup on disconnect failed', { error: err });
         }
       } else {
         sub.aborted = true;

--- a/packages/modelence/src/migration/index.test.ts
+++ b/packages/modelence/src/migration/index.test.ts
@@ -148,7 +148,7 @@ describe('migration/index', () => {
 
     expect(mockAcquireLock).toHaveBeenCalledWith('migrations');
     expect(mockLogInfo).toHaveBeenCalledWith('Migration startup failed', {
-      err: expect.any(Error),
+      error: expect.any(Error),
     });
 
     consoleError.mockRestore();

--- a/packages/modelence/src/migration/index.test.ts
+++ b/packages/modelence/src/migration/index.test.ts
@@ -13,6 +13,7 @@ vi.doMock('@/lock', () => ({
 
 vi.doMock('../telemetry', () => ({
   logInfo: mockLogInfo,
+  logError: mockLogInfo,
 }));
 
 vi.doMock('./db', () => ({
@@ -146,7 +147,9 @@ describe('migration/index', () => {
     await Promise.resolve();
 
     expect(mockAcquireLock).toHaveBeenCalledWith('migrations');
-    expect(consoleError).toHaveBeenCalledWith('Error running migrations:', expect.any(Error));
+    expect(mockLogInfo).toHaveBeenCalledWith('Migration startup failed', {
+      err: expect.any(Error),
+    });
 
     consoleError.mockRestore();
   });

--- a/packages/modelence/src/migration/index.test.ts
+++ b/packages/modelence/src/migration/index.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 const mockAcquireLock = vi.fn();
 const mockReleaseLock = vi.fn();
 const mockLogInfo = vi.fn();
+const mockLogError = vi.fn();
 const mockFetch = vi.fn();
 const mockUpsertOne = vi.fn();
 
@@ -13,7 +14,7 @@ vi.doMock('@/lock', () => ({
 
 vi.doMock('../telemetry', () => ({
   logInfo: mockLogInfo,
-  logError: mockLogInfo,
+  logError: mockLogError,
 }));
 
 vi.doMock('./db', () => ({
@@ -136,7 +137,6 @@ describe('migration/index', () => {
 
   test('startMigrations schedules execution and logs errors', async () => {
     vi.useFakeTimers();
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockAcquireLock.mockRejectedValue(new Error('lock failure') as never);
 
     startMigrations([{ version: 1, description: 'one', handler: async () => undefined }]);
@@ -147,10 +147,8 @@ describe('migration/index', () => {
     await Promise.resolve();
 
     expect(mockAcquireLock).toHaveBeenCalledWith('migrations');
-    expect(mockLogInfo).toHaveBeenCalledWith('Migration startup failed', {
+    expect(mockLogError).toHaveBeenCalledWith('Migration startup failed', {
       error: expect.any(Error),
     });
-
-    consoleError.mockRestore();
   });
 });

--- a/packages/modelence/src/migration/index.ts
+++ b/packages/modelence/src/migration/index.ts
@@ -109,7 +109,7 @@ export async function runMigrations(
 export function startMigrations(migrations: MigrationScript[]) {
   setTimeout(() => {
     runMigrations(migrations).catch((err) => {
-      logError('Migration startup failed', { err });
+      logError('Migration startup failed', { error: err });
     });
   }, 0);
 }

--- a/packages/modelence/src/migration/index.ts
+++ b/packages/modelence/src/migration/index.ts
@@ -1,7 +1,7 @@
 import { acquireLock, releaseLock } from '@/lock';
 import { Module } from '../app/module';
 import { dbMigrations } from './db';
-import { logInfo } from '../telemetry';
+import { logInfo, logError } from '../telemetry';
 
 export type MigrationScript = {
   version: number;
@@ -109,7 +109,7 @@ export async function runMigrations(
 export function startMigrations(migrations: MigrationScript[]) {
   setTimeout(() => {
     runMigrations(migrations).catch((err) => {
-      console.error('Error running migrations:', err);
+      logError('Migration startup failed', { err });
     });
   }, 0);
 }

--- a/packages/modelence/src/routes/handler.test.ts
+++ b/packages/modelence/src/routes/handler.test.ts
@@ -33,6 +33,7 @@ function redactSensitive(value: unknown): unknown {
 vi.doMock('../telemetry', () => ({
   startTransaction: mockStartTransaction,
   redactSensitive,
+  logError: vi.fn(),
 }));
 
 const { ValidationError } = await import('../error');

--- a/packages/modelence/src/routes/handler.ts
+++ b/packages/modelence/src/routes/handler.ts
@@ -4,7 +4,7 @@ import { ModelenceError } from '../error';
 import { authenticate } from '../auth';
 import { getMongodbUri } from '../db/client';
 import type { Context } from '../methods/types';
-import { startTransaction, redactSensitive } from '../telemetry';
+import { startTransaction, redactSensitive, logError } from '../telemetry';
 
 // TODO: Use cookies for authentication and automatically add session/user to context if accessing from browser
 export function createRouteHandler(method: string, path: string, handler: RouteHandler) {
@@ -78,8 +78,7 @@ export function createRouteHandler(method: string, path: string, handler: RouteH
       if (error instanceof ModelenceError) {
         res.status(error.status).send(error.message);
       } else {
-        console.error(`Error in route handler: ${req.path}`);
-        console.error(error);
+        logError('Error in route handler', { path: req.path, error });
         res.status(500).send(String(error));
       }
     }

--- a/packages/modelence/src/telemetry/index.test.ts
+++ b/packages/modelence/src/telemetry/index.test.ts
@@ -194,6 +194,48 @@ describe('telemetry/index', () => {
     expect(consoleError).not.toHaveBeenCalled();
   });
 
+  test('logError does not log to console when logger is not ready and log level is not set', () => {
+    mockIsTelemetryEnabled.mockReturnValue(true);
+    mockIsLoggerReady.mockReturnValue(false);
+
+    telemetry.logError('error-msg', { foo: 'bar' });
+
+    expect(mockGetLogger).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('logError normalizes Error instances for the remote sink', () => {
+    process.env.MODELENCE_LOG_LEVEL = 'error';
+    mockIsTelemetryEnabled.mockReturnValue(true);
+    const logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn() };
+    mockGetLogger.mockReturnValue(logger);
+    mockIsLoggerReady.mockReturnValue(true);
+    const error = new Error('boom');
+
+    telemetry.logError('error-msg', { path: '/api/x', error });
+
+    expect(logger.error).toHaveBeenCalledWith('error-msg', {
+      path: '/api/x',
+      error: { message: 'boom', stack: error.stack, name: 'Error' },
+    });
+    expect(consoleError).toHaveBeenCalledWith('error-msg', { path: '/api/x', error });
+  });
+
+  test('logError redacts sensitive keys before sending to the remote sink', () => {
+    mockIsTelemetryEnabled.mockReturnValue(true);
+    const logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn() };
+    mockGetLogger.mockReturnValue(logger);
+    mockIsLoggerReady.mockReturnValue(true);
+
+    telemetry.logError('error-msg', { token: 'raw', nested: { authToken: 't' }, email: 'a@b.com' });
+
+    expect(logger.error).toHaveBeenCalledWith('error-msg', {
+      token: '[redacted]',
+      nested: { authToken: '[redacted]' },
+      email: 'a@b.com',
+    });
+  });
+
   test('startTransaction returns noop handlers when telemetry disabled', () => {
     mockIsTelemetryEnabled.mockReturnValue(false);
 

--- a/packages/modelence/src/telemetry/index.test.ts
+++ b/packages/modelence/src/telemetry/index.test.ts
@@ -194,14 +194,37 @@ describe('telemetry/index', () => {
     expect(consoleError).not.toHaveBeenCalled();
   });
 
-  test('logError does not log to console when logger is not ready and log level is not set', () => {
+  test('logError falls back to console when logger is not ready and log level is not set', () => {
     mockIsTelemetryEnabled.mockReturnValue(true);
     mockIsLoggerReady.mockReturnValue(false);
 
     telemetry.logError('error-msg', { foo: 'bar' });
 
     expect(mockGetLogger).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith('error-msg', { foo: 'bar' });
+  });
+
+  test('logError stops console output once the logger is ready without a log level', () => {
+    mockIsTelemetryEnabled.mockReturnValue(true);
+    const logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn() };
+    mockGetLogger.mockReturnValue(logger);
+    mockIsLoggerReady.mockReturnValue(true);
+
+    telemetry.logError('error-msg', { foo: 'bar' });
+
+    expect(logger.error).toHaveBeenCalledWith('error-msg', { foo: 'bar' });
     expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('logInfo and logDebug fall back to console when logger is not ready', () => {
+    mockIsTelemetryEnabled.mockReturnValue(true);
+    mockIsLoggerReady.mockReturnValue(false);
+
+    telemetry.logInfo('info-msg', { foo: 'bar' });
+    telemetry.logDebug('debug-msg', { foo: 'bar' });
+
+    expect(consoleInfo).toHaveBeenCalledWith('info-msg', { foo: 'bar' });
+    expect(consoleDebug).toHaveBeenCalledWith('debug-msg', { foo: 'bar' });
   });
 
   test('logError normalizes Error instances for the remote sink', () => {

--- a/packages/modelence/src/telemetry/index.ts
+++ b/packages/modelence/src/telemetry/index.ts
@@ -49,7 +49,7 @@ export function logDebug(message: string, args: object) {
   if (isTelemetryEnabled() && isLoggerReady()) {
     getLogger().debug(message, args);
   }
-  if (getLogLevel() === 'debug') {
+  if (getLogLevel() === 'debug' || (isTelemetryEnabled() && !isLoggerReady())) {
     console.debug(message, args);
   }
 }
@@ -58,7 +58,7 @@ export function logInfo(message: string, args: object) {
   if (isTelemetryEnabled() && isLoggerReady()) {
     getLogger().info(message, args);
   }
-  if (['debug', 'info'].includes(getLogLevel())) {
+  if (['debug', 'info'].includes(getLogLevel()) || (isTelemetryEnabled() && !isLoggerReady())) {
     console.info(message, args);
   }
 }
@@ -67,7 +67,10 @@ export function logError(message: string, args: object) {
   if (isTelemetryEnabled() && isLoggerReady()) {
     getLogger().error(message, args);
   }
-  if (['debug', 'info', 'error'].includes(getLogLevel())) {
+  if (
+    ['debug', 'info', 'error'].includes(getLogLevel()) ||
+    (isTelemetryEnabled() && !isLoggerReady())
+  ) {
     console.error(message, args);
   }
 }

--- a/packages/modelence/src/telemetry/index.ts
+++ b/packages/modelence/src/telemetry/index.ts
@@ -45,11 +45,37 @@ function getLogLevel(): LogLevel {
   return (process.env.MODELENCE_LOG_LEVEL as LogLevel) || defaultLoglevel;
 }
 
+/**
+ * Whether `level` should also be written to the console.
+ *
+ * Normal rule: the configured level (see {@link getLogLevel}) must allow it —
+ * telemetry-enabled deployments send to Elastic, not stdout, unless
+ * MODELENCE_LOG_LEVEL is set.
+ *
+ * Bootstrap exception: while telemetry is enabled but the Winston logger is
+ * not ready yet (startup runs `setMetadata` → `connect()` → index/migration
+ * creation → `initMetrics`), there is no Elastic sink, so output falls back
+ * to the console to avoid silently dropping startup errors (e.g. MongoDB
+ * connect failures, unique-index violation reports).
+ *
+ * This cannot feed back into the logger: `startLoggerProcess` is only started
+ * after the logger is created, so once its stdout/stderr capture loop runs,
+ * `isLoggerReady()` is already true and this branch is off.
+ */
+function shouldLogToConsole(level: Exclude<LogLevel, ''>): boolean {
+  const enabledLevels: Record<Exclude<LogLevel, ''>, LogLevel[]> = {
+    debug: ['debug'],
+    info: ['debug', 'info'],
+    error: ['debug', 'info', 'error'],
+  };
+  return enabledLevels[level].includes(getLogLevel()) || (isTelemetryEnabled() && !isLoggerReady());
+}
+
 export function logDebug(message: string, args: object) {
   if (isTelemetryEnabled() && isLoggerReady()) {
     getLogger().debug(message, args);
   }
-  if (getLogLevel() === 'debug') {
+  if (shouldLogToConsole('debug')) {
     console.debug(message, args);
   }
 }
@@ -58,7 +84,7 @@ export function logInfo(message: string, args: object) {
   if (isTelemetryEnabled() && isLoggerReady()) {
     getLogger().info(message, args);
   }
-  if (['debug', 'info'].includes(getLogLevel())) {
+  if (shouldLogToConsole('info')) {
     console.info(message, args);
   }
 }
@@ -89,7 +115,7 @@ export function logError(message: string, args: object) {
   if (isTelemetryEnabled() && isLoggerReady()) {
     getLogger().error(message, redactSensitive(normalizeErrors(args)) as object);
   }
-  if (['debug', 'info', 'error'].includes(getLogLevel())) {
+  if (shouldLogToConsole('error')) {
     console.error(message, args);
   }
 }

--- a/packages/modelence/src/telemetry/index.ts
+++ b/packages/modelence/src/telemetry/index.ts
@@ -49,7 +49,7 @@ export function logDebug(message: string, args: object) {
   if (isTelemetryEnabled() && isLoggerReady()) {
     getLogger().debug(message, args);
   }
-  if (getLogLevel() === 'debug' || (isTelemetryEnabled() && !isLoggerReady())) {
+  if (getLogLevel() === 'debug') {
     console.debug(message, args);
   }
 }
@@ -58,19 +58,38 @@ export function logInfo(message: string, args: object) {
   if (isTelemetryEnabled() && isLoggerReady()) {
     getLogger().info(message, args);
   }
-  if (['debug', 'info'].includes(getLogLevel()) || (isTelemetryEnabled() && !isLoggerReady())) {
+  if (['debug', 'info'].includes(getLogLevel())) {
     console.info(message, args);
   }
 }
 
+/**
+ * Replaces any {@link Error} in `args` with `{ message, stack, name }` so the
+ * payload survives JSON serialization to the remote sink (Errors otherwise
+ * serialize to `{}`).
+ */
+function normalizeErrors(args: object): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    result[key] =
+      value instanceof Error
+        ? { message: value.message, stack: value.stack, name: value.name }
+        : value;
+  }
+  return result;
+}
+
+/**
+ * Logs an error. Before the payload is sent to the remote (Elastic) sink,
+ * {@link Error} values are normalized for JSON serialization and
+ * {@link SENSITIVE_KEYS} matches are redacted. Console output keeps the raw
+ * values for local debugging.
+ */
 export function logError(message: string, args: object) {
   if (isTelemetryEnabled() && isLoggerReady()) {
-    getLogger().error(message, args);
+    getLogger().error(message, redactSensitive(normalizeErrors(args)) as object);
   }
-  if (
-    ['debug', 'info', 'error'].includes(getLogLevel()) ||
-    (isTelemetryEnabled() && !isLoggerReady())
-  ) {
+  if (['debug', 'info', 'error'].includes(getLogLevel())) {
     console.error(message, args);
   }
 }

--- a/packages/modelence/src/websocket/socketio/server.ts
+++ b/packages/modelence/src/websocket/socketio/server.ts
@@ -11,6 +11,7 @@ import {
   handleUnsubscribeLiveQuery,
   handleLiveQueryDisconnect,
 } from '@/live-query';
+import { logError } from '@/telemetry';
 import type { Collection, Document } from 'mongodb';
 
 let socketServer: SocketServer | null = null;
@@ -49,13 +50,12 @@ export async function init({
             { expireAfterSeconds: ADAPTER_TTL_SECONDS, background: true }
           );
         } catch (retryError: unknown) {
-          console.error(
-            'Failed to recreate index on MongoDB collection for Socket.IO:',
-            retryError
-          );
+          logError('Failed to recreate Socket.IO MongoDB index', {
+            error: retryError,
+          });
         }
       } else {
-        console.error('Failed to create index on MongoDB collection for Socket.IO:', error);
+        logError('Failed to create Socket.IO MongoDB index', { error });
       }
     }
   }
@@ -71,7 +71,7 @@ export async function init({
   });
 
   socketServer.on('error', (error) => {
-    console.error('Socket.IO error:', error);
+    logError('Socket.IO error', { error });
   });
 
   socketServer.use(async (socket, next) => {


### PR DESCRIPTION
## Summary

Replaces ad-hoc `console.error` calls with `logError` from the telemetry module so errors are logged as a message plus a structured context object (e.g. `{ error, methodName, path, alias }`) instead of string concatenation.

Coverage spans **app startup** (cloud connect, cron startup, background indexes/migrations), **HTTP** (unhandled rejections/exceptions, method and route handler failures), **auth** (OAuth providers, magic link, password reset landing, email verification), **infra** (MongoDB connect, config sync, cron jobs, Socket.IO, live-query handlers, store index creation), and related tests/mocks. `bin/`, `client/`, and `viteServer.ts` are intentionally left alone (CLI/dev-server output).

## Telemetry changes

- `logError` normalizes `Error` instances into `{ message, stack, name }` before the payload is sent to the remote (Elastic) sink, so stack traces survive JSON serialization (previously Errors serialized to `{}`).
- `logError` applies `redactSensitive` (token/password/secret/nonce/code keys) to the payload shipped to the remote sink; console output keeps raw values for local debugging.
- Console logging behavior is unchanged and matches the documented contract: telemetry enabled + no `MODELENCE_LOG_LEVEL` ⇒ no console logging.

## Notes

- All context objects use the consistent `{ error }` key (unhandled rejections previously used `{ reason, promise }`; the `promise` field serialized to `{}` and was dropped).
- Test mocks for `logError` are now distinct from `logInfo` so assertions can fail correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad logging refactor plus auth validation and cron scheduling/persistence behavior; changes are mostly observability and edge cases but touch critical startup and sign-in paths.
> 
> **Overview**
> Replaces scattered **`console.error`** calls with **`logError`** from the telemetry module so failures are recorded as a message plus structured context (e.g. `{ error, methodName, path, alias }`) across app startup, HTTP handlers, auth, MongoDB, config sync, cron, Socket.IO, live queries, and store index creation.
> 
> **Telemetry:** `logError` now normalizes **`Error`** values for the Elastic sink (`{ message, stack, name }`), redacts sensitive keys on the remote path only, and uses **`shouldLogToConsole`** so startup errors still print when telemetry is on but the Winston logger is not ready yet. Tests and mocks were updated for the new call shape.
> 
> **Auth:** Password **login** and **signup** reject requests when a user is already authenticated with **`ValidationError`** and code **`ALREADY_AUTHENTICATED`**, before rate limits or DB work. **`ValidationError`** accepts an optional **`code`** (surfaced like other `ModelenceError` codes where applicable).
> 
> **Cron:** **`startCronJobs`** no-ops when MongoDB URI is missing; job runs persist **`lastStartDate`** via **`upsertOne`** (with **`$setOnInsert`**) instead of **`updateOne`**.
> 
> Smaller changes: NPM publish workflow tags non-`dev` prereleases as **`next`**; magic-link docs note availability since **`modelence@0.22.0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd8fa732a721b5d2a877e561a191de8ed09d9a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->