### PR TITLE
fix: secondary email verification (MOD-559)

### DIFF
--- a/packages/modelence/src/auth/verification.test.ts
+++ b/packages/modelence/src/auth/verification.test.ts
@@ -181,11 +181,10 @@ describe('auth/verification', () => {
         {
           _id: tokenDoc.userId,
           status: { $nin: ['deleted', 'disabled'] },
-          'emails.address': tokenDoc.email,
-          'emails.verified': { $ne: true },
+          emails: { $elemMatch: { address: tokenDoc.email, verified: { $ne: true } } },
         },
         { $set: { 'emails.$.verified': true } },
-        { returnDocument: 'after' }
+        { collation: { locale: 'en', strength: 2 }, returnDocument: 'after' }
       );
       expect(mockTokensDeleteOne).toHaveBeenCalledWith({ _id: tokenDoc._id });
       expect(authConfig.onAfterEmailVerification).toHaveBeenCalledWith({
@@ -212,6 +211,151 @@ describe('auth/verification', () => {
         headers: { 'Referrer-Policy': 'no-referrer' },
         redirect: '/verified?status=verified',
       });
+    });
+
+    test('verifies a second address on an account that already has a verified one', async () => {
+      // The reported repro: account holds a verified address A plus an
+      // unverified B. The old filter's independent `'emails.verified': { $ne:
+      // true }` meant "no element is verified", so B could never be verified.
+      const tokenDoc = {
+        _id: 'token-id',
+        token: 'token',
+        userId: 'user123',
+        email: 'b@example.com',
+        expiresAt: new Date(Date.now() + 1000),
+      };
+      mockTokensFindOne.mockResolvedValue(tokenDoc as never);
+      mockUsersFindOne.mockResolvedValueOnce({
+        _id: 'user123',
+        emails: [
+          { address: 'a@example.com', verified: true },
+          { address: 'b@example.com', verified: false },
+        ],
+      } as never);
+      mockFindOneAndUpdate.mockResolvedValue({
+        _id: 'user123',
+        emails: [
+          { address: 'a@example.com', verified: true },
+          { address: 'b@example.com', verified: true },
+        ],
+      } as never);
+      mockCreateSession.mockResolvedValue({ authToken: 'session-token-123' } as never);
+
+      const result = await handleVerifyEmail(baseParams as never);
+
+      // The selector must scope both conditions to the single element carrying
+      // the address, so the already-verified A cannot block B.
+      expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emails: { $elemMatch: { address: 'b@example.com', verified: { $ne: true } } },
+        }),
+        { $set: { 'emails.$.verified': true } },
+        { collation: { locale: 'en', strength: 2 }, returnDocument: 'after' }
+      );
+      expect(result).toEqual({
+        status: 301,
+        headers: { 'Referrer-Policy': 'no-referrer' },
+        redirect: '/verified?status=verified',
+      });
+    });
+
+    test('reports already-verified only when that specific address is verified', async () => {
+      const tokenDoc = {
+        _id: 'token-id',
+        token: 'token',
+        userId: 'user123',
+        email: 'b@example.com',
+        expiresAt: new Date(Date.now() + 1000),
+      };
+      mockTokensFindOne.mockResolvedValue(tokenDoc as never);
+      mockUsersFindOne.mockResolvedValueOnce({
+        _id: 'user123',
+        emails: [
+          { address: 'a@example.com', verified: true },
+          { address: 'b@example.com', verified: true },
+        ],
+      } as never);
+      mockFindOneAndUpdate.mockResolvedValue(null as never);
+
+      const result = await handleVerifyEmail(baseParams as never);
+
+      expect(result).toEqual({
+        status: 301,
+        headers: { 'Referrer-Policy': 'no-referrer' },
+        redirect: '/verified?status=error&message=Email%20is%20already%20verified',
+      });
+    });
+
+    test('does not claim already-verified when the address is still unverified', async () => {
+      // Previously the fallback only matched on address, so a failed update on
+      // an unverified address was misreported as "Email is already verified".
+      const tokenDoc = {
+        _id: 'token-id',
+        token: 'token',
+        userId: 'user123',
+        email: 'b@example.com',
+        expiresAt: new Date(Date.now() + 1000),
+      };
+      mockTokensFindOne.mockResolvedValue(tokenDoc as never);
+      mockUsersFindOne.mockResolvedValueOnce({
+        _id: 'user123',
+        emails: [{ address: 'b@example.com', verified: false }],
+      } as never);
+      mockFindOneAndUpdate.mockResolvedValue(null as never);
+
+      const result = await handleVerifyEmail(baseParams as never);
+
+      expect(result).toEqual({
+        status: 301,
+        headers: { 'Referrer-Policy': 'no-referrer' },
+        redirect: '/verified?status=error&message=Unable%20to%20verify%20email%20address',
+      });
+    });
+
+    test('reports a missing address when the user does not hold it', async () => {
+      const tokenDoc = {
+        _id: 'token-id',
+        token: 'token',
+        userId: 'user123',
+        email: 'ghost@example.com',
+        expiresAt: new Date(Date.now() + 1000),
+      };
+      mockTokensFindOne.mockResolvedValue(tokenDoc as never);
+      mockUsersFindOne.mockResolvedValueOnce({
+        _id: 'user123',
+        emails: [{ address: 'a@example.com', verified: true }],
+      } as never);
+      mockFindOneAndUpdate.mockResolvedValue(null as never);
+
+      const result = await handleVerifyEmail(baseParams as never);
+
+      expect(result).toEqual({
+        status: 301,
+        headers: { 'Referrer-Policy': 'no-referrer' },
+        redirect:
+          '/verified?status=error&message=Email%20address%20not%20found%20for%20this%20user',
+      });
+    });
+
+    test('consumes the token even when the update matches nothing', async () => {
+      // A token that always fails must not stay spendable until its 24h expiry.
+      const tokenDoc = {
+        _id: 'token-id',
+        token: 'token',
+        userId: 'user123',
+        email: 'b@example.com',
+        expiresAt: new Date(Date.now() + 1000),
+      };
+      mockTokensFindOne.mockResolvedValue(tokenDoc as never);
+      mockUsersFindOne.mockResolvedValueOnce({
+        _id: 'user123',
+        emails: [{ address: 'b@example.com', verified: true }],
+      } as never);
+      mockFindOneAndUpdate.mockResolvedValue(null as never);
+
+      await handleVerifyEmail(baseParams as never);
+
+      expect(mockTokensDeleteOne).toHaveBeenCalledWith({ _id: tokenDoc._id });
     });
 
     test('redirects with error when token is invalid', async () => {

--- a/packages/modelence/src/auth/verification.ts
+++ b/packages/modelence/src/auth/verification.ts
@@ -15,6 +15,8 @@ import { consumeRateLimit } from '@/rate-limit/rules';
 import { getConfig } from '@/config/server';
 import { createSession, setAuthTokenCookie } from './session';
 
+const USER_COLLATION = { locale: 'en', strength: 2 } as const;
+
 async function verifyEmailToken(token: string) {
   const tokenDoc = await emailVerificationTokensCollection.findOne({
     token,
@@ -40,33 +42,47 @@ async function verifyEmailToken(token: string) {
     throw new Error('Email not found in token');
   }
 
-  // Mark the specific email as verified atomically, returning the updated doc
+  // Mark the specific email as verified atomically, returning the updated doc.
+  // `$elemMatch` keeps both conditions bound to a single array element: with two
+  // independent dotted predicates, `'emails.verified': { $ne: true }` means "no
+  // element is verified", so any account already holding one verified address
+  // could never verify another, and the positional `$` had no guarantee of
+  // binding to the element carrying `address`.
+  // Same strength-2 collation as the lookups: the token always carries a
+  // lowercased address (validateEmail) while the stored address may keep its
+  // original casing (e.g. OAuth-created accounts), or the match silently fails.
   const updatedUserDoc = await usersCollection.findOneAndUpdate(
     {
       _id: tokenDoc.userId,
       status: { $nin: ['deleted', 'disabled'] },
-      'emails.address': email,
-      'emails.verified': { $ne: true },
+      emails: { $elemMatch: { address: email, verified: { $ne: true } } },
     },
     { $set: { 'emails.$.verified': true } },
-    { returnDocument: 'after' }
+    { collation: USER_COLLATION, returnDocument: 'after' }
   );
 
-  if (!updatedUserDoc) {
-    const existingUser = await usersCollection.findOne({
-      _id: tokenDoc.userId,
-      'emails.address': email,
-    });
+  // Consume the token regardless of the update outcome: it has now been
+  // presented, and leaving it spendable until its 24h expiry lets a token that
+  // always fails be replayed.
+  await emailVerificationTokensCollection.deleteOne({ _id: tokenDoc._id });
 
-    if (existingUser) {
-      throw new Error('Email is already verified');
-    } else {
+  if (!updatedUserDoc) {
+    // Distinguish "already verified" from "not this user's address" by checking
+    // the specific element, mirroring handleResendEmailVerification. The prior
+    // check only matched on address, so an address that failed to verify for any
+    // other reason was still reported as already verified.
+    const existingEmailDoc = userDoc.emails?.find((e) => e.address.toLowerCase() === email);
+
+    if (!existingEmailDoc) {
       throw new Error('Email address not found for this user');
     }
-  }
 
-  // Delete the used token
-  await emailVerificationTokensCollection.deleteOne({ _id: tokenDoc._id });
+    if (existingEmailDoc.verified) {
+      throw new Error('Email is already verified');
+    }
+
+    throw new Error('Unable to verify email address');
+  }
 
   return { userDoc: updatedUserDoc, email };
 }


### PR DESCRIPTION
This fixes 4 issues in email verification; below are the details provided by AI.

The bug
The findOneAndUpdate filter used two independent dotted predicates against the emails array:


{ 'emails.address': email,
  'emails.verified': { $ne: true } }
Because emails is an array, Mongo evaluates these against the document, not against a single element. 'emails.verified': { $ne: true } therefore means "no element has verified === true" — so as soon as an account has any verified address, no further address on that account can ever be verified. The positional $ was also unsafe: with two independent predicates there was no guarantee it bound to the element carrying address.

Fix: scope both conditions to one element with $elemMatch, which also gives $ a well-defined binding.


emails: { $elemMatch: { address: email, verified: { $ne: true } } }
Also fixed in the same function
Wrong error message. The if (!updatedUserDoc) fallback only checked { _id, 'emails.address': email }, so it threw Email is already verified — and redirected to ?status=error&message=Email%20is%20already%20verified — for an address that was not verified. It now inspects the specific email element (mirroring handleResendEmailVerification) and distinguishes three cases: address not on the account, address genuinely already verified, and a new Unable to verify email address for an unverified address whose update matched nothing. This also drops a now-redundant findOne, since the already-fetched userDoc has what's needed.

Token was never consumed on the failure path. emailVerificationTokensCollection.deleteOne(...) ran only after a successful update, so a token that always failed stayed spendable until its 24h expiry. It is now consumed regardless of outcome.

Missing collation (found while verifying, not in the original report). magicLink.ts:436-439 runs the equivalent positional update with collation: USER_COLLATION and a comment explaining why. The verify path had no collation. Since validateEmail lowercases (validators.ts:83) while stored addresses may keep their original casing — OAuth-created accounts being the documented case — the update would silently match nothing for those users. Added the same strength-2 collation. The userDoc lookup above queries by _id only, so it needs none.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 30e2b40c2ee55ab66eab90b7afd4150c7903f34d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->