### PR TITLE
docs: remove non-existent `auth`/`authorize`/`input` method options (MOD-584)

### DIFF
--- a/docs/web/core-concepts/modules.mdx
+++ b/docs/web/core-concepts/modules.mdx
@@ -70,45 +70,57 @@ Learn more about working with Stores in the [Stores documentation](/stores).
 
 ## Authentication & Authorization
 
-You can restrict access to queries and mutations using authentication requirements:
+<Warning>
+Every query and mutation you define is publicly callable over the network.
+There is no declarative `auth` or `authorize` option on a method definition —
+authentication and authorization must be enforced inside the handler.
+</Warning>
+
+Read `user` from the handler context and check it explicitly. For an
+unauthenticated caller, `user` is `null`:
 
 ```typescript
+import { Module, ObjectId } from 'modelence/server';
+import { AuthError } from 'modelence';
+import { dbTodos } from './db';
+
 export default new Module('todo', {
   queries: {
-    getAll: {
-      // Require authentication for this query
-      auth: true,
-      async handler({}, { user }) {
-        // user is guaranteed to exist here
-        return await dbTodos.fetch({ userId: user.id });
+    // Requires a signed-in user
+    async getAll({}, { user }) {
+      if (!user) {
+        throw new AuthError('Not authenticated');
       }
+
+      return await dbTodos.fetch({ userId: user.id });
     },
 
-    getPublic: {
-      // No authentication required
-      auth: false,
-      async handler() {
-        return await dbTodos.fetch({ isPublic: true });
-      }
+    // Public: no user check
+    async getPublic() {
+      return await dbTodos.fetch({ isPublic: true });
     }
   },
 
   mutations: {
-    adminDelete: {
-      // Custom authorization check
-      auth: true,
-      authorize: ({ user }) => {
-        if (!user.roles?.includes('admin')) {
-          throw new Error('Admin access required');
-        }
-      },
-      async handler({ id }) {
-        return await dbTodos.deleteOne({ _id: new ObjectId(id) });
+    // Admin only
+    async adminDelete({ id }, { user }) {
+      if (!user) {
+        throw new AuthError('Not authenticated');
       }
+
+      // Throws if the user doesn't have the "admin" role
+      user.requireRole('admin');
+
+      return await dbTodos.deleteOne({ _id: new ObjectId(id) });
     }
   }
 });
 ```
+
+<Tip>
+See [Roles](/roles) for defining roles, assigning them to users, and using
+`user.hasRole` / `user.requireRole`.
+</Tip>
 
 ## Queries
 
@@ -257,31 +269,37 @@ export default new Module('todo', {
 });
 ```
 
-### 5. Use TypeScript Types
+### 5. Validate Method Arguments
 
-Leverage TypeScript for type safety across your modules:
+Method arguments arrive from the client untyped and unvalidated — there is no
+`input` option on a method definition. Parse them at the top of the handler to
+get validation and types in one step:
 
 ```typescript
-import { schema } from 'modelence/server';
+import { Module, schema } from 'modelence/server';
+import { AuthError } from 'modelence';
 
-type TodoPriority = 'low' | 'medium' | 'high';
+const createArgs = schema.object({
+  title: schema.string().min(1),
+  priority: schema.enum(['low', 'medium', 'high'])
+});
 
 export default new Module('todo', {
   mutations: {
-    create: {
-      input: {
-        title: schema.string(),
-        priority: schema.enum<TodoPriority>(['low', 'medium', 'high'])
-      },
-      async handler(input, { user }) {
-        // input is fully typed
-        const { insertedId } = await dbTodos.insertOne({
-          ...input,
-          userId: user.id,
-          createdAt: new Date()
-        });
-        return insertedId;
+    async create(args, { user }) {
+      if (!user) {
+        throw new AuthError('Not authenticated');
       }
+
+      // Throws on invalid input; `input` is fully typed from here on
+      const input = createArgs.parse(args);
+
+      const { insertedId } = await dbTodos.insertOne({
+        ...input,
+        userId: user.id,
+        createdAt: new Date()
+      });
+      return insertedId;
     }
   }
 });


### PR DESCRIPTION
Fixes the docs half of [MOD-584](https://linear.app/modelence/issue/MOD-584). Reported via App Builder escalation (modelence 0.22.2) and confirmed by Aram as "a serious documentation bug".

## Problem

`core-concepts/modules.mdx` documented an `auth` / `authorize` option on query and mutation definitions. **The runtime has never read it.** `_createMethodInternal` in `packages/modelence/src/methods/index.ts` picks exactly two keys off a method definition:

```ts
const handler = typeof methodDef === 'function' ? methodDef : methodDef.handler;
const permissions = typeof methodDef === 'function' ? [] : (methodDef.permissions ?? []);
```

Everything else is dropped with no error and no warning, and `runMethod` gates only on `requireAccess(context.roles, method.permissions)` — a no-op when `permissions` is empty. So a method written in the documented form is publicly callable at `POST /api/_internal/method/<module>.<name>`. The reporter's admin-only `leads.list` / `leads.setStatus` were readable and mutable by an unauthenticated curl.

TypeScript does not catch it either: `Module`'s `TQueries` is an inferred generic, so excess property checking never fires and `{ auth, authorize, handler }` is happily assignable to `{ handler }`.

Same page, same root cause: the "Use TypeScript Types" example passed `input: { ... }` and claimed the args were typed. `input` is also read nowhere — method arguments arrive as `Record<string, unknown>` straight off the request body with no validation.

Verified against `main` @b4e57e3 and against the published `modelence@0.22.2` tarball. Org-wide search confirms this page was the only place either pattern appeared; `queries.mdx` and `mutations.mdx` are correct.

## Change

- **Authentication & Authorization** — replaced with the supported in-handler pattern (`if (!user) throw new AuthError(...)`, then `user.requireRole('admin')`), plus a `<Warning>` that every method is publicly callable by default and a pointer to `/roles`. This is also the workaround the reporter arrived at on his own.
- **Best Practices → 5** — retitled "Validate Method Arguments" and rewritten to parse args explicitly with `schema.object(...).parse(args)` instead of the phantom `input` key. The snippet type-checks under `--strict` against the zod version the framework ships (3.23.8).

Docs-only, no code changes.

## Follow-up (not in this PR)

MOD-584 also proposes rejecting unknown keys in `_createMethodInternal` at registration time, so an invented or misspelled option fails loudly at startup rather than silently opening an endpoint. Docs alone will drift again.

Worth noting separately: this fix stops new apps from being generated this way, but does not fix apps already built against the old docs. The App Builder agent reads docs.modelence.com, so generated apps with "admin-only" methods written in the documented form have live public endpoints today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only correction of incorrect API examples. No runtime changes; risk is limited to how developers copy the new patterns.
> 
> **Overview**
> Corrects `modules.mdx` so it no longer documents `auth`, `authorize`, and `input` on query/mutation definitions — those keys are ignored at runtime, so methods written that way stay publicly callable.
> 
> Auth examples now check `user` in the handler (`AuthError` / `user.requireRole`) and warn that every method is public by default. Argument typing is shown via `schema.object(...).parse(args)` instead of a phantom `input` option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba18202c0068e00582975aeebc4ad36afccd336c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->