### PR TITLE
fix: add regex validation for handle to allow only alphanumeric chars

### DIFF
--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -306,8 +306,10 @@ export type AuthConfig = {
    * Custom handle generator. If provided, overrides the default behavior
    * (which derives the handle from the email local-part). Receives
    * `{ email, firstName?, lastName? }` and returns the desired handle
-   * synchronously or as a `Promise<string>`. If the returned handle collides
-   * with an existing one, Modelence appends a numeric suffix automatically.
+   * synchronously or as a `Promise<string>`. The returned handle must contain
+   * only letters, numbers, underscores, and hyphens (matching `HANDLE_REGEX`).
+   * If the returned handle collides with an existing one, Modelence appends
+   * a numeric suffix automatically.
    */
   generateHandle?: (props: GenerateHandleProps) => Promise<string> | string;
 

--- a/packages/modelence/src/auth/profile.test.ts
+++ b/packages/modelence/src/auth/profile.test.ts
@@ -119,5 +119,19 @@ describe('auth/profile', () => {
       });
       expect(mockUpdateOne).toHaveBeenCalled();
     });
+
+    it('allows legacy users with invalid handle characters to update other fields when handle is unchanged', async () => {
+      mockRequireById.mockResolvedValueOnce({
+        _id: 'legacy-1',
+        handle: 'legacy.user',
+      });
+
+      await handleUpdateProfile(
+        { handle: 'legacy.user', firstName: 'Updated' },
+        authenticatedContext
+      );
+
+      expect(mockValidateProfileFields).toHaveBeenCalledWith({ firstName: 'Updated' });
+    });
   });
 });

--- a/packages/modelence/src/auth/profile.ts
+++ b/packages/modelence/src/auth/profile.ts
@@ -29,7 +29,14 @@ export async function handleUpdateProfile(props: Args, { user }: Context) {
 
   let profile = await usersCollection.requireById(user.id);
 
-  const update = validateProfileFields(props as UpdateProfileProps);
+  const rawProps = props as UpdateProfileProps;
+  const isHandleUnchanged =
+    typeof rawProps.handle === 'string' && rawProps.handle.trim() === profile.handle;
+
+  const { handle: _ignoredHandle, ...propsWithoutHandle } = rawProps;
+  const update = validateProfileFields(
+    isHandleUnchanged ? (propsWithoutHandle as UpdateProfileProps) : rawProps
+  );
 
   await getAuthConfig().validateProfileUpdate?.(update);
 

--- a/packages/modelence/src/auth/utils.test.ts
+++ b/packages/modelence/src/auth/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { resolveUniqueHandle } from './utils';
+import { usersCollection } from './db';
+import { validateHandle } from './validators';
+
+vi.mock('./db', () => ({
+  usersCollection: {
+    findOne: vi.fn(),
+  },
+}));
+
+describe('auth/utils resolveUniqueHandle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('sanitizes dots and pluses from email local-part into valid handles', async () => {
+    vi.mocked(usersCollection.findOne).mockResolvedValue(null);
+
+    const handle = await resolveUniqueHandle(undefined, 'john.doe+test@example.com');
+    expect(handle).toBe('john_doe_test');
+    expect(() => validateHandle(handle)).not.toThrow();
+  });
+
+  test('pads short local-part with underscores', async () => {
+    vi.mocked(usersCollection.findOne).mockResolvedValue(null);
+
+    const handle = await resolveUniqueHandle(undefined, 'a@example.com');
+    expect(handle).toBe('a__');
+    expect(() => validateHandle(handle)).not.toThrow();
+  });
+});

--- a/packages/modelence/src/auth/utils.ts
+++ b/packages/modelence/src/auth/utils.ts
@@ -159,7 +159,9 @@ export async function resolveUniqueHandle(
   }
 
   // Derive handle from the email local-part (everything before '@').
+  // Sanitize non-alphanumeric/underscore/hyphen characters to satisfy HANDLE_REGEX.
   // Truncate to MAX_HANDLE_LENGTH since RFC 5321 allows local parts up to 64 chars.
-  const baseHandle = email.split('@')[0].padEnd(MIN_HANDLE_LENGTH, '_').slice(0, MAX_HANDLE_LENGTH);
+  const rawBase = email.split('@')[0].replace(/[^a-zA-Z0-9_-]/g, '_');
+  const baseHandle = rawBase.padEnd(MIN_HANDLE_LENGTH, '_').slice(0, MAX_HANDLE_LENGTH);
   return findAvailableHandle(baseHandle);
 }

--- a/packages/modelence/src/auth/utils.ts
+++ b/packages/modelence/src/auth/utils.ts
@@ -123,7 +123,9 @@ export async function resolveUniqueHandle(
   }
 
   // Derive handle from the email local-part (everything before '@').
+  // Sanitize non-alphanumeric/underscore/hyphen characters to satisfy HANDLE_REGEX.
   // Truncate to MAX_HANDLE_LENGTH since RFC 5321 allows local parts up to 64 chars.
