### PR TITLE
fix(auth): rate limit profile updates

### DIFF
--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -85,6 +85,8 @@ export type AuthRateLimitsConfig = {
   magicLink?: AuthRateLimitOverride[];
   /** Rate limits for one-time code sign-in attempts. */
   oneTimeCode?: AuthRateLimitOverride[];
+  /** Per-user rate limits for profile updates. */
+  updateProfile?: AuthRateLimitOverride[];
 };
 
 type GenerateHandleProps = {

--- a/packages/modelence/src/auth/profile.test.ts
+++ b/packages/modelence/src/auth/profile.test.ts
@@ -1,6 +1,58 @@
-import { getOwnProfile } from './profile';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireById = vi.fn();
+const mockFindOne = vi.fn();
+const mockUpdateOne = vi.fn();
+const mockValidateProfileFields = vi.fn();
+const mockValidateProfileUpdate = vi.fn();
+const mockConsumeRateLimit = vi.fn();
+
+vi.doMock('./db', () => ({
+  usersCollection: {
+    requireById: mockRequireById,
+    findOne: mockFindOne,
+    updateOne: mockUpdateOne,
+  },
+}));
+
+vi.doMock('./validators', () => ({
+  validateProfileFields: mockValidateProfileFields,
+}));
+
+vi.doMock('@/app/authConfig', () => ({
+  getAuthConfig: () => ({ validateProfileUpdate: mockValidateProfileUpdate }),
+}));
+
+vi.doMock('../rate-limit/rules', () => ({
+  consumeRateLimit: mockConsumeRateLimit,
+}));
+
+vi.doMock('./utils', () => ({
+  serializeUserForClient: (profile: unknown) => profile,
+}));
+
+const { getOwnProfile, handleUpdateProfile } = await import('./profile');
 
 describe('auth/profile', () => {
+  const authenticatedContext = {
+    user: { id: 'user-1' },
+  } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireById.mockResolvedValue({
+      _id: 'profile-1',
+      handle: 'existing-handle',
+      authMethods: {},
+      emails: [],
+    } as never);
+    mockFindOne.mockResolvedValue(null as never);
+    mockUpdateOne.mockResolvedValue(undefined as never);
+    mockValidateProfileFields.mockImplementation((props: unknown) => props);
+    mockValidateProfileUpdate.mockResolvedValue(undefined as never);
+    mockConsumeRateLimit.mockResolvedValue(undefined as never);
+  });
+
   describe('getOwnProfile', () => {
     it('should be a function', () => {
       expect(typeof getOwnProfile).toBe('function');
@@ -31,6 +83,41 @@ describe('auth/profile', () => {
           }
         )
       ).rejects.toThrow('Not authenticated');
+    });
+  });
+
+  describe('handleUpdateProfile', () => {
+    it('does not consume the profile update limit when field validation fails', async () => {
+      mockValidateProfileFields.mockImplementation(() => {
+        throw new Error('Invalid profile field');
+      });
+
+      await expect(
+        handleUpdateProfile({ firstName: 'Invalid' }, authenticatedContext)
+      ).rejects.toThrow('Invalid profile field');
+
+      expect(mockConsumeRateLimit).not.toHaveBeenCalled();
+    });
+
+    it('does not consume the profile update limit when the validation hook rejects', async () => {
+      mockValidateProfileUpdate.mockRejectedValue(new Error('Profile update rejected') as never);
+
+      await expect(
+        handleUpdateProfile({ firstName: 'Blocked' }, authenticatedContext)
+      ).rejects.toThrow('Profile update rejected');
+
+      expect(mockConsumeRateLimit).not.toHaveBeenCalled();
+    });
+
+    it('consumes the profile update limit before persisting a valid update', async () => {
+      await handleUpdateProfile({ firstName: 'Updated' }, authenticatedContext);
+
+      expect(mockConsumeRateLimit).toHaveBeenCalledWith({
+        bucket: 'updateProfile',
+        type: 'user',
+        value: 'user-1',
+      });
+      expect(mockUpdateOne).toHaveBeenCalled();
     });
   });
 });

--- a/packages/modelence/src/auth/profile.ts
+++ b/packages/modelence/src/auth/profile.ts
@@ -3,6 +3,7 @@ import { Args, Context, UpdateProfileProps } from '../methods/types';
 import { serializeUserForClient } from './utils';
 import { validateProfileFields } from './validators';
 import { getAuthConfig } from '@/app/authConfig';
