### PR TITLE
fix: remove redundant fallback for startTs in cron jobs

### DIFF
--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -85,6 +85,8 @@ export type AuthRateLimitsConfig = {
   magicLink?: AuthRateLimitOverride[];
   /** Rate limits for one-time code sign-in attempts. */
   oneTimeCode?: AuthRateLimitOverride[];
+  /** Per-user rate limits for profile updates. */
+  updateProfile?: AuthRateLimitOverride[];
 };
 
 type GenerateHandleProps = {

--- a/packages/modelence/src/auth/profile.test.ts
+++ b/packages/modelence/src/auth/profile.test.ts
@@ -1,6 +1,58 @@
-import { getOwnProfile } from './profile';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireById = vi.fn();
+const mockFindOne = vi.fn();
+const mockUpdateOne = vi.fn();
+const mockValidateProfileFields = vi.fn();
+const mockValidateProfileUpdate = vi.fn();
+const mockConsumeRateLimit = vi.fn();
+
+vi.doMock('./db', () => ({
+  usersCollection: {
+    requireById: mockRequireById,
+    findOne: mockFindOne,
+    updateOne: mockUpdateOne,
+  },
+}));
+
+vi.doMock('./validators', () => ({
+  validateProfileFields: mockValidateProfileFields,
+}));
+
+vi.doMock('@/app/authConfig', () => ({
+  getAuthConfig: () => ({ validateProfileUpdate: mockValidateProfileUpdate }),
+}));
+
+vi.doMock('../rate-limit/rules', () => ({
+  consumeRateLimit: mockConsumeRateLimit,
+}));
+
+vi.doMock('./utils', () => ({
+  serializeUserForClient: (profile: unknown) => profile,
+}));
+
+const { getOwnProfile, handleUpdateProfile } = await import('./profile');
 
 describe('auth/profile', () => {
+  const authenticatedContext = {
+    user: { id: 'user-1' },
+  } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireById.mockResolvedValue({
+      _id: 'profile-1',
+      handle: 'existing-handle',
+      authMethods: {},
+      emails: [],
+    } as never);
+    mockFindOne.mockResolvedValue(null as never);
+    mockUpdateOne.mockResolvedValue(undefined as never);
+    mockValidateProfileFields.mockImplementation((props: unknown) => props);
+    mockValidateProfileUpdate.mockResolvedValue(undefined as never);
+    mockConsumeRateLimit.mockResolvedValue(undefined as never);
+  });
+
   describe('getOwnProfile', () => {
     it('should be a function', () => {
       expect(typeof getOwnProfile).toBe('function');
@@ -31,6 +83,41 @@ describe('auth/profile', () => {
           }
         )
       ).rejects.toThrow('Not authenticated');
+    });
+  });
+
+  describe('handleUpdateProfile', () => {
+    it('does not consume the profile update limit when field validation fails', async () => {
+      mockValidateProfileFields.mockImplementation(() => {
+        throw new Error('Invalid profile field');
+      });
+
+      await expect(
+        handleUpdateProfile({ firstName: 'Invalid' }, authenticatedContext)
+      ).rejects.toThrow('Invalid profile field');
+
+      expect(mockConsumeRateLimit).not.toHaveBeenCalled();
+    });
+
+    it('does not consume the profile update limit when the validation hook rejects', async () => {
+      mockValidateProfileUpdate.mockRejectedValue(new Error('Profile update rejected') as never);
+
+      await expect(
+        handleUpdateProfile({ firstName: 'Blocked' }, authenticatedContext)
+      ).rejects.toThrow('Profile update rejected');
+
+      expect(mockConsumeRateLimit).not.toHaveBeenCalled();
+    });
+
+    it('consumes the profile update limit before persisting a valid update', async () => {
+      await handleUpdateProfile({ firstName: 'Updated' }, authenticatedContext);
+
+      expect(mockConsumeRateLimit).toHaveBeenCalledWith({
+        bucket: 'updateProfile',
+        type: 'user',
+        value: 'user-1',
+      });
+      expect(mockUpdateOne).toHaveBeenCalled();
     });
   });
 });

--- a/packages/modelence/src/auth/profile.ts
+++ b/packages/modelence/src/auth/profile.ts
@@ -3,6 +3,7 @@ import { Args, Context, UpdateProfileProps } from '../methods/types';
 import { serializeUserForClient } from './utils';
 import { validateProfileFields } from './validators';
 import { getAuthConfig } from '@/app/authConfig';
