### PR TITLE
fix: validate password on password reset

### DIFF
--- a/docs/web/authentication/hooks.mdx
+++ b/docs/web/authentication/hooks.mdx
@@ -17,9 +17,6 @@ startApp({
   auth: {
     validateSignup: ({ email, firstName, lastName, password, handle, avatarUrl }) => {
       // Custom validation logic
-      if (password.length < 12) {
-        throw new Error('Password must be at least 12 characters');
-      }
       if (!firstName) {
         throw new Error('First name is required');
       }
@@ -27,6 +24,13 @@ startApp({
   },
 });
 ```
+
+<Warning>
+  Don't enforce **password** rules here. `validateSignup` only runs at signup, so a user
+  could sign up with a compliant password and immediately reset to a weaker one — password
+  reset would only enforce the framework's built-in 8-character floor. Use
+  [`validatePassword`](#validatepassword) instead: it runs on every password-setting path.
+</Warning>
 
 **Props:**
 
@@ -40,6 +44,61 @@ startApp({
 | `handle`    | `string \| undefined` | 
 
 **Returns:** `void | Promise<void>` 
+
+### `validatePassword`
+
+Enforces your password policy on **every** path that sets a password — signup and password
+reset today, plus any future change-password flow. Throw an error to reject the password;
+the message is surfaced to the client.
+
+This is the hook to use for password rules. Modelence enforces a built-in floor of 8
+characters (and a 128-character ceiling) before calling it, so your hook only needs to add
+your own rules on top.
+
+```typescript
+import { startApp } from 'modelence/server';
+
+startApp({
+  auth: {
+    validatePassword: ({ password, email, context }) => {
+      if (password.length < 12) {
+        throw new Error('Password must be at least 12 characters');
+      }
+      if (password.toLowerCase().includes(email.split('@')[0])) {
+        throw new Error('Password must not contain your email address');
+      }
+    },
+  },
+});
+```
+
+The hook runs after the built-in length checks and before the password is hashed. On the
+reset path it runs *before* the reset token is consumed, so a user whose password is
+rejected can retry with the same link.
+
+**Props:**
+
+| Property   | Type                    |                                                          |
+| ---------- | ----------------------- | -------------------------------------------------------- |
+| `password` | `string`                | The candidate plaintext password                          |
+| `email`    | `string`                | Lowercased email of the account the password is set on    |
+| `context`  | `'signup' \| 'reset'`   | Which flow is setting the password                        |
+
+**Returns:** `void | Promise<void>`
+
+Use `context` when a flow needs different treatment — for example, checking a
+breach-database only on reset:
+
+```typescript
+validatePassword: async ({ password, context }) => {
+  if (password.length < 12) {
+    throw new Error('Password must be at least 12 characters');
+  }
+  if (context === 'reset' && (await isBreachedPassword(password))) {
+    throw new Error('This password has appeared in a data breach — pick another');
+  }
+},
+```
 
 ### `onBeforeSignup`
 
@@ -224,6 +283,11 @@ startApp({
     validateSignup: ({ email, password, firstName }) => {
       if (!firstName) {
         throw new Error('First name is required');
+      }
+    },
+    validatePassword: ({ password }) => {
+      if (password.length < 12) {
+        throw new Error('Password must be at least 12 characters');
       }
     },
     validateProfileUpdate: ({ handle }) => {

--- a/docs/web/authentication/index.mdx
+++ b/docs/web/authentication/index.mdx
@@ -22,7 +22,7 @@ Modelence authentication includes:
 
 Modelence splits authentication configuration across two top-level keys in `startApp`:
 
-- **`auth: { ... }`** — authentication *lifecycle*: validation hooks (`validateSignup`, `validateProfileUpdate`), event callbacks (`onAfterLogin`, `onAfterSignup`, `onAfterEmailVerification`, …), `generateHandle`, OAuth linking behavior, and `rateLimits`. See [AuthConfig](/api-reference/modelence/server/type-aliases/AuthConfig) and [Hooks](/authentication/hooks).
+- **`auth: { ... }`** — authentication *lifecycle*: validation hooks (`validateSignup`, `validatePassword`, `validateProfileUpdate`), event callbacks (`onAfterLogin`, `onAfterSignup`, `onAfterEmailVerification`, …), `generateHandle`, OAuth linking behavior, and `rateLimits`. See [AuthConfig](/api-reference/modelence/server/type-aliases/AuthConfig) and [Hooks](/authentication/hooks).
 - **`email: { ... }`** — email *delivery*: the email provider, sender address, and per-flow templates/subjects/redirect URLs for `verification` and `passwordReset`. See [Email Configuration](/email).
 
 The two are complementary: `email:` controls whether and how the verification/reset email is delivered; `auth:` controls what happens when the user clicks the link (and the rest of the auth lifecycle).
@@ -58,10 +58,11 @@ When a user signs up with email and password:
 1. **Validation** - Email format and password strength are validated
 2. **Duplicate Check** - System checks if email already exists
 3. **Validate Signup** (Optional) - If provided, validates signup using `validateSignup` hook
-4. **Password Hashing** - Password is securely hashed using bcrypt (never stored in plain text)
-5. **User Creation** - User record is created in the `_modelenceUsers` collection
-6. **Session Linking** - The session is linked to the new user
-7. **Email Verification** (Optional) - If enabled, a verification email is sent
+4. **Validate Password** (Optional) - If provided, the `validatePassword` hook enforces your password policy. This hook also runs on password reset, so a policy set here can't be bypassed by resetting to a weaker password.
+5. **Password Hashing** - Password is securely hashed using bcrypt (never stored in plain text)
+6. **User Creation** - User record is created in the `_modelenceUsers` collection
+7. **Session Linking** - The session is linked to the new user
+8. **Email Verification** (Optional) - If enabled, a verification email is sent
 
 #### Login Process
 

--- a/docs/web/authentication/password-reset.mdx
+++ b/docs/web/authentication/password-reset.mdx
@@ -35,13 +35,20 @@ startApp({
 3. An email with a reset link is sent to the user
 4. The link points at a Modelence server route, **not** your SPA page. That route validates the token, stores it in a short-lived `httpOnly` cookie, and redirects to your configured `redirectUrl` **without the token in the URL**
 5. On that page, the user enters their new password and you call `resetPassword({ password })` — the token is read server-side from the cookie, so it never reaches client JavaScript
-6. Password is updated and the token is invalidated (single-use)
-7. If the user's email was not yet verified, it is automatically marked as verified
+6. The new password is checked against the built-in length limits and your [`validatePassword`](/authentication/hooks#validatepassword) hook, if configured
+7. Password is updated and the token is invalidated (single-use)
+8. If the user's email was not yet verified, it is automatically marked as verified
 
 Since the user must receive the reset email to complete the flow, a successful password reset proves ownership of the email address.
 
 <Note>
 This is a **set-or-reset** flow. It works for accounts that have no password yet — for example those created via [magic link](/authentication/magic-link) or OAuth — letting the user add a local password. Completing it sets the password whether or not one existed before.
+</Note>
+
+<Note>
+Modelence enforces a built-in minimum of 8 characters here. To apply a stricter policy, configure the [`validatePassword`](/authentication/hooks#validatepassword) hook — it runs on **both** signup and reset, so users can't sidestep your rules by resetting to a weaker password. A policy enforced only in `validateSignup` is bypassable this way.
+
+If your hook rejects the password, the reset token is **not** consumed, so the user can retry with the same link.
 </Note>
 
 <Note>

--- a/packages/modelence/package-lock.json
+++ b/packages/modelence/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelence",
-  "version": "0.22.0",
+  "version": "0.22.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelence",
-      "version": "0.22.0",
+      "version": "0.22.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@socket.io/mongo-adapter": "^0.4.0",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.22.2-dev.0",
+  "version": "0.22.2",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.22.2",
+  "version": "0.22.2-dev.0",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -94,6 +94,29 @@ type GenerateHandleProps = {
 };
 
 /**
+ * The password-setting flow that invoked {@link AuthConfig.validatePassword}.
+ *
+ * Every path that writes a password hash passes one of these, so a policy can
+ * be uniform by default while still special-casing a flow if it needs to.
+ */
+export type PasswordContext = 'signup' | 'reset';
+
+/**
+ * Props passed to {@link AuthConfig.validatePassword}.
+ */
+export type ValidatePasswordProps = {
+  /** The candidate plaintext password, after the built-in length checks. */
+  password: string;
+  /**
+   * Lowercased email address of the account the password is being set on.
+   * Useful for rejecting passwords that contain the local-part.
+   */
+  email: string;
+  /** Which flow is setting the password. */
+  context: PasswordContext;
+};
+
+/**
  * Props passed to {@link AuthConfig.onBeforeSignup}.
  *
  * The hook fires after validation and the built-in disposable-email check,
@@ -171,6 +194,36 @@ export type AuthConfig = {
    * `firstName`, `lastName`, `avatarUrl`, `handle`). May be async.
    */
   validateSignup?: (props: SignupProps) => void | Promise<void>;
+
+  /**
+   * Password policy hook. Runs on **every** path that sets a password — signup
+   * and password reset today, plus any future change-password flow — after the
+   * built-in length checks (`MIN_PASSWORD_LENGTH`..`MAX_PASSWORD_LENGTH`) and
+   * before the password is hashed. Throw to reject the password; the thrown
+   * message is surfaced to the client.
+   *
+   * Prefer this over {@link AuthConfig.validateSignup} for password rules.
+   * `validateSignup` only runs at signup, so a policy enforced there alone can
+   * be bypassed by signing up with a compliant password and immediately
+   * resetting to a weaker one.
+   *
+   * Receives `{ password, email, context }`, where `context` is the flow that
+   * triggered the check (`'signup'` or `'reset'`). May be async.
+   *
+   * @example Enforce a 12-character minimum everywhere.
+   * ```typescript
+   * startApp({
+   *   auth: {
+   *     validatePassword: ({ password }) => {
+   *       if (password.length < 12) {
+   *         throw new Error('Password must be at least 12 characters');
+   *       }
+   *     },
+   *   },
+   * });
+   * ```
+   */
+  validatePassword?: (props: ValidatePasswordProps) => void | Promise<void>;
 
   /**
    * Pre-update validation hook. Runs before a user's profile fields

--- a/packages/modelence/src/auth/resetPassword.test.ts
+++ b/packages/modelence/src/auth/resetPassword.test.ts
@@ -21,6 +21,7 @@ const mockResetTokensFindOneAndDelete: MockedFunction<
   ResetPasswordTokensCollection['findOneAndDelete']
 > = vi.fn();
 const mockGetEmailConfig = vi.fn();
+const mockGetAuthConfig = vi.fn();
 const mockHtmlToText: MockedFunction<(html: string) => string> = vi.fn();
 const mockValidateEmail: MockedFunction<(email: string) => string> = vi.fn();
 const mockValidatePassword: MockedFunction<(password: string) => string> = vi.fn();
@@ -64,6 +65,10 @@ vi.doMock('./db', () => ({
 
 vi.doMock('@/app/emailConfig', () => ({
   getEmailConfig: mockGetEmailConfig,
+}));
+
+vi.doMock('@/app/authConfig', () => ({
+  getAuthConfig: mockGetAuthConfig,
 }));
 
 vi.doMock('@/utils', () => ({
@@ -172,6 +177,7 @@ describe('auth/resetPassword', () => {
         redirectUrl: '/reset-password',
       },
     });
+    mockGetAuthConfig.mockReturnValue({});
     mockConsumeRateLimit.mockResolvedValue(undefined as never);
     mockHtmlToText.mockImplementation((html: string) => html.replace(/<[^>]*>/g, ''));
     mockTime.hours.mockReturnValue(3600000); // 1 hour in ms
@@ -679,6 +685,118 @@ describe('auth/resetPassword', () => {
         success: true,
         message: 'Password has been reset successfully',
       });
+    });
+
+    test('runs the validatePassword hook with the reset context', async () => {
+      const token = 'validtoken123';
+      const password = 'NewP@ssw0rd!';
+      const userId = new ObjectId();
+      const email = 'user@example.com';
+      const validatePasswordHook = vi.fn();
+
+      mockGetAuthConfig.mockReturnValue({ validatePassword: validatePasswordHook });
+      mockValidatePassword.mockReturnValue(password);
+      mockUsersFindOne.mockResolvedValue(createMockUser({ _id: userId }));
+      mockBcryptHash.mockResolvedValue('hashedNewPassword');
+
+      const tokenDoc = createMockResetToken({ userId, email, token });
+      mockResetTokensFindOne.mockResolvedValue(tokenDoc);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(tokenDoc);
+
+      await handleResetPassword({ token, password }, createContext());
+
+      expect(validatePasswordHook).toHaveBeenCalledWith({
+        password,
+        email,
+        context: 'reset',
+      });
+    });
+
+    test('still runs validatePassword for legacy tokens without an email field', async () => {
+      const token = 'validtoken123';
+      const password = 'NewP@ssw0rd!';
+      const userId = new ObjectId();
+      const validatePasswordHook = vi.fn();
+
+      mockGetAuthConfig.mockReturnValue({ validatePassword: validatePasswordHook });
+      mockValidatePassword.mockReturnValue(password);
+      mockUsersFindOne.mockResolvedValue(
+        createMockUser({ _id: userId, emails: [{ address: 'User@Example.com', verified: true }] })
+      );
+      mockBcryptHash.mockResolvedValue('hashedNewPassword');
+
+      // Legacy token: no `email` field.
+      const tokenDoc = createMockResetToken({ userId, token });
+      delete (tokenDoc as unknown as { email?: string }).email;
+      mockResetTokensFindOne.mockResolvedValue(tokenDoc);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(tokenDoc);
+
+      await handleResetPassword({ token, password }, createContext());
+
+      // Falls back to the user's stored address, lowercased — the policy must
+      // not be skipped just because the token predates the email field.
+      expect(validatePasswordHook).toHaveBeenCalledWith({
+        password,
+        email: 'user@example.com',
+        context: 'reset',
+      });
+    });
+
+    test('rejects a password the validatePassword hook throws on, without writing a hash', async () => {
+      const token = 'validtoken123';
+      // Clears the framework floor of 8 but violates an app policy of 12.
+      const password = 'shortpass9';
+      const userId = new ObjectId();
+
+      mockGetAuthConfig.mockReturnValue({
+        validatePassword: () => {
+          throw new Error('Password must be at least 12 characters');
+        },
+      });
+      mockValidatePassword.mockReturnValue(password);
+      mockUsersFindOne.mockResolvedValue(createMockUser({ _id: userId }));
+
+      const tokenDoc = createMockResetToken({ userId, token });
+      mockResetTokensFindOne.mockResolvedValue(tokenDoc);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(tokenDoc);
+
+      await expect(handleResetPassword({ token, password }, createContext())).rejects.toThrow(
+        'Password must be at least 12 characters'
+      );
+
+      // The policy runs before the commit point, so nothing was written...
+      expect(mockBcryptHash).not.toHaveBeenCalled();
+      expect(mockUsersUpdateOne).not.toHaveBeenCalled();
+      expect(mockInvalidateAllUserSessions).not.toHaveBeenCalled();
+      // ...and the token stays unclaimed so the same link can be retried with a
+      // compliant password.
+      expect(mockResetTokensFindOneAndDelete).not.toHaveBeenCalled();
+    });
+
+    test('awaits an async validatePassword hook before setting the password', async () => {
+      const token = 'validtoken123';
+      const password = 'NewP@ssw0rd!';
+      const userId = new ObjectId();
+
+      mockGetAuthConfig.mockReturnValue({
+        validatePassword: async () => {
+          await Promise.resolve();
+          throw new Error('Password was found in a breach database');
+        },
+      });
+      mockValidatePassword.mockReturnValue(password);
+      mockUsersFindOne.mockResolvedValue(createMockUser({ _id: userId }));
+
+      const tokenDoc = createMockResetToken({ userId, token });
+      mockResetTokensFindOne.mockResolvedValue(tokenDoc);
+      mockResetTokensFindOneAndDelete.mockResolvedValue(tokenDoc);
+
+      await expect(handleResetPassword({ token, password }, createContext())).rejects.toThrow(
+        'Password was found in a breach database'
+      );
+
+      expect(mockBcryptHash).not.toHaveBeenCalled();
+      expect(mockUsersUpdateOne).not.toHaveBeenCalled();
     });
 
     test('verifies the email with strength-2 collation so mixed-case stored addresses still match', async () => {

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -6,6 +6,7 @@ import { Args, Context } from '@/methods/types';
 import { ObjectId, RouteParams, RouteResponse } from '@/server';
 import { usersCollection, resetPasswordTokensCollection, magicLinkTokensCollection } from './db';
 import { getEmailConfig } from '@/app/emailConfig';
+import { getAuthConfig } from '@/app/authConfig';
 import { time } from '@/time';
 import { htmlToText } from '@/utils';
 import { validateEmail, validatePassword } from './validators';
@@ -245,6 +246,20 @@ export async function handleResetPassword(args: Args, context: Context) {
   if (!userDoc) {
     throw new Error('User not found');
   }
+
+  // App-level password policy. Runs before the token is claimed below, so a
+  // rejected password leaves the link valid and the user can retry with a
+  // compliant one — same rationale as the deferred token lookup above.
+  //
+  // Legacy tokens predate the `email` field (see the guard on the verify write
+  // below), so fall back to the user's first stored address. The hook still
+  // runs either way: skipping the policy for those tokens would reopen the very
+  // bypass it exists to close.
+  await getAuthConfig().validatePassword?.({
+    password,
+    email: resetTokenDoc.email ?? userDoc.emails?.[0]?.address?.toLowerCase() ?? '',
+    context: 'reset',
+  });
 
   // Hash the new password
   const hash = await bcrypt.hash(password, 10);

--- a/packages/modelence/src/auth/signup.test.ts
+++ b/packages/modelence/src/auth/signup.test.ts
@@ -90,12 +90,14 @@ describe('auth/signup', () => {
     onAfterSignup: ReturnType<typeof vi.fn>;
     onSignupError: ReturnType<typeof vi.fn>;
     onBeforeSignup?: ReturnType<typeof vi.fn>;
+    validatePassword?: ReturnType<typeof vi.fn>;
     allowDisposableEmails?: boolean;
     signup: { onSuccess: ReturnType<typeof vi.fn>; onError: ReturnType<typeof vi.fn> };
   } = {
     onAfterSignup: vi.fn(),
     onSignupError: vi.fn(),
     onBeforeSignup: vi.fn(),
+    validatePassword: vi.fn(),
     signup: {
       onSuccess: vi.fn(),
       onError: vi.fn(),
@@ -106,6 +108,7 @@ describe('auth/signup', () => {
     vi.clearAllMocks();
     authConfig.allowDisposableEmails = false;
     authConfig.onBeforeSignup = vi.fn();
+    authConfig.validatePassword = vi.fn();
     mockGetAuthConfig.mockReturnValue(authConfig as never);
     mockValidateEmail.mockImplementation((v: unknown) => v);
     mockValidatePassword.mockImplementation((v: unknown) => v);
@@ -159,6 +162,46 @@ describe('auth/signup', () => {
 
     // The inserted document should use the email-derived handle
     expect(mockInsertOne).toHaveBeenCalledWith(expect.objectContaining({ handle: 'test' }));
+  });
+
+  test('runs the validatePassword hook with the signup context', async () => {
+    const insertedId = createObjectId('user-vp');
+    mockInsertOne.mockResolvedValue({ insertedId } as never);
+    mockFindOne.mockResolvedValueOnce(null as never).mockResolvedValueOnce({
+      _id: insertedId,
+      handle: 'test',
+      createdAt: new Date(),
+      authMethods: {},
+      emails: [{ address: 'test@example.com', verified: false }],
+    } as never);
+
+    await handleSignupWithPassword(
+      { email: 'test@example.com', password: 'Secret123' },
+      baseContext
+    );
+
+    expect(authConfig.validatePassword).toHaveBeenCalledWith({
+      password: 'Secret123',
+      email: 'test@example.com',
+      context: 'signup',
+    });
+  });
+
+  test('rejects the signup when validatePassword throws, without creating a user', async () => {
+    authConfig.validatePassword = vi.fn(() => {
+      throw new Error('Password must be at least 12 characters');
+    });
+    mockFindOne.mockResolvedValueOnce(null as never);
+
+    await expect(
+      handleSignupWithPassword({ email: 'test@example.com', password: 'Secret123' }, baseContext)
+    ).rejects.toThrow('Password must be at least 12 characters');
+
+    expect(mockHash).not.toHaveBeenCalled();
+    expect(mockInsertOne).not.toHaveBeenCalled();
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+    // A rejected password is a signup failure like any other.
+    expect(authConfig.onSignupError).toHaveBeenCalled();
   });
 
   test('uses provided handle when supplied', async () => {

--- a/packages/modelence/src/auth/signup.ts
+++ b/packages/modelence/src/auth/signup.ts
@@ -87,6 +87,14 @@ export async function handleSignupWithPassword(
       ...profileFields,
     });
 
+    // Runs on every password-setting path (see `resetPassword`), so a policy
+    // configured here can't be bypassed by resetting to a weaker password.
+    await authConfig.validatePassword?.({
+      password,
+      email,
+      context: 'signup',
+    });
+
     // Resolve unique handle
     let resolvedHandle: string;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication password-setting flows (signup and reset). Changes are additive and well-tested, but incorrect hook placement could affect password updates or token consumption.
> 
> **Overview**
> Adds a **`validatePassword`** auth hook so password policies apply on **every** password-setting path (signup and reset), closing the bypass where rules in `validateSignup` alone could be skipped by resetting to a weaker password.
> 
> The hook receives `{ password, email, context }` (`'signup' | 'reset'`), runs after built-in length checks and before hashing, and on reset runs **before** the token is consumed so a rejected password can be retried with the same link. Docs now steer password rules to this hook instead of `validateSignup`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a090d564bfc1099b70c0e16b82e86e3c5b9830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->