### PR TITLE
fix: throw ValidationError and AuthError in profile.ts

### DIFF
--- a/packages/modelence/src/auth/profile.test.ts
+++ b/packages/modelence/src/auth/profile.test.ts
@@ -1,36 +1,101 @@
-import { getOwnProfile } from './profile';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { getOwnProfile, handleUpdateProfile } from './profile';
+import { AuthError, ValidationError } from '../error';
+import { usersCollection } from './db';
+
+vi.mock('./db', () => ({
+  usersCollection: {
+    requireById: vi.fn(),
+    findOne: vi.fn(),
+    updateOne: vi.fn(),
+  },
+}));
+
+const baseContext = {
+  session: {} as any,
+  roles: [],
+  clientInfo: {
+    screenWidth: 1920,
+    screenHeight: 1080,
+    windowWidth: 1920,
+    windowHeight: 1080,
+    pixelRatio: 1,
+    orientation: 'landscape' as const,
+  },
+  connectionInfo: {
+    userAgent: 'test',
+    ip: '127.0.0.1',
+    baseUrl: 'http://localhost:3000',
+  },
+  req: null,
+  res: null,
+};
 
 describe('auth/profile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('getOwnProfile', () => {
     it('should be a function', () => {
       expect(typeof getOwnProfile).toBe('function');
     });
 
-    it('should throw error when user is not authenticated', async () => {
+    it('should throw AuthError when user is not authenticated', async () => {
+      await expect(getOwnProfile({}, { ...baseContext, user: null })).rejects.toThrowError(
+        AuthError
+      );
+    });
+
+    it('should retrieve own profile when authenticated', async () => {
+      const mockProfile = {
+        _id: 'user-id',
+        handle: 'john_doe',
+        emails: [],
+        authMethods: {},
+      };
+      vi.mocked(usersCollection.requireById).mockResolvedValue(mockProfile as any);
+
+      const result = await getOwnProfile(
+        {},
+        { ...baseContext, user: { id: 'user-id', handle: 'john_doe', roles: [] } as any }
+      );
+      expect(result.handle).toBe('john_doe');
+    });
+  });
+
+  describe('handleUpdateProfile', () => {
+    it('should throw AuthError when user is not authenticated', async () => {
+      await expect(handleUpdateProfile({}, { ...baseContext, user: null })).rejects.toThrowError(
+        AuthError
+      );
+    });
+
+    it('should throw ValidationError when handle is already taken', async () => {
+      const activeUser = { id: 'user-id-1', handle: 'user1', roles: [] };
+      const existingUserInDb = { _id: 'user-id-2', handle: 'taken_handle' };
+
+      vi.mocked(usersCollection.requireById).mockResolvedValue({
+        _id: 'user-id-1',
+        handle: 'user1',
+      } as any);
+      vi.mocked(usersCollection.findOne).mockResolvedValue(existingUserInDb as any);
+
       await expect(
-        getOwnProfile(
-          {},
-          {
-            user: null,
-            session: null,
-            roles: [],
-            clientInfo: {
-              screenWidth: 1920,
-              screenHeight: 1080,
-              windowWidth: 1920,
-              windowHeight: 1080,
-              pixelRatio: 1,
-              orientation: 'landscape',
-            },
-            connectionInfo: {
-              userAgent: 'test',
-              ip: '127.0.0.1',
-            },
-            req: null,
-            res: null,
-          }
-        )
-      ).rejects.toThrow('Not authenticated');
+        handleUpdateProfile({ handle: 'taken_handle' }, { ...baseContext, user: activeUser as any })
+      ).rejects.toThrowError(ValidationError);
+    });
+
+    it('should throw ValidationError when profile validation fails', async () => {
+      const activeUser = { id: 'user-id-1', handle: 'user1', roles: [] };
+      vi.mocked(usersCollection.requireById).mockResolvedValue({
+        _id: 'user-id-1',
+        handle: 'user1',
+      } as any);
+
+      await expect(
+        handleUpdateProfile({ handle: 'sh' }, { ...baseContext, user: activeUser as any }) // shorter than MIN_HANDLE_LENGTH
+      ).rejects.toThrowError(ValidationError);
     });
   });
 });