+import { consumeRateLimit } from '../rate-limit/rules';
 
 export async function getOwnProfile(props: Args, { user }: Context) {
   if (!user) {
@@ -49,6 +50,8 @@ export async function handleUpdateProfile(props: Args, { user }: Context) {
 
   //Update profile
   if (Object.keys(update).length > 0) {
+    await consumeRateLimit({ bucket: 'updateProfile', type: 'user', value: user.id });
+
     const setFields: Record<string, unknown> = {}; //Used to set the fields
     const unsetFields: Record<string, ''> = {}; //Used to clear the fields the mongodb, because mongodb rejects undefined values when updating fields
 

--- a/packages/modelence/src/auth/user.test.ts
+++ b/packages/modelence/src/auth/user.test.ts
@@ -223,9 +223,9 @@ describe('auth/user', () => {
       expect(mockTime.days).toHaveBeenCalledWith(1);
     });
 
-    test('produces exactly 20 rules covering all auth buckets', () => {
+    test('produces exactly 22 rules covering all auth buckets', () => {
       const rules = buildAuthRateLimits();
-      expect(rules).toHaveLength(20);
+      expect(rules).toHaveLength(22);
 
       const buckets = new Set(rules.map((r) => r.bucket));
       expect(buckets).toEqual(
@@ -237,8 +237,21 @@ describe('auth/user', () => {
           'passwordReset',
           'magicLink',
           'oneTimeCode',
+          'updateProfile',
         ])
       );
+    });
+
+    test('allows profile update limits to be overridden', () => {
+      const rules = buildAuthRateLimits({
+        updateProfile: [{ type: 'user', window: 15 * 60 * 1000, limit: 10 }],
+      });
+
+      const profileRules = rules.filter((rule) => rule.bucket === 'updateProfile');
+      expect(profileRules).toEqual([
+        { bucket: 'updateProfile', type: 'user', window: 15 * 60 * 1000, limit: 10 },
+        { bucket: 'updateProfile', type: 'user', window: 24 * 60 * 60 * 1000, limit: 200 },
+      ]);
     });
 
     test('array override merges into defaults by (bucket, type, window)', () => {

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -55,6 +55,8 @@ function defaultAuthRateLimits(): RateLimitRule[] {
     { bucket: 'oneTimeCode', type: 'ip', window: time.days(1), limit: 100 },
     { bucket: 'oneTimeCode', type: 'email', window: time.hours(1), limit: 10 },
     { bucket: 'oneTimeCode', type: 'email', window: time.days(1), limit: 20 },
+    { bucket: 'updateProfile', type: 'user', window: time.minutes(15), limit: 30 },
+    { bucket: 'updateProfile', type: 'user', window: time.days(1), limit: 200 },
   ];
 }
 
@@ -69,6 +71,7 @@ function collectOverrides(config: AuthRateLimitsConfig): RateLimitRule[] {
     'passwordReset',
     'magicLink',
     'oneTimeCode',
+    'updateProfile',
   ];
 
   for (const bucket of buckets) {


### PR DESCRIPTION
## Summary

- add per-user limits for profile updates (30 per 15 minutes; 200 per day)
- expose `auth.rateLimits.updateProfile` for configuration overrides
- validate profile updates and handle availability before consuming the quota
- add coverage for defaults, overrides, validation failures, and successful updates

This branch was rebuilt from current `main` and contains only the profile-update rate-limit change.

## Testing

- `npm run lint:check`
- `npm run build`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to profile update mutation with conservative defaults; quota is not consumed on validation failures, limiting user impact.
> 
> **Overview**
> Adds **per-user rate limiting** on profile updates so abusive or automated `updateProfile` traffic is capped like other auth actions.
> 
> Default limits are **30 updates per 15 minutes** and **200 per day** per user, registered on the auth module’s rate-limit rules. Apps can tune them via **`auth.rateLimits.updateProfile`** using the same override/merge behavior as other auth buckets.
> 
> `handleUpdateProfile` now calls **`consumeRateLimit`** with bucket `updateProfile` only when there is a non-empty update to persist—**after** field validation, the optional `validateProfileUpdate` hook, and handle uniqueness checks—so invalid or rejected requests do not burn quota. Tests cover defaults, overrides, and when the limit is (not) consumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1af3bfb689181078a5fdbfcd410e118c6f985c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->