### PR TITLE
fix: mitigate password timing attack and email enumeration in login

### DIFF
--- a/packages/modelence/src/auth/login.test.ts
+++ b/packages/modelence/src/auth/login.test.ts
@@ -147,6 +147,19 @@ describe('auth/login', () => {
     });
   });
 
+  test('runs bcrypt against a dummy hash when the email is unknown', async () => {
+    mockFindOne.mockResolvedValue(null as never);
+
+    await expect(
+      handleLoginWithPassword(
+        { email: 'unknown@example.com', password: 'Secret123' },
+        baseContext as never
+      )
+    ).rejects.toThrow('Incorrect email/password combination');
+
+    expect(mockCompare).toHaveBeenCalledWith('Secret123', expect.stringMatching(/^\$2b\$10\$/));
+  });
+
   test('throws unverified error when email is unverified and provider configured', async () => {
     const userId = new ObjectId('507f1f77bcf86cd799439012');
     mockFindOne.mockResolvedValue({
@@ -182,6 +195,25 @@ describe('auth/login', () => {
       connectionInfo: baseContext.connectionInfo,
     });
     expect(authConfig.login.onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  test('does not reveal an unverified email when the password is incorrect', async () => {
+    const userId = new ObjectId('507f1f77bcf86cd799439023');
+    mockFindOne.mockResolvedValue({
+      _id: userId,
+      handle: 'demo',
+      authMethods: { password: { hash: 'hashed' } },
+      emails: [{ address: 'user@example.com', verified: false }],
+    } as never);
+    mockGetEmailConfig.mockReturnValue({ provider: 'resend' });
+    mockCompare.mockResolvedValue(false as never);
+
+    await expect(
+      handleLoginWithPassword(
+        { email: 'user@example.com', password: 'wrong' },
+        baseContext as never
+      )
+    ).rejects.toThrow('Incorrect email/password combination');
   });
 
   test('allows unverified login when verification flag is disabled', async () => {

--- a/packages/modelence/src/auth/login.test.ts
+++ b/packages/modelence/src/auth/login.test.ts
@@ -163,6 +163,25 @@ describe('auth/login', () => {
     expect(mockCompare).toHaveBeenCalledWith('Secret123', expect.stringMatching(/^\$2b\$10\$/));
   });
 
+  test('runs bcrypt against a dummy hash for accounts without a password', async () => {
+    const userId = new ObjectId('507f1f77bcf86cd799439014');
+    mockFindOne.mockResolvedValue({
+      _id: userId,
+      handle: 'demo',
+      authMethods: {},
+      emails: [{ address: 'user@example.com', verified: true }],
+    } as never);
+
+    await expect(
+      handleLoginWithPassword(
+        { email: 'user@example.com', password: 'Secret123' },
+        baseContext as never
+      )
+    ).rejects.toThrow('Incorrect email/password combination');
+
+    expect(mockCompare).toHaveBeenCalledWith('Secret123', expect.stringMatching(/^\$2b\$10\$/));
+  });
+
   test('throws unverified error when email is unverified and provider configured', async () => {
     const userId = new ObjectId('507f1f77bcf86cd799439012');
     mockFindOne.mockResolvedValue({

--- a/packages/modelence/src/auth/login.test.ts
+++ b/packages/modelence/src/auth/login.test.ts
@@ -12,6 +12,7 @@ const mockGetEmailConfig = vi.fn();
 const mockGetAuthConfig = vi.fn();
 const mockGetConfig = vi.fn();
 const mockCompare = vi.fn();
+const mockHashSync = vi.fn(() => '$2b$10$dummyDummyDummyDummyDummyDummyDummyDummy');
 
 vi.doMock('@/server', () => ({
   consumeRateLimit: mockConsumeRateLimit,
@@ -56,8 +57,10 @@ vi.doMock('@/config/server', () => ({
 vi.doMock('bcrypt', () => ({
   default: {
     compare: mockCompare,
+    hashSync: mockHashSync,
   },
   compare: mockCompare,
+  hashSync: mockHashSync,
 }));
 
 const { handleLoginWithPassword, handleLogout } = await import('./login');

--- a/packages/modelence/src/auth/login.ts
+++ b/packages/modelence/src/auth/login.ts
@@ -35,6 +35,8 @@ function isEmailVerificationRequired(): boolean {
   return Boolean(getConfig('_system.user.auth.email.verification'));
 }
 
+const DUMMY_PASSWORD_HASH = '$2b$10$AUM.KxS9LpsdJ5XQ85jQG.zC2y8b375b4pQeO2XoGf29xNn4/WlFm';
+
 export async function handleLoginWithPassword(
   args: Args,
   { user, session, connectionInfo, res }: Context
@@ -69,10 +71,17 @@ export async function handleLoginWithPassword(
     );
 
     const passwordHash = userDoc?.authMethods?.password?.hash;
-    if (!passwordHash) {
+
+    // Always run bcrypt.compare to mitigate timing attacks that could reveal if an email exists.
+    const hashToCompare = passwordHash || DUMMY_PASSWORD_HASH;
+    const isValidPassword = await bcrypt.compare(password, hashToCompare);
+
+    if (!passwordHash || !isValidPassword) {
       throw incorrectCredentialsError();
     }
 
+    // Only check email verification if the user exists and the password is correct,
+    // to prevent email enumeration by observing verification errors before password checks.
     const emailDoc = userDoc.emails?.find((e) => e.address.toLowerCase() === email);
 
     if (!emailDoc?.verified && isEmailVerificationRequired()) {
@@ -80,11 +89,6 @@ export async function handleLoginWithPassword(
         "Your email address hasn't been verified yet. Please check your inbox for the verification email.",
         'EMAIL_NOT_VERIFIED'
       );
-    }
-
-    const isValidPassword = await bcrypt.compare(password, passwordHash);
-    if (!isValidPassword) {
-      throw incorrectCredentialsError();
     }
 
     await setSessionUser(session.authToken, userDoc._id);

--- a/packages/modelence/src/auth/login.ts
+++ b/packages/modelence/src/auth/login.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'crypto';
+
 import bcrypt from 'bcrypt';
 import { z } from 'zod';
 
@@ -35,7 +37,8 @@ function isEmailVerificationRequired(): boolean {
   return Boolean(getConfig('_system.user.auth.email.verification'));
 }
 
-const DUMMY_PASSWORD_HASH = '$2b$10$AUM.KxS9LpsdJ5XQ85jQG.zC2y8b375b4pQeO2XoGf29xNn4/WlFm';
+const SALT_ROUNDS = 10;
+const DUMMY_PASSWORD_HASH = bcrypt.hashSync(randomBytes(32).toString('hex'), SALT_ROUNDS);
 
 export async function handleLoginWithPassword(
   args: Args,


### PR DESCRIPTION
Resolves #304

## Summary

- Runs `bcrypt.compare` against a generated dummy hash (no hardcoded value) when no password hash is found, keeping unknown-email and known-email login timing comparable.
- Checks email verification only after the password succeeds, preventing unverified-account enumeration.

## Behavioral change

Unverified users who type a **wrong password** now get `Incorrect email/password combination` instead of the "email isn't verified" message. That is intentional (prevents enumeration), but it removes a self-explanatory hint for legitimate unverified users and may generate support tickets. Worth calling out in release notes.

## Validation

- `npm run lint:check`
- `npm run build`
- `npx tsc --noEmit`
- `npm test` (859 passing)