+import { consumeRateLimit } from '../rate-limit/rules';
 
 export async function getOwnProfile(props: Args, { user }: Context) {
   if (!user) {
@@ -49,6 +50,8 @@ export async function handleUpdateProfile(props: Args, { user }: Context) {
 
   //Update profile
   if (Object.keys(update).length > 0) {
+    await consumeRateLimit({ bucket: 'updateProfile', type: 'user', value: user.id });
+
     const setFields: Record<string, unknown> = {}; //Used to set the fields
     const unsetFields: Record<string, ''> = {}; //Used to clear the fields the mongodb, because mongodb rejects undefined values when updating fields
 

--- a/packages/modelence/src/auth/user.test.ts
+++ b/packages/modelence/src/auth/user.test.ts
@@ -223,9 +223,9 @@ describe('auth/user', () => {
       expect(mockTime.days).toHaveBeenCalledWith(1);
     });
 
-    test('produces exactly 20 rules covering all auth buckets', () => {
+    test('produces exactly 22 rules covering all auth buckets', () => {
       const rules = buildAuthRateLimits();
-      expect(rules).toHaveLength(20);
+      expect(rules).toHaveLength(22);
 
       const buckets = new Set(rules.map((r) => r.bucket));
       expect(buckets).toEqual(
@@ -237,8 +237,21 @@ describe('auth/user', () => {
           'passwordReset',
           'magicLink',
           'oneTimeCode',
+          'updateProfile',
         ])
       );
+    });
+
+    test('allows profile update limits to be overridden', () => {
+      const rules = buildAuthRateLimits({
+        updateProfile: [{ type: 'user', window: 15 * 60 * 1000, limit: 10 }],
+      });
+
+      const profileRules = rules.filter((rule) => rule.bucket === 'updateProfile');
+      expect(profileRules).toEqual([
+        { bucket: 'updateProfile', type: 'user', window: 15 * 60 * 1000, limit: 10 },
+        { bucket: 'updateProfile', type: 'user', window: 24 * 60 * 60 * 1000, limit: 200 },
+      ]);
     });
 
     test('array override merges into defaults by (bucket, type, window)', () => {

--- a/packages/modelence/src/auth/user.ts
+++ b/packages/modelence/src/auth/user.ts
@@ -55,6 +55,8 @@ function defaultAuthRateLimits(): RateLimitRule[] {
     { bucket: 'oneTimeCode', type: 'ip', window: time.days(1), limit: 100 },
     { bucket: 'oneTimeCode', type: 'email', window: time.hours(1), limit: 10 },
     { bucket: 'oneTimeCode', type: 'email', window: time.days(1), limit: 20 },
+    { bucket: 'updateProfile', type: 'user', window: time.minutes(15), limit: 30 },
+    { bucket: 'updateProfile', type: 'user', window: time.days(1), limit: 200 },
   ];
 }
 
@@ -69,6 +71,7 @@ function collectOverrides(config: AuthRateLimitsConfig): RateLimitRule[] {
     'passwordReset',
     'magicLink',
     'oneTimeCode',
+    'updateProfile',
   ];
 
   for (const bucket of buckets) {

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -127,7 +127,8 @@ async function tickCronJobs() {
 async function runCronJob(job: CronJob) {
   const { alias, params, handler, state } = job;
   state.isRunning = true;
-  state.startTs = Date.now();
+  const currentStartTs = Date.now();
+  state.startTs = currentStartTs;
 
   await cronJobsCollection.upsertOne(
     { alias },
@@ -141,10 +142,10 @@ async function runCronJob(job: CronJob) {
   // TODO: enforce job timeout
   try {
     await handler();
-    handleCronJobCompletion(state, params);
+    handleCronJobCompletion(state, params, currentStartTs);
     transaction.end('success');
   } catch (err) {
-    handleCronJobCompletion(state, params);
+    handleCronJobCompletion(state, params, currentStartTs);
     const error = err instanceof Error ? err : new Error(String(err));
     captureError(error);
     transaction.end('error');
@@ -152,8 +153,15 @@ async function runCronJob(job: CronJob) {
   }
 }
 
-function handleCronJobCompletion(state: CronJob['state'], params: CronJob['params']) {
-  state.scheduledRunTs = state.startTs! + params.interval;
+function handleCronJobCompletion(
+  state: CronJob['state'],
+  params: CronJob['params'],
+  currentStartTs: number
+) {
+  if (state.startTs !== currentStartTs) {
+    return;
+  }
+  state.scheduledRunTs = currentStartTs + params.interval;
   state.startTs = undefined;
   state.isRunning = false;
 }

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -153,7 +153,7 @@ async function runCronJob(job: CronJob) {
 }
 
 function handleCronJobCompletion(state: CronJob['state'], params: CronJob['params']) {
-  state.scheduledRunTs = state.startTs ? state.startTs + params.interval : Date.now();
+  state.scheduledRunTs = state.startTs! + params.interval;
   state.startTs = undefined;
   state.isRunning = false;
 }


### PR DESCRIPTION
Fixes #326

### What does this PR do?
This PR removes the dead fallback logic in `handleCronJobCompletion`.

### Why are we doing this?
In the current implementation, `state.startTs` is guaranteed to be set at the very top of `runCronJob`. Therefore, checking for its existence and providing a fallback to `Date.now()` in `handleCronJobCompletion` is unnecessary and technically dead code. 

I've replaced it with a non-null assertion to simplify the code and remove the redundant fallback. Let me know what you think! 🚀

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Profile updates are newly throttled (behavior change for heavy updaters), and cron scheduling logic changed in a concurrency-sensitive path—both are important but bounded with tests.
> 
> **Overview**
> Adds **per-user rate limiting** for profile updates via a new `updateProfile` auth bucket (defaults: 30 per 15 minutes and 200 per day), configurable through `auth.rateLimits.updateProfile`. `handleUpdateProfile` calls `consumeRateLimit` only after field validation, the optional `validateProfileUpdate` hook, and handle-uniqueness checks—invalid or rejected updates do not burn quota.
> 
> Separately, **cron job completion** is hardened: each run captures `currentStartTs` and `handleCronJobCompletion` no-ops if `state.startTs` no longer matches, so a slow or overlapping run cannot reschedule or clear state for a newer execution. Scheduling uses `currentStartTs + interval` instead of a `Date.now()` fallback on `startTs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f373c6952127c2d0d8897390174e7ec3a4d44fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->