--- a/packages/modelence/src/auth/profile.test.ts
+++ b/packages/modelence/src/auth/profile.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthError, ValidationError } from '../error';
 
 const mockRequireById = vi.fn();
 const mockFindOne = vi.fn();
@@ -58,43 +59,47 @@ describe('auth/profile', () => {
       expect(typeof getOwnProfile).toBe('function');
     });
 
-    it('should throw error when user is not authenticated', async () => {
-      await expect(
-        getOwnProfile(
-          {},
-          {
-            user: null,
-            session: null,
-            roles: [],
-            clientInfo: {
-              screenWidth: 1920,
-              screenHeight: 1080,
-              windowWidth: 1920,
-              windowHeight: 1080,
-              pixelRatio: 1,
-              orientation: 'landscape',
-            },
-            connectionInfo: {
-              userAgent: 'test',
-              ip: '127.0.0.1',
-            },
-            req: null,
-            res: null,
-          }
-        )
-      ).rejects.toThrow('Not authenticated');
+    it('should throw AuthError when user is not authenticated', async () => {
+      await expect(getOwnProfile({}, { user: null } as never)).rejects.toThrowError(AuthError);
+    });
+
+    it('should retrieve own profile when authenticated', async () => {
+      const mockProfile = {
+        _id: 'user-id',
+        handle: 'john_doe',
+        emails: [],
+        authMethods: {},
+      };
+      mockRequireById.mockResolvedValueOnce(mockProfile);
+
+      const result = await getOwnProfile({}, authenticatedContext);
+      expect(result.handle).toBe('john_doe');
     });
   });
 
   describe('handleUpdateProfile', () => {
+    it('should throw AuthError when user is not authenticated', async () => {
+      await expect(handleUpdateProfile({}, { user: null } as never)).rejects.toThrowError(
+        AuthError
+      );
+    });
+
+    it('should throw ValidationError when handle is already taken', async () => {
+      mockFindOne.mockResolvedValueOnce({ _id: 'user-id-2', handle: 'taken_handle' });
+
+      await expect(
+        handleUpdateProfile({ handle: 'taken_handle' }, authenticatedContext)
+      ).rejects.toThrowError(ValidationError);
+    });
+
     it('does not consume the profile update limit when field validation fails', async () => {
       mockValidateProfileFields.mockImplementation(() => {
-        throw new Error('Invalid profile field');
+        throw new ValidationError('Invalid profile field');
       });
 
       await expect(
         handleUpdateProfile({ firstName: 'Invalid' }, authenticatedContext)
-      ).rejects.toThrow('Invalid profile field');
+      ).rejects.toThrowError(ValidationError);
 
       expect(mockConsumeRateLimit).not.toHaveBeenCalled();
     });

--- a/packages/modelence/src/auth/profile.ts
+++ b/packages/modelence/src/auth/profile.ts
@@ -3,10 +3,11 @@ import { Args, Context, UpdateProfileProps } from '../methods/types';
 import { serializeUserForClient } from './utils';
 import { validateProfileFields } from './validators';
 import { getAuthConfig } from '@/app/authConfig';
+import { AuthError, ValidationError } from '../error';
 
 export async function getOwnProfile(props: Args, { user }: Context) {
   if (!user) {
-    throw new Error('Not authenticated');
+    throw new AuthError('Not authenticated');
   }
 
   const profile = await usersCollection.requireById(user.id);
@@ -23,7 +24,7 @@ export async function getOwnProfile(props: Args, { user }: Context) {
 
 export async function handleUpdateProfile(props: Args, { user }: Context) {
   if (!user) {
-    throw new Error('Not authenticated');
+    throw new AuthError('Not authenticated');
   }
 
   let profile = await usersCollection.requireById(user.id);
@@ -43,7 +44,7 @@ export async function handleUpdateProfile(props: Args, { user }: Context) {
     );
 
     if (existing) {
-      throw new Error('Handle already taken.');
+      throw new ValidationError('Handle already taken.');
     }
   }
 
@@ -74,7 +75,7 @@ export async function handleUpdateProfile(props: Args, { user }: Context) {
       profile = { ...profile, ...setFields, ...clearedFields } as typeof profile;
     } catch (error) {
       if (error instanceof Error && 'code' in error && (error as { code: number }).code === 11000) {
-        throw new Error('Handle already taken.');
+        throw new ValidationError('Handle already taken.');
       }
       throw error;
     }

--- a/packages/modelence/src/auth/profile.ts
+++ b/packages/modelence/src/auth/profile.ts
@@ -4,10 +4,11 @@ import { serializeUserForClient } from './utils';
 import { validateProfileFields } from './validators';
 import { getAuthConfig } from '@/app/authConfig';
 import { consumeRateLimit } from '../rate-limit/rules';
+import { AuthError, ValidationError } from '../error';
 
 export async function getOwnProfile(props: Args, { user }: Context) {
   if (!user) {
-    throw new Error('Not authenticated');
+    throw new AuthError('Not authenticated');
   }
 
   const profile = await usersCollection.requireById(user.id);
@@ -24,7 +25,7 @@ export async function getOwnProfile(props: Args, { user }: Context) {
 
 export async function handleUpdateProfile(props: Args, { user }: Context) {
   if (!user) {
-    throw new Error('Not authenticated');
+    throw new AuthError('Not authenticated');
   }
 
   let profile = await usersCollection.requireById(user.id);
@@ -44,7 +45,7 @@ export async function handleUpdateProfile(props: Args, { user }: Context) {
     );
 
     if (existing) {
-      throw new Error('Handle already taken.');
+      throw new ValidationError('Handle already taken.');
     }
   }
 
@@ -77,7 +78,7 @@ export async function handleUpdateProfile(props: Args, { user }: Context) {
       profile = { ...profile, ...setFields, ...clearedFields } as typeof profile;
     } catch (error) {
       if (error instanceof Error && 'code' in error && (error as { code: number }).code === 11000) {
-        throw new Error('Handle already taken.');
+        throw new ValidationError('Handle already taken.');
       }
       throw error;
     }

--- a/packages/modelence/src/auth/validators.ts
+++ b/packages/modelence/src/auth/validators.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { UpdateProfileProps } from '../methods/types';
+import { ValidationError } from '../error';
 
 export const MIN_HANDLE_LENGTH = 3;
 export const MAX_HANDLE_LENGTH = 50;
@@ -54,7 +55,7 @@ export function validateProfileFields(
     const issue = result.error.issues[0];
     const path = issue.path.join('.');
     const msg = path ? `${path}: ${issue.message}` : issue.message;
-    throw new Error(msg);
+    throw new ValidationError(msg);
   }
 
   return result.data;


### PR DESCRIPTION
Fixes #332

### Description
Currently, unauthenticated profile requests and validation/handle conflict errors throw generic `Error` objects. Because these default to HTTP 500, client applications cannot tell validation and authentication failures apart from internal server errors.

This PR changes them to throw `AuthError` (HTTP 401) and `ValidationError` (HTTP 400).

### Changes
1. Updated `profile.ts` error throws to throw `AuthError` (unauthenticated user) and `ValidationError` (handle conflict).
2. Updated `validateProfileFields` in `validators.ts` to throw `ValidationError` on zod parsing failure.
3. Added unit tests in `profile.test.ts` to assert that the correct error classes are thrown.

All unit tests pass and the build is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted error-type change with clearer HTTP semantics; clients that only handled 500 for these cases may need to handle 401/400 instead.
> 
> **Overview**
> Profile auth and validation failures now surface as typed **`AuthError`** (401) and **`ValidationError`** (400) instead of generic **`Error`** (previously 500), so clients can distinguish unauthenticated, invalid fields, and handle conflicts from server faults.
> 
> **`getOwnProfile`** and **`handleUpdateProfile`** throw **`AuthError`** when there is no user. Handle uniqueness (lookup and Mongo duplicate key) and **`validateProfileFields`** Zod failures throw **`ValidationError`**.
> 
> Tests in **`profile.test.ts`** assert these error classes, cover successful **`getOwnProfile`**, and use slimmer unauthenticated context fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a07a93d79d23938794d1a0fb58bfa98c8bfc05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->