### PR TITLE
fix: explicit destruction of destination stream on SSR error

### DIFF
--- a/packages/modelence/src/ssr/render.tsx
+++ b/packages/modelence/src/ssr/render.tsx
@@ -154,7 +154,10 @@ export async function renderSsrTreeStream(options: SsrStreamOptions): Promise<Ss
         },
       });
 
-      passthrough.on('error', reject);
+      passthrough.on('error', (err) => {
+        destination.destroy(err);
+        reject(err);
+      });
       destination.on('error', reject);
 
       streamRef.pipe(passthrough);


### PR DESCRIPTION
Resolves #306

This PR fixes a bug in Server-Side Rendering (SSR) where stream errors could lead to dangling HTTP responses. 

**Changes:**
- Updated the error handler for the `passthrough` stream in `packages/modelence/src/ssr/render.tsx`. When an error is emitted, we now explicitly call `destination.destroy(err)` before rejecting the promise. This ensures the underlying HTTP connection is severed, preventing clients from waiting indefinitely and avoiding memory/connection leaks on the server.

**Testing:**
- All tests continue to pass successfully.
- Code conforms to all linting rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single error-path change in SSR streaming cleanup; no impact on the happy path.
> 
> **Overview**
> Fixes SSR streaming failures leaving HTTP responses open when the internal `passthrough` `Writable` errors.
> 
> In `renderSsrTreeStream`'s `pipe()` helper, the `passthrough` `'error'` handler now calls **`destination.destroy(err)`** before rejecting the pipe promise. That tears down the caller's response stream (e.g. the Node HTTP `Writable`) instead of only rejecting while the client keeps waiting.
> 
> **Risk:** Low — error-path only; successful streaming behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f35b2250475c3ccb8358ef5c4f701d143a8e219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->