### PR TITLE
fix: correct Socket.IO auth middleware error handling

### DIFF
--- a/packages/modelence/src/websocket/socketio/server.test.ts
+++ b/packages/modelence/src/websocket/socketio/server.test.ts
@@ -144,6 +144,31 @@ describe('websocket/socketio/server', () => {
     expect(socket.emit).toHaveBeenCalledWith('leftChannel', 'chat:room1');
   });
 
+  test('auth middleware rejects connection when authenticate throws an error', async () => {
+    await websocketProvider.init({
+      httpServer: {} as Server,
+      channels: [],
+    });
+
+    const middleware = socketMiddlewares[0];
+    expect(middleware).toBeDefined();
+
+    const authError = new Error('Authentication failed');
+    mockAuthenticate.mockRejectedValueOnce(authError);
+
+    const next = vi.fn();
+    const authSocket = {
+      handshake: { auth: { token: 'invalid' } },
+      data: null,
+    } as unknown as Socket;
+
+    await middleware?.(authSocket, next);
+
+    expect(mockAuthenticate).toHaveBeenCalledWith('invalid');
+    expect(authSocket.data).toBeNull();
+    expect(next).toHaveBeenCalledWith(authError);
+  });
+
   test('init skips mongo adapter when multiInstance is disabled', async () => {
     await websocketProvider.init({
       httpServer: {} as Server,

--- a/packages/modelence/src/websocket/socketio/server.ts
+++ b/packages/modelence/src/websocket/socketio/server.ts
@@ -79,8 +79,9 @@ export async function init({
 
     try {
       socket.data = await authenticate(token);
-    } finally {
       next();
+    } catch (error) {
+      next(error instanceof Error ? error : new Error(String(error)));
     }
   });
 


### PR DESCRIPTION
### Description

This PR fixes a security vulnerability/auth bypass where the Socket.IO authentication middleware called `next()` inside a `finally` block instead of inside the `try` block.

If `authenticate(token)` throws an error (e.g., due to an expired/invalid token or DB failure), the exception is ignored, the `finally` block runs, and `next()` is called without arguments, successfully admitting the unauthenticated client to the connection.

### Changes

- Refactored the Socket.IO auth middleware in `packages/modelence/src/websocket/socketio/server.ts` to call `next()` on successful authentication, and `next(error)` on failure so that connection rejection occurs correctly.
- Added a robust unit test in `packages/modelence/src/websocket/socketio/server.test.ts` to assert that the connection is properly rejected and the error is passed to `next()` when `authenticate()` fails.

Closes #296

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Corrects security-critical websocket authentication behavior; the prior bug could allow unauthenticated connections when token validation failed.
> 
> **Overview**
> **Fixes an auth bypass** in Socket.IO connection middleware: failed `authenticate(token)` calls no longer admit clients because `next()` is only invoked after success, and failures route through `next(error)`.
> 
> Adds a unit test that rejects connections when `authenticate` throws, asserting `socket.data` stays unset and `next` receives the error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b1303e691a798e1692ccae2430f47839d93601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->