### PR TITLE
fix(auth): clear persisted browser session on logout

### DIFF
--- a/packages/modelence/src/auth/client/index.test.ts
+++ b/packages/modelence/src/auth/client/index.test.ts
@@ -12,11 +12,18 @@ vi.doMock('../../client/session', () => ({
   setCurrentUser: mockSetCurrentUser,
 }));
 
+const mockGetClientConfig = vi.fn();
+vi.doMock('../../client/clientConfig', () => ({
+  getClientConfig: mockGetClientConfig,
+}));
+
 const mockGetLocalStorageSession = vi.fn();
 const mockClearLocalStorageSession = vi.fn();
+const mockSetLocalStorageSession = vi.fn();
 vi.doMock('../../client/localStorage', () => ({
   clearLocalStorageSession: mockClearLocalStorageSession,
   getLocalStorageSession: mockGetLocalStorageSession,
+  setLocalStorageSession: mockSetLocalStorageSession,
 }));
 const mockFetch: MockedFunction<typeof fetch> = vi.fn();
 globalThis.fetch = mockFetch;
@@ -32,6 +39,7 @@ describe('auth/client', () => {
   beforeEach(() => {
     window.location.href = '';
     vi.clearAllMocks();
+    mockGetClientConfig.mockReturnValue(null);
     mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
   });
 
@@ -44,10 +52,11 @@ describe('auth/client', () => {
     });
   });
 
