### PR TITLE
fix: set keepAliveTimeout above load balancer idle timeouts (MOD-554)

### DIFF
--- a/packages/modelence/package.json
+++ b/packages/modelence/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "modelence",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "The Node.js Framework for Real-Time MongoDB Apps",
   "main": "dist/index.js",
   "types": "dist/global.d.ts",

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -151,6 +151,17 @@ export async function startServer(
 
   const httpServer = http.createServer(app);
 
+  // Keep-alive must exceed the idle timeout of any load balancer in front of the
+  // app, or Node destroys pooled sockets the LB still considers live and requests
+  // dispatched onto them fail with intermittent 502s. Node's stock default is 5s,
+  // below every common LB idle timeout (AWS ALB defaults to 60s). This is the
+  // post-response idle timeout only; it never applies to an in-flight request.
+  const keepAliveTimeoutMs = Number(process.env.MODELENCE_KEEP_ALIVE_TIMEOUT_MS) || 65000;
+  httpServer.keepAliveTimeout = keepAliveTimeoutMs;
+  // Must exceed keepAliveTimeout, or requests whose headers are still in flight
+  // when keep-alive expires are dropped (nodejs/node#27363).
+  httpServer.headersTimeout = keepAliveTimeoutMs + 5000;
+
   await server.init({ httpServer });
 
   if (server.middlewares) {


### PR DESCRIPTION
Node's default keepAliveTimeout is 5s, which sits below the idle timeout of every common load balancer (AWS ALB defaults to 60s, ours run 300-600s). Behind an LB that pools connections, the server destroys sockets the LB still considers live, and requests the LB dispatches onto them fail with intermittent 502s while the target looks perfectly healthy — this is what has been causing the App Builder escalations against cloud.modelence.com (MOD-554 in the studio tracker).

Sets keepAliveTimeout to 65s by default, overridable via MODELENCE_KEEP_ALIVE_TIMEOUT_MS for LBs with longer idle timeouts, and headersTimeout just above it (nodejs/node#27363). This is the post-response idle timeout only, so in-flight requests are unaffected.

Bumps the version to 0.22.3 so a release can be tagged right after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small HTTP server timeout tweak with an env override; no auth, data, or request-handling logic changes. In-flight requests are unaffected.
> 
> **Overview**
> Raises Node’s HTTP `keepAliveTimeout` from the 5s default to **65s** (overridable via `MODELENCE_KEEP_ALIVE_TIMEOUT_MS`) so pooled connections behind load balancers are not closed while the LB still considers them live, which was causing intermittent 502s.
> 
> Also sets `headersTimeout` 5s above keep-alive to avoid dropping in-flight headers (nodejs/node#27363). Bumps `modelence` to **0.22.3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb83b94c2fb354edde07825530ba48a9911b3982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->