### PR TITLE
fix(cron): don't wedge a job when the lastStartDate write fails

### DIFF
--- a/packages/modelence/src/cron/jobs.test.ts
+++ b/packages/modelence/src/cron/jobs.test.ts
@@ -226,4 +226,27 @@ describe('cron/jobs', () => {
     const transaction = mockStartTransaction.mock.results.slice(-1)[0]?.value as { end: Mock };
     expect(transaction.end).toHaveBeenCalledWith('error');
   });
+
+  test('cron loop recovers when the lastStartDate write fails', async () => {
+    const handler = vi.fn(async () => {});
+    cronStoreMocks.fetch.mockResolvedValue([] as never);
+    cronStoreMocks.upsertOne.mockRejectedValue(new Error('write failed') as never);
+    defineCronJob('hourly', {
+      description: '',
+      interval: mockSeconds(10),
+      handler,
+    });
+
+    await startCronJobs();
+    await intervalCallback?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // With the write outside the try/catch, its rejection escaped runCronJob,
+    // so the error was never captured and isRunning was left true, wedging the
+    // job until its timeout. It must be caught and the run marked as errored.
+    expect(mockCaptureError).toHaveBeenCalledWith(expect.any(Error));
+    const transaction = mockStartTransaction.mock.results.slice(-1)[0]?.value as { end: Mock };
+    expect(transaction.end).toHaveBeenCalledWith('error');
+  });
 });

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -129,17 +129,16 @@ async function runCronJob(job: CronJob) {
   state.isRunning = true;
   state.startTs = Date.now();
 
-  await cronJobsCollection.upsertOne(
-    { alias },
-    {
-      $set: { lastStartDate: new Date(state.startTs) },
-      $setOnInsert: { alias },
-    }
-  );
-
   const transaction = startTransaction('cron', `cron:${alias}`);
   // TODO: enforce job timeout
   try {
+    await cronJobsCollection.upsertOne(
+      { alias },
+      {
+        $set: { lastStartDate: new Date(state.startTs) },
+        $setOnInsert: { alias },
+      }
+    );
     await handler();
     handleCronJobCompletion(state, params);
     transaction.end('success');


### PR DESCRIPTION
Fixes #338

`runCronJob` set `state.isRunning = true` and then wrote `lastStartDate` to Mongo before entering the try/catch:

```ts
state.isRunning = true;
state.startTs = Date.now();

await cronJobsCollection.upsertOne(/* ... */);   // outside the try

const transaction = startTransaction('cron', `cron:${alias}`);
try {
  await handler();
  handleCronJobCompletion(state, params);
  // ...
```

If that write rejects, the throw skips both the handler and `handleCronJobCompletion`, so `isRunning` is never reset. `tickCronJobs` runs jobs in a fire-and-forget `forEach(async ...)`, so the rejection isn't awaited or caught anywhere and just becomes an unhandled promise rejection. The job then hits the `if (state.isRunning) return` guard on every tick and stays wedged until `startTs + timeout` passes, which is the timeout-recovery path, not normal operation.

Moving the `upsertOne` inside the existing try makes a failed write behave like any other failure: it's captured, the run is marked errored, and `isRunning` is reset so the next interval reschedules normally. The success path is unchanged (the write still happens before the handler).

Added a regression test to `jobs.test.ts` that rejects `upsertOne` and asserts the error is captured and the transaction ends as `error`. It fails on `main` (the rejection escapes, `captureError` is never called) and passes with the fix. Full `cron/jobs.test.ts` suite is green (8 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested reliability fix that only relocates an existing write into the existing error path; success behavior is unchanged.
> 
> **Overview**
> Prevents cron jobs from getting stuck when the `lastStartDate` Mongo write fails.
> 
> Moves the `upsertOne` in `runCronJob` **inside** the existing try/catch so a rejected write is captured, the run is marked errored, and `isRunning` is reset via `handleCronJobCompletion` instead of leaving the job wedged until timeout.
> 
> Adds a regression test that rejects `upsertOne` and asserts the error is captured and the transaction ends as `error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af2c46a7de23997118dcbeb0b87627f313cf002f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->