### PR TITLE
chore: remove debug winston console transport

### DIFF
--- a/packages/modelence/src/app/metrics.ts
+++ b/packages/modelence/src/app/metrics.ts
@@ -84,10 +84,7 @@ async function initElasticApm() {
       serviceName,
     },
     format: winston.format.combine(winston.format.json()),
-    transports: [
-      // new winston.transports.Console(), // TODO: remove, just for debugging
-      esTransport,
-    ],
+    transports: [esTransport],
   });
 
   startLoggerProcess({


### PR DESCRIPTION
Resolves an issue where a debug artifact was left in the metrics logger setup.

Fixes #317