-  const baseHandle = email.split('@')[0].padEnd(MIN_HANDLE_LENGTH, '_').slice(0, MAX_HANDLE_LENGTH);
+  const rawBase = email.split('@')[0].replace(/[^a-zA-Z0-9_-]/g, '_');
+  const baseHandle = rawBase.padEnd(MIN_HANDLE_LENGTH, '_').slice(0, MAX_HANDLE_LENGTH);
   return findAvailableHandle(baseHandle);
 }

--- a/packages/modelence/src/auth/validators.test.ts
+++ b/packages/modelence/src/auth/validators.test.ts
@@ -75,7 +75,7 @@ describe('auth/validators', () => {
     test('should accept valid handles between 3 and 50 characters', () => {
       expect(validateHandle('abc')).toBe('abc');
       expect(validateHandle('my_handle')).toBe('my_handle');
-      expect(validateHandle('user123')).toBe('user123');
+      expect(validateHandle('user-123')).toBe('user-123');
     });
 
     test('should throw error for handle shorter than 3 characters', () => {
@@ -87,6 +87,18 @@ describe('auth/validators', () => {
     test('should throw error for handle longer than 50 characters', () => {
       const longHandle = 'a'.repeat(51);
       expect(() => validateHandle(longHandle)).toThrow('must be at most 50 characters');
+    });
+
+    test('should throw error for handle with spaces or invalid special characters', () => {
+      expect(() => validateHandle('user name')).toThrow(
+        'must contain only letters, numbers, underscores, and hyphens'
+      );
+      expect(() => validateHandle('user@123')).toThrow(
+        'must contain only letters, numbers, underscores, and hyphens'
+      );
+      expect(() => validateHandle('user.name!')).toThrow(
+        'must contain only letters, numbers, underscores, and hyphens'
+      );
     });
 
     test('should accept handle at exactly 3 and 50 characters', () => {

--- a/packages/modelence/src/auth/validators.ts
+++ b/packages/modelence/src/auth/validators.ts
@@ -3,6 +3,7 @@ import { UpdateProfileProps } from '../methods/types';
 
 export const MIN_HANDLE_LENGTH = 3;
 export const MAX_HANDLE_LENGTH = 50;
+export const HANDLE_REGEX = /^[a-zA-Z0-9_-]+$/;
 
 export const MIN_PASSWORD_LENGTH = 8;
 export const MAX_PASSWORD_LENGTH = 128;
@@ -25,13 +26,20 @@ const trimmedOptionalString = (opts: { max: number }) =>
     .transform((val) => (val === '' ? undefined : val))
     .optional();
 
+const handleSchema = trimmedNonEmptyString({
+  min: MIN_HANDLE_LENGTH,
+  max: MAX_HANDLE_LENGTH,
+}).regex(HANDLE_REGEX, {
+  message: 'must contain only letters, numbers, underscores, and hyphens',
+});
+
 // Base schema (used for both full & partial validation)
 const profileFieldsSchema = z
   .object({
     firstName: trimmedOptionalString({ max: 50 }),
     lastName: trimmedOptionalString({ max: 50 }),
     avatarUrl: trimmedOptionalString({ max: 400 }),
-    handle: trimmedNonEmptyString({ min: MIN_HANDLE_LENGTH, max: MAX_HANDLE_LENGTH }),
+    handle: handleSchema,
   })
   .strict();
 
@@ -84,5 +92,5 @@ export function validateEmail(value: string) {
 }
 
 export function validateHandle(value: string) {
-  return trimmedNonEmptyString({ min: MIN_HANDLE_LENGTH, max: MAX_HANDLE_LENGTH }).parse(value);
+  return handleSchema.parse(value);
 }


### PR DESCRIPTION
Fixes #331

### Description
Currently `validateHandle` and `validateProfileFields` in `validators.ts` only check handle min and max length (3 to 50 characters). It does not validate what characters are allowed in the handle.

Because of this, handles can be set with spaces or special characters (like `user name` or `user@123`), which can break profile URL links and routes.

### Changes
1. Added `HANDLE_REGEX = /^[a-zA-Z0-9_-]+$/` in `validators.ts`.
2. Updated `handleSchema` to check against `HANDLE_REGEX` so handles can only contain alphanumeric characters, underscores, and hyphens.
3. Added unit tests in `validators.test.ts` to test invalid handle formats (spaces, special symbols) and valid handles.

All unit tests pass and build is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth validation and signup handle generation; legacy carve-out reduces breakage for existing bad handles, but new or changed handles are enforced strictly.
> 
> **Overview**
> Handles are now restricted to letters, numbers, underscores, and hyphens via **`HANDLE_REGEX`** on **`validateHandle`** and profile updates, rejecting values like spaces or `@` that could break profile URLs.
> 
> **`handleUpdateProfile`** skips re-validating **`handle`** when the submitted value matches the stored handle (after trim), so accounts that already have “invalid” handles can still change other profile fields without being blocked.
> 
> Auto-generated handles from email local-parts in **`resolveUniqueHandle`** replace disallowed characters with underscores before length padding, and **`AuthConfig.generateHandle`** docs now state custom handles must match the same rules. Tests cover invalid formats, legacy profile updates, and email-derived handle sanitization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1540234b28a968313bf176984d45b3be33ca8633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->