-  test('loginWithPassword resolves user and stores in session', async () => {
+  test('loginWithPassword resolves user and stores the browser session', async () => {
     const rawUser = { id: '1', handle: 'demo', roles: [] };
     const enrichedUser = { ...rawUser, hasRole: () => true, requireRole: () => {} };
-    mockCallMethod.mockResolvedValue({ user: rawUser } as never);
+    const session = { authToken: 'password-token' };
+    mockCallMethod.mockResolvedValue({ user: rawUser, session } as never);
     mockSetCurrentUser.mockReturnValue(enrichedUser);
 
     const result = await authClient.loginWithPassword({
@@ -59,8 +68,49 @@ describe('auth/client', () => {
       email: 'user@example.com',
       password: 'secret',
     });
+    expect(mockSetLocalStorageSession).toHaveBeenCalledWith(session);
     expect(mockSetCurrentUser).toHaveBeenCalledWith(rawUser);
     expect(result).toBe(enrichedUser);
+  });
+
+  test('loginWithPassword stores the token through custom client configuration', async () => {
+    const setAuthToken = vi.fn();
+    mockGetClientConfig.mockReturnValue({ setAuthToken });
+    const session = { authToken: 'custom-client-token' };
+    mockCallMethod.mockResolvedValue({
+      user: { id: '1', handle: 'demo', roles: [] },
+      session,
+    } as never);
+
+    await authClient.loginWithPassword({ email: 'user@example.com', password: 'secret' });
+
+    expect(setAuthToken).toHaveBeenCalledWith(session.authToken);
+    expect(mockSetLocalStorageSession).not.toHaveBeenCalled();
+  });
+
+  test('loginWithMagicLink stores the browser session', async () => {
+    const user = { id: '1', handle: 'demo', roles: [] };
+    const session = { authToken: 'magic-link-token' };
+    mockCallMethod.mockResolvedValue({ user, session } as never);
+
+    await authClient.loginWithMagicLink();
+
+    expect(mockCallMethod).toHaveBeenCalledWith('_system.user.loginWithMagicLink');
+    expect(mockSetLocalStorageSession).toHaveBeenCalledWith(session);
+  });
+
+  test('loginWithOneTimeCode stores the browser session', async () => {
+    const user = { id: '1', handle: 'demo', roles: [] };
+    const session = { authToken: 'one-time-code-token' };
+    mockCallMethod.mockResolvedValue({ user, session } as never);
+
+    await authClient.loginWithOneTimeCode({ email: 'user@example.com', code: '123456' });
+
+    expect(mockCallMethod).toHaveBeenCalledWith('_system.user.loginWithOneTimeCode', {
+      email: 'user@example.com',
+      code: '123456',
+    });
+    expect(mockSetLocalStorageSession).toHaveBeenCalledWith(session);
   });
 
   test('verifyEmail calls backend method with token', async () => {

--- a/packages/modelence/src/auth/client/index.test.ts
+++ b/packages/modelence/src/auth/client/index.test.ts
@@ -13,7 +13,9 @@ vi.doMock('../../client/session', () => ({
 }));
 
 const mockGetLocalStorageSession = vi.fn();
+const mockClearLocalStorageSession = vi.fn();
 vi.doMock('../../client/localStorage', () => ({
+  clearLocalStorageSession: mockClearLocalStorageSession,
   getLocalStorageSession: mockGetLocalStorageSession,
 }));
 const mockFetch: MockedFunction<typeof fetch> = vi.fn();
@@ -79,6 +81,7 @@ describe('auth/client', () => {
     await authClient.logout();
 
     expect(mockCallMethod).toHaveBeenCalledWith('_system.user.logout');
+    expect(mockClearLocalStorageSession).toHaveBeenCalledTimes(1);
     expect(mockSetCurrentUser).toHaveBeenCalledWith(null);
   });
 

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -1,6 +1,6 @@
 import { setCurrentUser } from '@/client/session';
 import { callMethod } from '@/client/method';
-import { getLocalStorageSession } from '@/client/localStorage';
+import { clearLocalStorageSession, getLocalStorageSession } from '@/client/localStorage';
 import { getClientConfig } from '@/client/clientConfig';
 import type { ClientInfo } from '@/methods/types';
 import { OAuthProvider } from '../types';
@@ -151,6 +151,7 @@ export async function resendEmailVerification(options: { email: string }) {
  */
 export async function logout() {
   await callMethod('_system.user.logout');
+  clearLocalStorageSession();
   const config = getClientConfig();
   if (config) {
     config.setAuthToken(null);

--- a/packages/modelence/src/auth/client/index.ts
+++ b/packages/modelence/src/auth/client/index.ts
@@ -1,6 +1,10 @@
 import { setCurrentUser } from '@/client/session';
 import { callMethod } from '@/client/method';
-import { clearLocalStorageSession, getLocalStorageSession } from '@/client/localStorage';
+import {
+  clearLocalStorageSession,
+  getLocalStorageSession,
+  setLocalStorageSession,
+} from '@/client/localStorage';
 import { getClientConfig } from '@/client/clientConfig';
 import type { ClientInfo } from '@/methods/types';
 import { OAuthProvider } from '../types';
@@ -24,6 +28,15 @@ type RawUserData = {
   lastName?: string;
   avatarUrl?: string;
 };
+
+function persistSession(session: { authToken: string }) {
+  const config = getClientConfig();
+  if (config) {
+    config.setAuthToken(session.authToken);
+  } else {
+    setLocalStorageSession(session);
+  }
+}
 
 /**
  * Sign up a new user with an email and password.
@@ -78,10 +91,7 @@ export async function loginWithPassword(options: { email: string; password: stri
       password,
     }
   );
-  const config = getClientConfig();
-  if (config) {
-    config.setAuthToken(session.authToken);
-  }
+  persistSession(session);
   const enrichedUser = setCurrentUser(user);
   return enrichedUser;
 }
@@ -209,10 +219,7 @@ export async function loginWithMagicLink() {
   const { user, session } = await callMethod<{ user: RawUserData; session: { authToken: string } }>(
     '_system.user.loginWithMagicLink'
   );
-  const config = getClientConfig();
-  if (config) {
-    config.setAuthToken(session.authToken);
-  }
+  persistSession(session);
   const enrichedUser = setCurrentUser(user);
   return enrichedUser;
 }
@@ -239,10 +246,7 @@ export async function loginWithOneTimeCode(options: { email: string; code: strin
     '_system.user.loginWithOneTimeCode',
     { email, code }
   );
-  const config = getClientConfig();
-  if (config) {
-    config.setAuthToken(session.authToken);
-  }
+  persistSession(session);
   const enrichedUser = setCurrentUser(user);
   return enrichedUser;
 }

--- a/packages/modelence/src/client/localStorage.test.ts
+++ b/packages/modelence/src/client/localStorage.test.ts
@@ -1,4 +1,8 @@
-import { getLocalStorageSession, setLocalStorageSession } from './localStorage';
+import {
+  clearLocalStorageSession,
+  getLocalStorageSession,
+  setLocalStorageSession,
+} from './localStorage';
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -93,6 +97,16 @@ describe('client/localStorage', () => {
       setLocalStorageSession(complexSession);
       const retrieved = getLocalStorageSession();
       expect(retrieved).toEqual(complexSession);
+    });
+  });
+
+  describe('clearLocalStorageSession', () => {
+    test('should remove the stored session', () => {
+      setLocalStorageSession({ authToken: 'token' });
+
+      clearLocalStorageSession();
+
+      expect(getLocalStorageSession()).toBeNull();
     });
   });
 });

--- a/packages/modelence/src/client/localStorage.ts
+++ b/packages/modelence/src/client/localStorage.ts
@@ -25,3 +25,11 @@ export function setLocalStorageSession(session: object) {
 
   globalThis.localStorage.setItem(SESSION_KEY, JSON.stringify(session));
 }
+
+export function clearLocalStorageSession() {
+  if (!hasLocalStorage()) {
+    return;
+  }
+
+  globalThis.localStorage.removeItem(SESSION_KEY);
+}


### PR DESCRIPTION
## Summary

Closes #320.

Browser logout cleared the in-memory user, but retained `modelence.session` in `localStorage`. That stale token was then included in later client initialization and method requests.

This PR removes browser session storage after the server confirms logout, while retaining the existing `ClientConfig.setAuthToken(null)` behavior for custom clients.

## Re-login behavior

The login helpers now persist their returned session in browser storage as well. This covers password, magic-link, and one-time-code login, so a same-page re-login immediately restores authentication for subsequent method calls, WebSocket connections, and OAuth linking. Custom clients continue to store tokens through `ClientConfig.setAuthToken`.

## Changes

- add a guarded `clearLocalStorageSession()` helper;
- clear browser session storage after a successful logout;
- centralize post-login session persistence across all login methods; and
- cover logout, browser login, and custom-client storage behavior with unit tests.

## Verification

- `npm test` — 93 files / 861 tests passed
- `npm run build` — passed
- `npx tsc --noEmit` — passed
- Prettier and `git diff --check` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication session persistence and logout cleanup; incorrect behavior could leak credentials or break sign-in, but the change is narrow and well covered by tests.
> 
> **Overview**
> Fixes logout leaving a stale `modelence.session` token in **localStorage**, which could still be sent on later requests via `getAuthToken()`.
> 
> Adds **`clearLocalStorageSession()`** (same non-browser guard as other session helpers) and calls it after a successful server logout, alongside the existing **`ClientConfig.setAuthToken(null)`** path.
> 
> Refactors password, magic link, and one-time-code sign-in to use **`persistSession`**, which writes the auth token through custom client config when present and otherwise **`setLocalStorageSession`**—so default browser clients persist sessions on login, not only on logout cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd8896ac83d67cc843d1155fd17f7dcef61c4c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->