### PR TITLE
fix: remove empty unload listener to support BFCache

### DIFF
--- a/packages/modelence/src/client/query.test.ts
+++ b/packages/modelence/src/client/query.test.ts
@@ -11,7 +11,12 @@ vi.doMock('../websocket/client', () => ({
   subscribeLiveQuery: mockSubscribeLiveQuery,
 }));
 
-const { modelenceLiveQuery, disconnectModelenceQueryClient } = await import('./query');
+const {
+  modelenceLiveQuery,
+  disconnectModelenceQueryClient,
+  connectModelenceQueryClient,
+  revalidateModelenceQueries,
+} = await import('./query');
 
 describe('modelenceLiveQuery', () => {
   const originalWindow = globalThis.window;
@@ -23,6 +28,19 @@ describe('modelenceLiveQuery', () => {
 
   afterEach(() => {
     globalThis.window = originalWindow;
+  });
+
+  test('revalidateModelenceQueries invalidates queries on connected QueryClient', () => {
+    const mockInvalidateQueries = vi.fn();
+    const fakeQueryClient = {
+      getQueryCache: () => ({ subscribe: vi.fn() }),
+      invalidateQueries: mockInvalidateQueries,
+    } as unknown as Parameters<typeof connectModelenceQueryClient>[0];
+
+    connectModelenceQueryClient(fakeQueryClient);
+    revalidateModelenceQueries();
+
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
   });
 
   test('queryFn returns a never-resolving promise on the server (no window)', async () => {

--- a/packages/modelence/src/client/query.ts
+++ b/packages/modelence/src/client/query.ts
@@ -76,6 +76,13 @@ export function disconnectModelenceQueryClient() {
   websocketsStarted = false;
 }
 
+/** Revalidate all cached queries when restored from BFCache (`event.persisted === true`). */
+export function revalidateModelenceQueries() {
+  if (queryClientRef) {
+    void queryClientRef.invalidateQueries();
+  }
+}
+
 /** @deprecated Use `connectModelenceQueryClient(queryClient)` instead. */
 export class ModelenceQueryClient {
   connect(queryClient: QueryClient) {

--- a/packages/modelence/src/client/renderApp.test.tsx
+++ b/packages/modelence/src/client/renderApp.test.tsx
@@ -109,7 +109,7 @@ describe('client/renderApp', () => {
     globalThis.window = originalWindow;
   });
 
-  test('initializes error handler, attaches unload listener, and renders AppProvider', () => {
+  test('initializes error handler and renders AppProvider', () => {
     renderApp({
       loadingElement: <div>Loading</div>,
       routesElement: <div>Routes</div>,
@@ -122,7 +122,6 @@ describe('client/renderApp', () => {
     const renderFn = rootResult ? (rootResult.value as { render: Mock }).render : undefined;
     expect(renderFn).toBeDefined();
     expect(renderFn).toHaveBeenCalledTimes(1);
-    expect(addEventListenerMock).toHaveBeenCalledWith('unload', expect.any(Function));
   });
 
   test('creates favicon link when none exists', () => {

--- a/packages/modelence/src/client/renderApp.test.tsx
+++ b/packages/modelence/src/client/renderApp.test.tsx
@@ -25,10 +25,12 @@ vi.doMock('react-dom/client', () => ({
 
 const mockHydrateSession = vi.fn();
 const mockStartSessionHeartbeat = vi.fn();
+const mockRevalidateSessionOnPageShow = vi.fn();
 
 vi.doMock('./session', () => ({
   hydrateSession: mockHydrateSession,
   startSessionHeartbeat: mockStartSessionHeartbeat,
+  revalidateSessionOnPageShow: mockRevalidateSessionOnPageShow,
 }));
 
 const mockQueryProvider = vi.fn(({ children }: { children: React.ReactNode }) => <>{children}</>);
@@ -109,7 +111,7 @@ describe('client/renderApp', () => {
     globalThis.window = originalWindow;
   });
 
-  test('initializes error handler, attaches unload listener, and renders AppProvider', () => {
+  test('initializes error handler and renders AppProvider', () => {
     renderApp({
       loadingElement: <div>Loading</div>,
       routesElement: <div>Routes</div>,
@@ -122,7 +124,26 @@ describe('client/renderApp', () => {
     const renderFn = rootResult ? (rootResult.value as { render: Mock }).render : undefined;
     expect(renderFn).toBeDefined();
     expect(renderFn).toHaveBeenCalledTimes(1);
-    expect(addEventListenerMock).toHaveBeenCalledWith('unload', expect.any(Function));
+  });
+
+  test('attaches pageshow listener and revalidates session when event.persisted is true', () => {
+    renderApp({
+      loadingElement: null,
+      routesElement: null,
+    });
+
+    expect(addEventListenerMock).toHaveBeenCalledWith('pageshow', expect.any(Function));
+    const pageshowCall = addEventListenerMock.mock.calls.find((call) => call[0] === 'pageshow');
+    const pageshowHandler = pageshowCall?.[1] as
+      | ((event: { persisted: boolean }) => void)
+      | undefined;
+    expect(pageshowHandler).toBeDefined();
+
+    pageshowHandler?.({ persisted: false });
+    expect(mockRevalidateSessionOnPageShow).not.toHaveBeenCalled();
+
+    pageshowHandler?.({ persisted: true });
+    expect(mockRevalidateSessionOnPageShow).toHaveBeenCalledTimes(1);
   });
 
   test('creates favicon link when none exists', () => {

--- a/packages/modelence/src/client/renderApp.tsx
+++ b/packages/modelence/src/client/renderApp.tsx
@@ -80,9 +80,6 @@ export function renderApp(options: RenderAppOptions) {
     setErrorHandler(errorHandler);
   }
 
-  // Empty 'unload' handler prevents bfcache in most browsers.
-  window.addEventListener('unload', () => {});
-
   // Hydrate session BEFORE building the tree so `isSessionInitialized()` is
   // true on the first render and matches the server output. Hydration mode
   // tracks marker presence (not parse success): a parse failure still leaves

--- a/packages/modelence/src/client/renderApp.tsx
+++ b/packages/modelence/src/client/renderApp.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { AppProvider } from '../client';
 import { setErrorHandler, ErrorHandler } from './errorHandler';
-import { hydrateSession, startSessionHeartbeat, type SessionInitPayload } from './session';
+import {
+  hydrateSession,
+  revalidateSessionOnPageShow,
+  startSessionHeartbeat,
+  type SessionInitPayload,
+} from './session';
 import { ModelenceQueryProvider } from './queryProvider';
 import { hasConnectedQueryClient } from './query';
 
@@ -86,8 +91,12 @@ export function renderApp(options: RenderAppOptions) {
     setErrorHandler(errorHandler);
   }
 
-  // Empty 'unload' handler prevents bfcache in most browsers.
-  window.addEventListener('unload', () => {});
+  // Revalidate session when page is restored from BFCache (e.g. back navigation after logout)
+  window.addEventListener('pageshow', (event) => {
+    if (event.persisted) {
+      void revalidateSessionOnPageShow();
+    }
+  });
 
   // Hydrate session BEFORE building the tree so `isSessionInitialized()` is
   // true on the first render and matches the server output. Hydration mode

--- a/packages/modelence/src/client/session.test.ts
+++ b/packages/modelence/src/client/session.test.ts
@@ -55,6 +55,7 @@ describe('client/session', () => {
     mockGetLocalStorageSession.mockReturnValue(null);
     mockGetClientConfig.mockReset();
     mockGetClientConfig.mockReturnValue(null);
+    mockRevalidateModelenceQueries.mockReset();
     global.setTimeout = ((fn: Parameters<typeof originalSetTimeout>[0], delay?: number) => {
       return originalSetTimeout(fn, delay);
     }) as typeof setTimeout;
@@ -299,6 +300,54 @@ describe('client/session', () => {
     expect(mockSetConfig).toHaveBeenCalledWith([{ key: 'k', value: 'v' }]);
     expect(mockSetLocalStorageSession).toHaveBeenCalledWith({ authToken: 'fresh-token' });
     expect(fresh.useSessionStore.getState().user?.id).toBe('99');
+    expect(mockRevalidateModelenceQueries).toHaveBeenCalledTimes(1);
+  });
+
+  test('revalidateSessionOnPageShow delegates token storage to client config when configured', async () => {
+    const mockSetAuthToken = vi.fn();
+    mockGetClientConfig.mockReturnValue({ setAuthToken: mockSetAuthToken });
+    const fresh = await import('./session');
+    mockCallMethod.mockResolvedValueOnce({
+      configs: {},
+      session: { authToken: 'custom-config-token' },
+      user: { id: '100', handle: 'custom-user', roles: [] },
+    } as never);
+
+    await fresh.revalidateSessionOnPageShow();
+
+    expect(mockSetAuthToken).toHaveBeenCalledWith('custom-config-token');
+    expect(mockSetLocalStorageSession).not.toHaveBeenCalled();
+  });
+
+  test('revalidateSessionOnPageShow logs error when revalidation fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fresh = await import('./session');
+    mockCallMethod.mockRejectedValueOnce(new Error('Network error'));
+
+    await fresh.revalidateSessionOnPageShow();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Modelence: session revalidation failed on pageshow',
+      expect.any(Error)
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('revalidateSessionOnPageShow clears populated user state when revalidated anonymously (user: null)', async () => {
+    const fresh = await import('./session');
+    fresh.setCurrentUser({ id: 'active-user', handle: 'logged-in', roles: ['user'] });
+    expect(fresh.useSessionStore.getState().user?.id).toBe('active-user');
+
+    mockCallMethod.mockResolvedValueOnce({
+      configs: {},
+      session: { authToken: 'anon-token' },
+      user: null,
+    } as never);
+
+    await fresh.revalidateSessionOnPageShow();
+
+    expect(mockCallMethod).toHaveBeenCalledWith('_system.session.init');
+    expect(fresh.useSessionStore.getState().user).toBeNull();
     expect(mockRevalidateModelenceQueries).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/modelence/src/client/session.test.ts
+++ b/packages/modelence/src/client/session.test.ts
@@ -7,6 +7,7 @@ const mockSetConfig = vi.fn();
 const mockSetLocalStorageSession = vi.fn();
 const mockGetLocalStorageSession = vi.fn<() => object | null>(() => null);
 const mockGetClientConfig = vi.fn();
+const mockRevalidateModelenceQueries = vi.fn();
 const mockSeconds = vi.fn((value: number) => value * 1000);
 
 vi.doMock('./method', () => ({
@@ -24,6 +25,10 @@ vi.doMock('./localStorage', () => ({
 
 vi.doMock('./clientConfig', () => ({
   getClientConfig: mockGetClientConfig,
+}));
+
+vi.doMock('./query', () => ({
+  revalidateModelenceQueries: mockRevalidateModelenceQueries,
 }));
 
 vi.doMock('../time', () => ({
@@ -278,5 +283,22 @@ describe('client/session', () => {
 
     await fresh.reconcileSession();
     expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  test('revalidateSessionOnPageShow re-initializes session and updates user state', async () => {
+    const fresh = await import('./session');
+    mockCallMethod.mockResolvedValueOnce({
+      configs: [{ key: 'k', value: 'v' }],
+      session: { authToken: 'fresh-token' },
+      user: { id: '99', handle: 'bfcache-user', roles: ['user'] },
+    } as never);
+
+    await fresh.revalidateSessionOnPageShow();
+
+    expect(mockCallMethod).toHaveBeenCalledWith('_system.session.init');
+    expect(mockSetConfig).toHaveBeenCalledWith([{ key: 'k', value: 'v' }]);
+    expect(mockSetLocalStorageSession).toHaveBeenCalledWith({ authToken: 'fresh-token' });
+    expect(fresh.useSessionStore.getState().user?.id).toBe('99');
+    expect(mockRevalidateModelenceQueries).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/modelence/src/client/session.ts
+++ b/packages/modelence/src/client/session.ts
@@ -145,14 +145,7 @@ export function _isReconciliationPending(): boolean {
   return pendingReconciliation;
 }
 
-export async function initSession() {
-  if (isInitialized) {
-    return;
-  }
-
-  isInitialized = true;
-
-  const payload = await callMethod<SessionInitPayload>('_system.session.init');
+function applySessionPayload(payload: SessionInitPayload) {
   const { configs, session, user } = payload;
   setupRequired = Boolean(payload.setupRequired);
   _setConfig(configs);
@@ -165,29 +158,36 @@ export async function initSession() {
   }
 
   useSessionStore.getState().setUser(parseUser(user));
+}
+
+export async function initSession() {
+  if (isInitialized) {
+    return;
+  }
+
+  isInitialized = true;
+
+  const payload = await callMethod<SessionInitPayload>('_system.session.init');
+  applySessionPayload(payload);
 
   await loopSessionHeartbeat();
 }
 
 /** Revalidate session on pageshow when restored from BFCache (`event.persisted === true`). */
 export async function revalidateSessionOnPageShow() {
+  if (heartbeatTimer !== null) {
+    clearTimeout(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+
   try {
     const payload = await callMethod<SessionInitPayload>('_system.session.init');
-    const { configs, session, user } = payload;
-    setupRequired = Boolean(payload.setupRequired);
-    _setConfig(configs);
-
-    const config = getClientConfig();
-    if (config) {
-      config.setAuthToken(session.authToken);
-    } else {
-      setLocalStorageSession(session);
-    }
-
-    useSessionStore.getState().setUser(parseUser(user));
+    applySessionPayload(payload);
     revalidateModelenceQueries();
   } catch (error) {
     console.error('Modelence: session revalidation failed on pageshow', error);
+  } finally {
+    void loopSessionHeartbeat();
   }
 }
 

--- a/packages/modelence/src/client/session.ts
+++ b/packages/modelence/src/client/session.ts
@@ -4,6 +4,7 @@ import { callMethod } from './method';
 import { _setConfig } from '../config/client';
 import { getLocalStorageSession, setLocalStorageSession } from './localStorage';
 import { getClientConfig } from './clientConfig';
+import { revalidateModelenceQueries } from './query';
 import { time } from '../time';
 import { Configs } from '../config/types';
 
@@ -166,6 +167,28 @@ export async function initSession() {
   useSessionStore.getState().setUser(parseUser(user));
 
   await loopSessionHeartbeat();
+}
+
+/** Revalidate session on pageshow when restored from BFCache (`event.persisted === true`). */
+export async function revalidateSessionOnPageShow() {
+  try {
+    const payload = await callMethod<SessionInitPayload>('_system.session.init');
+    const { configs, session, user } = payload;
+    setupRequired = Boolean(payload.setupRequired);
+    _setConfig(configs);
+
+    const config = getClientConfig();
+    if (config) {
+      config.setAuthToken(session.authToken);
+    } else {
+      setLocalStorageSession(session);
+    }
+
+    useSessionStore.getState().setUser(parseUser(user));
+    revalidateModelenceQueries();
+  } catch (error) {
+    console.error('Modelence: session revalidation failed on pageshow', error);
+  }
 }
 
 /** Idempotent, client-only. Auto-started by `initSession`; call explicitly after `hydrateSession`. */


### PR DESCRIPTION
### What & Why
This PR removes the empty `unload` event listener and its comment from `renderApp.tsx`. 
The presence of an `unload` listener, even when empty, prevents browsers from caching the page in the Back-Forward Cache (bfcache), resulting in slower navigation times when users use back/forward controls. 

Removing this listener enables bfcache optimization in client applications and resolves issue #308.

Closes #308

### How it was tested
1. Verified that the package compiles and builds successfully via `npm run build`.
2. Verified that all unit tests in `src/client/renderApp.test.tsx` pass successfully.
3. Verified the entire test suite (777 tests) passes successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session initialization and auth token handling on navigation restore; behavior is covered by new unit tests but affects every client app using `renderApp`.
> 
> **Overview**
> Removes the empty **`unload`** listener in **`renderApp`** so browsers can keep pages in the back-forward cache, and replaces it with a **`pageshow`** handler that runs only when **`event.persisted`** is true.
> 
> On BFCache restore, **`revalidateSessionOnPageShow`** calls **`_system.session.init`** again (via shared **`applySessionPayload`**), refreshes auth/config/user state (including clearing the user after logout), restarts the session heartbeat, and triggers **`revalidateModelenceQueries`** to invalidate the connected TanStack Query cache so UI data is not stale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42822667c0b77140605d674b32801084cfdc677e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->