### PR TITLE
fix(auth): prevent signup email enumeration

### DIFF
--- a/packages/modelence/src/auth/signup.test.ts
+++ b/packages/modelence/src/auth/signup.test.ts
@@ -377,6 +377,21 @@ describe('auth/signup', () => {
     expect(authConfig.signup.onError).toHaveBeenCalled();
   });
 
+  test('returns a generic error for disabled accounts without revealing their status', async () => {
+    mockFindOne.mockResolvedValueOnce({
+      _id: createObjectId('disabled'),
+      handle: 'disableduser',
+      createdAt: new Date(),
+      authMethods: {},
+      status: 'disabled',
+      emails: [{ address: 'test@example.com', verified: true }],
+    } as never);
+
+    await expect(
+      handleSignupWithPassword({ email: 'test@example.com', password: 'Secret123' }, baseContext)
+    ).rejects.toThrow('Unable to create account');
+  });
+
   test('throws already-exists when a concurrent signup wins the race and the unique index rejects the insert', async () => {
     // The findOne pre-check sees nothing (concurrent request has not inserted yet)...
     mockFindOne.mockResolvedValueOnce(null as never);

--- a/packages/modelence/src/auth/signup.test.ts
+++ b/packages/modelence/src/auth/signup.test.ts
@@ -349,8 +349,8 @@ describe('auth/signup', () => {
     ).rejects.toThrow('Please use a permanent email address');
   });
 
-  test('throws when user already exists', async () => {
-    mockFindOne.mockResolvedValueOnce({
+  test('returns a generic error when the email is already registered', async () => {
+    mockFindOne.mockResolvedValue({
       _id: createObjectId('existing'),
       handle: 'existinguser',
       createdAt: new Date(),
@@ -361,7 +361,17 @@ describe('auth/signup', () => {
 
     await expect(
       handleSignupWithPassword({ email: 'test@example.com', password: 'Secret123' }, baseContext)
-    ).rejects.toThrow('User with email already exists: test@example.com');
+    ).rejects.toThrow('Unable to create account');
+
+    await expect(
+      handleSignupWithPassword({ email: 'TEST@example.com', password: 'Secret123' }, baseContext)
+    ).rejects.toThrow('Unable to create account');
+
+    expect(authConfig.onSignupError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ message: 'Unable to create account' }),
+      })
+    );
 
     expect(authConfig.onSignupError).toHaveBeenCalled();
     expect(authConfig.signup.onError).toHaveBeenCalled();
@@ -378,7 +388,7 @@ describe('auth/signup', () => {
 
     await expect(
       handleSignupWithPassword({ email: 'test@example.com', password: 'Secret123' }, baseContext)
-    ).rejects.toThrow('User with email already exists: test@example.com');
+    ).rejects.toThrow('Unable to create account');
 
     expect(authConfig.onSignupError).toHaveBeenCalled();
     expect(mockSendVerificationEmail).not.toHaveBeenCalled();
@@ -456,7 +466,7 @@ describe('auth/signup', () => {
 
     await expect(
       handleSignupWithPassword({ email: 'test@example.com', password: 'Secret123' }, baseContext)
-    ).rejects.toThrow('User with email already exists');
+    ).rejects.toThrow('Unable to create account');
 
     expect(authConfig.onBeforeSignup).not.toHaveBeenCalled();
   });

--- a/packages/modelence/src/auth/signup.ts
+++ b/packages/modelence/src/auth/signup.ts
@@ -47,13 +47,12 @@ export async function handleSignupWithPassword(
     );
 
     if (existingUser) {
-      const existingEmail = existingUser.emails?.find((e) => e.address.toLowerCase() === email);
       if (existingUser.status === 'disabled') {
         throw new Error(
           `User is marked for deletion, please contact support if you want to restore the account.`
         );
       }
-      throw new Error(`User with email already exists: ${existingEmail?.address}`);
+      throw new Error('Unable to create account');
     }
 
     await authConfig.onBeforeSignup?.({
@@ -143,7 +142,7 @@ export async function handleSignupWithPassword(
         // A concurrent signup won the race between the findOne check above and
         // this insert; the unique emails.address index rejected the duplicate.
         // Surface the same message the pre-check would have.
-        throw new Error(`User with email already exists: ${email}`);
+        throw new Error('Unable to create account');
       }
       throw error;
     }

--- a/packages/modelence/src/auth/signup.ts
+++ b/packages/modelence/src/auth/signup.ts
@@ -47,9 +47,6 @@ export async function handleSignupWithPassword(
     );
 
     if (existingUser) {
-      if (existingUser.status === 'disabled') {
-        throw new Error('Unable to create account');
-      }
       throw new Error('Unable to create account');
     }
 

--- a/packages/modelence/src/auth/signup.ts
+++ b/packages/modelence/src/auth/signup.ts
@@ -48,9 +48,7 @@ export async function handleSignupWithPassword(
 
     if (existingUser) {
       if (existingUser.status === 'disabled') {
-        throw new Error(
-          `User is marked for deletion, please contact support if you want to restore the account.`
-        );
+        throw new Error('Unable to create account');
       }
       throw new Error('Unable to create account');
     }


### PR DESCRIPTION
Closes #339.

## Summary

The password signup endpoint included the submitted address or account status in duplicate-email errors, allowing unauthenticated callers to confirm whether an email was registered.

## Changes

- Return the fixed Unable to create account message for active duplicate accounts, disabled accounts, and concurrent unique-index failures.
- Preserve signup error callbacks while removing account-state details from the client-visible error.
- Add regression coverage for existing emails, case variants, disabled accounts, and concurrent duplicate inserts.

## Compatibility

Duplicate-email signups still fail and invoke the same error callbacks; only the client-visible error text changes. The email address and disabled status are no longer disclosed.

## Verification

- 
pm test -- --run src/auth/signup.test.ts — 19 passed.
- 
pm test -- --run src/auth — 296 passed across 22 files.
- 
pm run lint:check — passed.
- 
pm run build — passed (ESM and DTS).

The test runner emitted unrelated tsconfig discovery warnings from other directories in the shared workspace, but the targeted commands exited successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Security-hardening change limited to client-visible error text; signup failure behavior and callbacks are unchanged.
> 
> **Overview**
> Password signup no longer leaks whether an email is registered or whether the account is disabled. **Duplicate-email**, **disabled-account**, and **concurrent unique-index** failures all return the same client message: `Unable to create account`, instead of messages that included the address or deletion/support wording.
> 
> Signup still fails on those paths and **`onSignupError` / `signup.onError`** still run with the generic error. Tests were updated to assert the new message (including case-insensitive duplicates) and to cover disabled accounts without exposing status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ad426c9c3eda29f5e984f40953ca35f0c9ccd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->