### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @omegascorp


### PR DESCRIPTION
Auto-request review on all pull requests, including those opened from forks by outside contributors (who cannot set reviewers or assignees themselves).

Background of the change: I'm reviwing the contributions late when they are not assigned to me - adding this to auto-assign.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository metadata only; no application code, runtime behavior, or security logic changes.
> 
> **Overview**
> Adds a new **`.github/CODEOWNERS`** file so GitHub automatically requests review from **`@omegascorp`** on every pull request.
> 
> The rule uses a repo-wide `*` pattern, so all changed paths are covered—including PRs from forks where outside contributors cannot set reviewers themselves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b15f15d145702cf9343faa434609deb687a45f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->