### PR TITLE
fix(resend): surface send failures instead of resolving as success (MOD-305)

### DIFF
--- a/packages/resend/src/index.ts
+++ b/packages/resend/src/index.ts
@@ -70,28 +70,29 @@ export async function sendEmail(
 ) {
   const client = initializeResendClient();
 
-  console.log("client initialized");
+  // The Resend SDK does not throw on failure: it catches both non-2xx responses
+  // and network-level errors and resolves with `{ data: null, error }`, so the
+  // returned error has to be checked explicitly.
+  const { error } = await client.emails.send({
+    from,
+    to,
+    subject,
+    html,
+    text,
+    react: undefined,
+    cc,
+    bcc,
+    replyTo,
+    headers,
+    attachments: attachments?.map(attachment => ({
+      name: attachment.filename,
+      content: attachment.content,
+      type: attachment.contentType,
+    })),
+  });
 
-  try {
-    await client.emails.send({
-      from,
-      to,
-      subject,
-      html,
-      text,
-      react: undefined,
-      cc,
-      bcc,
-      replyTo,
-      headers,
-      attachments: attachments?.map(attachment => ({
-        name: attachment.filename,
-        content: attachment.content,
-        type: attachment.contentType,
-      })),
-    });
-  } catch (error) {
-    throw new Error(`Failed to send email using Resend: ${error instanceof Error ? error.message : String(error)}`);
+  if (error) {
+    throw new Error(`Failed to send email using Resend (${error.name}): ${error.message}`);
   }
 }
 


### PR DESCRIPTION
Fixes the root cause of [MOD-305](https://linear.app/modelence/issue/MOD-305/catch-and-surface-email-sending-errors-more-explicitly-for-app-builder) — "error in the Resend dashboard, success in the app, nothing in the server logs".

## Cause

`packages/resend/src/index.ts` did `await client.emails.send(...)` and discarded the result. **The Resend SDK never throws** — `fetchRequest` (`resend/dist/index.mjs`) catches both the non-2xx branch and the network-level `fetch` rejection, and in every path returns `{ data: null, error }`:

```js
async fetchRequest(path, options = {}) {
  try {
    const response = await fetch(`${baseUrl}${path}`, options);
    if (!response.ok) { ... return { data: null, error: JSON.parse(rawError), ... }; }
    return { data: await response.json(), error: null, ... };
  } catch {
    return { data: null, error: { name: "application_error", statusCode: null,
      message: "Unable to fetch data. The request could not be resolved." }, ... };
  }
}
```

So the adapter's `try/catch` was dead code, and **every** refused send — unverified sending domain, invalid/restricted API key, `rate_limit_exceeded`, `monthly_quota_exceeded`, network outage — resolved as success with nothing logged. Verified against `resend@6.9.2`, i.e. our current `^6.9.2` range, not just the version the reporter hit.

## Change

Check the returned error and throw with Resend's own error code and message (`error.name` is their `RESEND_ERROR_CODE_KEY`, so failures are now self-diagnosing: `validation_error`, `invalid_api_key`, `monthly_quota_exceeded`, …). Also drops a stray `console.log("client initialized")` that ran on every send.

I removed the `try/catch` rather than keeping it around the new check — it can't fire, and if it wrapped the new `throw` it would double-prefix the message. If you'd rather keep it as insurance against a future 6.x that starts throwing, say the word and I'll restore it *outside* the error check.

## Not affected

`packages/aws-ses` (AWS SDK throws) and `packages/smtp` (nodemailer throws) already propagate correctly. This is Resend-only — no shared abstraction to fix.

## Verification

`npm ci && npx tsc --noEmit && npm run build` in `packages/resend` are green (`resend@6.9.2` installed; `error.name`/`error.message` typecheck against their `ErrorResponse`). Note the Build workflow only covers `packages/modelence`, so CI here will **not** exercise this package.

## Follow-ups (not in this PR)

- Version bump + release: `@modelence/resend` is `1.0.2` on `main`; per PUBLISHING.md this needs a `@modelence/resend@1.0.3` release tag to reach apps. Left out since version bumps land as their own commits here.
- [MOD-523](https://linear.app/modelence/issue/MOD-523) is the signup-side half: `handleSignupWithPassword` commits the user row and *then* awaits the verification email with no rollback. It only became reachable through this adapter once sends can actually throw, so it's worth landing alongside.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound email error propagation for all Resend-backed sends; callers that assumed sends always succeed may now see thrown errors (intended fix).
> 
> **Overview**
> Fixes **silent email send failures** in `@modelence/resend`: the adapter now inspects the Resend SDK’s `{ data, error }` result and **throws** when `error` is set, instead of treating every send as success.
> 
> The previous `try/catch` around `client.emails.send` never ran because Resend resolves with `{ data: null, error }` for API and network failures rather than throwing. Failures are surfaced with Resend’s `error.name` and `error.message` (e.g. `validation_error`, `invalid_api_key`). A debug **`console.log("client initialized")`** on each send is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb714d1c56190b101b98c1bbd0794a478177947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->