### PR TITLE
fix: prevent memory leak from process event listeners

### DIFF
--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -75,6 +75,8 @@ function registerModuleRoutes(app: express.Application, modules: Module[]) {
   }
 }
 
+let globalProcessListenersRegistered = false;
+
 export async function startServer(
   server: AppServer,
   {
@@ -161,18 +163,21 @@ export async function startServer(
     Promise.resolve(server.handler(req, res)).catch(next);
   });
 
-  process.on('unhandledRejection', (reason, promise) => {
-    console.error('Unhandled Promise Rejection:');
-    console.error(reason instanceof Error ? reason.stack : reason);
-    console.error('Promise:', promise);
-  });
+  if (!globalProcessListenersRegistered) {
+    globalProcessListenersRegistered = true;
+    process.on('unhandledRejection', (reason, promise) => {
+      console.error('Unhandled Promise Rejection:');
+      console.error(reason instanceof Error ? reason.stack : reason);
+      console.error('Promise:', promise);
+    });
 
-  // Global uncaught exceptions
-  process.on('uncaughtException', (error) => {
-    console.error('Uncaught Exception:');
-    console.error(error.stack); // This gives you the full stack trace
-    console.trace('Full application stack:'); // Additional context
-  });
+    // Global uncaught exceptions
+    process.on('uncaughtException', (error) => {
+      console.error('Uncaught Exception:');
+      console.error(error.stack); // This gives you the full stack trace
+      console.trace('Full application stack:'); // Additional context
+    });
+  }
 
   const websocketProvider = getWebsocketConfig()?.provider;
   if (websocketProvider) {


### PR DESCRIPTION
This PR fixes a MaxListenersExceededWarning caused by repeatedly registering `process.on` listeners in `startServer` across tests. It uses a module-level variable to ensure they are added only once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change around existing logging handlers; no new behavior on first boot and no auth or data-path impact.
> 
> **Overview**
> **Fixes listener accumulation** when `startServer` runs multiple times in the same Node process (e.g. repeated test runs), which triggered `MaxListenersExceededWarning`.
> 
> Global `unhandledRejection` and `uncaughtException` handlers are now registered behind a module-level `globalProcessListenersRegistered` guard so they attach **once**; later `startServer` calls skip re-registration. Handler behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e6c1dd3dd4834edffbf41222d70d75058612230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->