### PR TITLE
feat: support contentType in route responses

### DIFF
--- a/packages/modelence/src/routes/handler.test.ts
+++ b/packages/modelence/src/routes/handler.test.ts
@@ -160,6 +160,35 @@ describe('routes/handler', () => {
     expect(res.send).toHaveBeenCalledWith({ ok: true });
   });
 
+  test('applies contentType before sending the response body', async () => {
+    const handler = createRouteHandler('GET', '/report', async () => ({
+      data: 'name,email\nAda,ada@example.com',
+      contentType: 'text/csv; charset=utf-8',
+    }));
+
+    await handler(baseReq, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv; charset=utf-8');
+    const contentTypeOrder = (res.setHeader as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0];
+    const sendOrder = (res.send as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    expect(contentTypeOrder).toBeLessThan(sendOrder);
+    expect(res.send).toHaveBeenCalledWith('name,email\nAda,ada@example.com');
+  });
+
+  test('allows custom Content-Type headers to override contentType', async () => {
+    const handler = createRouteHandler('GET', '/report', async () => ({
+      data: 'report',
+      contentType: 'text/csv',
+      headers: { 'Content-Type': 'application/vnd.ms-excel' },
+    }));
+
+    await handler(baseReq, res, next);
+
+    expect(res.setHeader).toHaveBeenNthCalledWith(1, 'Content-Type', 'text/csv');
+    expect(res.setHeader).toHaveBeenNthCalledWith(2, 'Content-Type', 'application/vnd.ms-excel');
+  });
+
   test('handles ModelenceError gracefully', async () => {
     const handler = createRouteHandler('GET', '/test', async () => {
       throw new ValidationError('fail');

--- a/packages/modelence/src/routes/handler.ts
+++ b/packages/modelence/src/routes/handler.ts
@@ -52,8 +52,14 @@ export function createRouteHandler(method: string, path: string, handler: RouteH
       if (response) {
         res.status(response.status || 200);
 
-        // Apply custom headers before sending the body/redirect, otherwise
+        // Apply response headers before sending the body/redirect, otherwise
         // res.redirect()/res.send() flush the response and the headers are lost.
+        if (response.contentType) {
+          res.setHeader('Content-Type', response.contentType);
+        }
+
+        // Custom headers are applied after contentType so callers can override
+        // it with headers['Content-Type'] when needed.
         if (response.headers) {
           Object.entries(response.headers).forEach(([key, value]) => {
             res.setHeader(key, value);

--- a/packages/modelence/src/routes/types.ts
+++ b/packages/modelence/src/routes/types.ts
@@ -28,9 +28,12 @@ export type RouteResponse<T = unknown> = {
   data?: T;
   status?: number;
   headers?: Record<string, string>;
+  /**
+   * Sets the response Content-Type before sending `data`. A Content-Type supplied
+   * through `headers` takes precedence when both options are provided.
+   */
+  contentType?: string;
   redirect?: string;
-  // contentType?: string;
-  // filename?: string;
 } | null;
 
 export type RouteHandler<T = unknown> = (


### PR DESCRIPTION
## Summary

- add a typed `contentType` option to `RouteResponse`
- set the Content-Type header before sending a custom route response
- allow an explicit `headers["Content-Type"]` value to override the convenience option
- add coverage for content type application and precedence

Closes #318

## Validation

- `npm run format:check`
- `npm run lint:check`
- `npm run test` (91 files, 779 tests)
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive typed option and small header-ordering change in the route response path; no auth or data-model changes.
> 
> **Overview**
> Route handlers can now return a **`contentType`** field on **`RouteResponse`** so non-JSON bodies (e.g. CSV) get the right **`Content-Type`** before **`res.send()`**, matching the existing rule that headers must be set before the response is flushed.
> 
> **`createRouteHandler`** applies **`contentType`** first, then **`headers`**, so **`headers['Content-Type']`** still wins when both are set. Tests cover header ordering relative to **`send`** and override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90f0000d2339fe2d917dfc0975a06fb73c90a75c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->