### PR TITLE
feat: allow to configure trusted proxies

### DIFF
--- a/docs/web/core-concepts/environment-and-setup.mdx
+++ b/docs/web/core-concepts/environment-and-setup.mdx
@@ -66,6 +66,7 @@ Every `MODELENCE_*` variable (plus the few non-prefixed ones) that the framework
 | `MODELENCE_SITE_URL` | string | — | `packages/modelence` (public site URL, used by auth callbacks and emails) |
 | `PORT` | number | `3000` | `packages/modelence/app/server.ts` |
 | `MODELENCE_PORT` | number | falls back to `PORT` | `packages/modelence/app/server.ts` |
+| `MODELENCE_TRUSTED_PROXIES` | string (comma-separated addresses/ranges) | all proxies trusted for backward compatibility | `packages/modelence/app/server.ts` |
 | `NODE_ENV` | `development` \| `production` | `development` | Build pipeline, cookie `secure` flag, Vite dev server |
 | `MODELENCE_LOG_LEVEL` | `debug` \| `info` \| `warn` \| `error` | `info` | `packages/modelence/telemetry` |
 | `MODELENCE_ENV_TYPE` | string | — | `packages/modelence/config` (`_system.env.type`) |

--- a/docs/web/rate-limiting.mdx
+++ b/docs/web/rate-limiting.mdx
@@ -97,3 +97,36 @@ Forged values prepended by a caller do not become the IP rate-limit key.
 
 Configure the edge proxy to overwrite or append the actual peer address, and
 prevent untrusted clients from connecting directly to the application port.
+
+### Cloudflare
+
+Cloudflare *appends* to an inbound `X-Forwarded-For` header rather than
+overwriting it, so its left-most value is chosen by the caller. Cloudflare
+therefore [recommends](https://developers.cloudflare.com/fundamentals/reference/http-headers/)
+reading `CF-Connecting-IP`, which always holds exactly one address. Set
+`clientIpHeader` to use it:
+
+```typescript
+startApp({
+  security: {
+    trustedProxies: [/* Cloudflare's published IP ranges */],
+    clientIpHeader: 'cf-connecting-ip',
+  },
+});
+```
+
+`clientIpHeader` is only read when the connecting peer matches `trustedProxies`,
+so it must be configured alongside them with Cloudflare's
+[published IP ranges](https://www.cloudflare.com/ips/). Two caveats:
+
+- With the default trust-all behavior (neither `trustedProxies` nor
+  `MODELENCE_TRUSTED_PROXIES` set), every peer counts as trusted, so anyone able
+  to reach the application port directly could set the header themselves. Always
+  pair `clientIpHeader` with an explicit trusted proxy list.
+- If the trusted list does not cover the full Cloudflare edge, requests through
+  uncovered addresses fall back to the peer address, collapsing many clients
+  onto a single rate-limit key.
+
+`True-Client-IP` works the same way, but is Enterprise-only and must be enabled
+via a Managed Transform. Cloudflare warns that in a stacked-CDN setup its value
+can be spoofed unless your own edge sets it.

--- a/docs/web/rate-limiting.mdx
+++ b/docs/web/rate-limiting.mdx
@@ -66,3 +66,34 @@ await consumeRateLimit({
 });
 ```
 
+## Reverse Proxy Deployments
+
+For backward compatibility, Modelence trusts the complete `X-Forwarded-For`
+chain when no proxy configuration is present. This preserves existing client IP
+behavior during upgrades, but callers can supply their own value. Production
+deployments should list only the proxy addresses or networks they control:
+
+```typescript
+import { startApp } from 'modelence/server';
+
+startApp({
+  security: {
+    trustedProxies: ['loopback', '10.0.0.0/8'],
+  },
+});
+```
+
+For hosted deployments, the equivalent environment variable takes precedence
+over the `startApp()` setting:
+
+```bash
+MODELENCE_TRUSTED_PROXIES="loopback,10.0.0.0/8"
+```
+
+`trustedProxies` accepts IP addresses, CIDR ranges, and the Express named ranges
+`loopback`, `linklocal`, and `uniquelocal`. Modelence then walks the forwarded
+chain from the app toward the client and uses the first untrusted address.
+Forged values prepended by a caller do not become the IP rate-limit key.
+
+Configure the edge proxy to overwrite or append the actual peer address, and
+prevent untrusted clients from connecting directly to the application port.

--- a/packages/modelence/src/app/securityConfig.test.ts
+++ b/packages/modelence/src/app/securityConfig.test.ts
@@ -65,4 +65,12 @@ describe('securityConfig', () => {
 
     expect(getSecurityConfig().trustedProxies).toEqual(['loopback', '10.0.0.0/8']);
   });
+
+  test('stores the client IP header', async () => {
+    const { setSecurityConfig, getSecurityConfig } = await import('./securityConfig');
+
+    setSecurityConfig({ clientIpHeader: 'cf-connecting-ip' });
+
+    expect(getSecurityConfig().clientIpHeader).toBe('cf-connecting-ip');
+  });
 });

--- a/packages/modelence/src/app/securityConfig.test.ts
+++ b/packages/modelence/src/app/securityConfig.test.ts
@@ -57,4 +57,12 @@ describe('securityConfig', () => {
       'https://app.modelence.com',
     ]);
   });
+
+  test('stores trusted proxy addresses', async () => {
+    const { setSecurityConfig, getSecurityConfig } = await import('./securityConfig');
+
+    setSecurityConfig({ trustedProxies: ['loopback', '10.0.0.0/8'] });
+
+    expect(getSecurityConfig().trustedProxies).toEqual(['loopback', '10.0.0.0/8']);
+  });
 });

--- a/packages/modelence/src/app/securityConfig.ts
+++ b/packages/modelence/src/app/securityConfig.ts
@@ -13,6 +13,7 @@
  * startApp({
  *   security: {
  *     frameAncestors: ['https://modelence.com', 'https://app.example.com'],
+ *     trustedProxies: ['loopback', 'linklocal', 'uniquelocal'],
  *   },
  * });
  * ```
@@ -26,6 +27,28 @@ export type SecurityConfig = {
    * When set, `X-Frame-Options` is omitted since it cannot express multiple origins.
    */
   frameAncestors?: string[];
+
+  /**
+   * IP addresses or CIDR ranges of reverse proxies that are allowed to supply
+   * the client IP through `X-Forwarded-For`. This uses Express's `trust proxy`
+   * address syntax, which also supports the named ranges `loopback`,
+   * `linklocal`, and `uniquelocal`.
+   *
+   * For backward compatibility, all proxy addresses are trusted when neither
+   * this option nor `MODELENCE_TRUSTED_PROXIES` is set. Configure one of them in
+   * production so only addresses that cannot be reached directly by untrusted
+   * clients are trusted. Once configured,
+   * `connectionInfo.ip` is resolved by walking the proxy chain from the app
+   * toward the client and stopping at the first untrusted address. This keeps a
+   * caller from choosing its rate-limit identity by prepending a forged
+   * `X-Forwarded-For` value.
+   *
+   * @example
+   * ```typescript
+   * trustedProxies: ['loopback', '10.0.0.0/8']
+   * ```
+   */
+  trustedProxies?: string | string[];
 };
 
 let securityConfig: SecurityConfig = Object.freeze({});

--- a/packages/modelence/src/app/securityConfig.ts
+++ b/packages/modelence/src/app/securityConfig.ts
@@ -14,6 +14,7 @@
  *   security: {
  *     frameAncestors: ['https://modelence.com', 'https://app.example.com'],
  *     trustedProxies: ['loopback', 'linklocal', 'uniquelocal'],
+ *     clientIpHeader: 'cf-connecting-ip',
  *   },
  * });
  * ```
@@ -49,6 +50,30 @@ export type SecurityConfig = {
    * ```
    */
   trustedProxies?: string | string[];
+
+  /**
+   * Name of a single-value header the trusted proxy sets to the originating
+   * client IP, used instead of walking the `X-Forwarded-For` chain.
+   *
+   * Cloudflare recommends reading `CF-Connecting-IP` (or `True-Client-IP` on
+   * Enterprise plans) rather than `X-Forwarded-For`, because Cloudflare
+   * *appends* to an inbound `X-Forwarded-For` instead of overwriting it, while
+   * these headers always carry exactly one address.
+   *
+   * This header is only read when the immediate peer is a trusted proxy, so
+   * `trustedProxies` (or `MODELENCE_TRUSTED_PROXIES`) must also be configured
+   * with the proxy's addresses. Without that, a direct caller could set the
+   * header themselves and choose their own rate-limit identity. When the peer
+   * is untrusted or the header is absent, the IP falls back to the normal
+   * `trust proxy` resolution.
+   *
+   * @example
+   * ```typescript
+   * // Behind Cloudflare, with Cloudflare's published ranges trusted:
+   * clientIpHeader: 'cf-connecting-ip'
+   * ```
+   */
+  clientIpHeader?: string;
 };
 
 let securityConfig: SecurityConfig = Object.freeze({});

--- a/packages/modelence/src/app/server.test.ts
+++ b/packages/modelence/src/app/server.test.ts
@@ -275,11 +275,12 @@ describe('app/server getCallContext', () => {
     expect(ctx.clientInfo.screenWidth).toBe(100);
   });
 
-  test('falls back to unauthenticated context when database missing', async () => {
+  test('does not trust X-Forwarded-For when the request IP is direct', async () => {
     const req = createRequest({
       body: {
         authToken: 'body-token',
       },
+      ip: '::ffff:192.0.2.10',
       headers: {
         'x-forwarded-for': '10.0.0.1, 2.2.2.2',
         host: 'localhost',
@@ -292,7 +293,7 @@ describe('app/server getCallContext', () => {
 
     expect(ctx.session).toBeNull();
     expect(ctx.roles).toEqual(['guest']);
-    expect(ctx.connectionInfo.ip).toBe('10.0.0.1');
+    expect(ctx.connectionInfo.ip).toBe('192.0.2.10');
   });
 
   test('normalizes direct IP addresses without proxy headers', async () => {
@@ -378,8 +379,11 @@ describe('app/server getCallContext', () => {
     });
   });
 
-  test('handles X-Forwarded-For with multiple IPs', async () => {
+  test('uses the IP resolved by Express for a trusted proxy chain', async () => {
     const req = createRequest({
+      // Express resolves this from the socket and X-Forwarded-For according to
+      // the configured trusted proxy addresses.
+      ip: '5.6.7.8',
       headers: {
         'x-forwarded-for': '1.2.3.4, 5.6.7.8, 9.10.11.12',
         host: 'localhost',
@@ -389,10 +393,10 @@ describe('app/server getCallContext', () => {
 
     const ctx = await getCallContext(req, {} as Response);
 
-    expect(ctx.connectionInfo.ip).toBe('1.2.3.4');
+    expect(ctx.connectionInfo.ip).toBe('5.6.7.8');
   });
 
-  test('handles X-Forwarded-For as array', async () => {
+  test('ignores X-Forwarded-For when Express resolves no forwarded IP', async () => {
     const req = createRequest({
       headers: { host: 'localhost' },
     });
@@ -401,7 +405,7 @@ describe('app/server getCallContext', () => {
 
     const ctx = await getCallContext(req, {} as Response);
 
-    expect(ctx.connectionInfo.ip).toBe('1.2.3.4');
+    expect(ctx.connectionInfo.ip).toBeUndefined();
   });
 
   test('uses socket remoteAddress when ip is not available', async () => {
@@ -525,6 +529,58 @@ describe('app/server startServer', () => {
       "frame-ancestors 'self'"
     );
     expect(mockRes.setHeader).toHaveBeenCalledWith('X-Frame-Options', 'SAMEORIGIN');
+  });
+
+  test('preserves the legacy trust-all proxy behavior by default', async () => {
+    const mockServer = createMockServer();
+
+    await startServer(mockServer, {
+      combinedModules: [],
+      channels: [],
+    });
+
+    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', true);
+  });
+
+  test('configures only the explicitly trusted proxy addresses', async () => {
+    mockGetSecurityConfig.mockReturnValue({
+      trustedProxies: ['loopback', '10.0.0.0/8'],
+    });
+    const mockServer = createMockServer();
+
+    await startServer(mockServer, {
+      combinedModules: [],
+      channels: [],
+    });
+
+    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', ['loopback', '10.0.0.0/8']);
+  });
+
+  test('configures trusted proxies from MODELENCE_TRUSTED_PROXIES', async () => {
+    process.env.MODELENCE_TRUSTED_PROXIES = 'loopback,linklocal,uniquelocal';
+    const mockServer = createMockServer();
+
+    await startServer(mockServer, {
+      combinedModules: [],
+      channels: [],
+    });
+
+    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', 'loopback,linklocal,uniquelocal');
+  });
+
+  test('MODELENCE_TRUSTED_PROXIES overrides the application security config', async () => {
+    process.env.MODELENCE_TRUSTED_PROXIES = '10.0.0.0/8';
+    mockGetSecurityConfig.mockReturnValue({
+      trustedProxies: ['loopback'],
+    });
+    const mockServer = createMockServer();
+
+    await startServer(mockServer, {
+      combinedModules: [],
+      channels: [],
+    });
+
+    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', '10.0.0.0/8');
   });
 
   test('sets custom frame-ancestors and omits X-Frame-Options', async () => {

--- a/packages/modelence/src/app/server.test.ts
+++ b/packages/modelence/src/app/server.test.ts
@@ -206,6 +206,30 @@ function createRequest(overrides: Partial<Request> & { headers?: Record<string, 
   } as Request;
 }
 
+function createTrustingApp(trusted: string[]) {
+  // Mirrors how Express exposes its compiled `trust proxy` predicate on
+  // `req.app`. Only the exact addresses/ranges used by these tests are matched.
+  const trustFn = (addr: string) =>
+    trusted.some((entry) => {
+      if (entry === 'loopback') {
+        return addr === '127.0.0.1' || addr === '::1';
+      }
+      const [subnet, bits] = entry.split('/');
+      if (!bits) {
+        return addr === subnet;
+      }
+      const prefix = subnet
+        .split('.')
+        .slice(0, Math.floor(Number(bits) / 8))
+        .join('.');
+      return addr.startsWith(`${prefix}.`);
+    });
+
+  return {
+    get: (name: string) => (name === 'trust proxy fn' ? trustFn : undefined),
+  } as unknown as Request['app'];
+}
+
 function createResponse(): Response {
   const res = {
     json: vi.fn(),
@@ -222,6 +246,7 @@ function createResponse(): Response {
 describe('app/server getCallContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetSecurityConfig.mockReturnValue({});
     mockAuthenticate.mockResolvedValue({ session: null, user: null, roles: [] } as never);
     mockGetUnauthenticatedRoles.mockReturnValue(['guest']);
     mockGetMongodbUri.mockReturnValue(undefined);
@@ -408,6 +433,90 @@ describe('app/server getCallContext', () => {
     expect(ctx.connectionInfo.ip).toBeUndefined();
   });
 
+  test('prefers the configured client IP header from a trusted peer', async () => {
+    mockGetSecurityConfig.mockReturnValue({
+      trustedProxies: ['10.0.0.0/8'],
+      clientIpHeader: 'CF-Connecting-IP',
+    });
+    const req = createRequest({
+      // Cloudflare appends to X-Forwarded-For rather than overwriting it, so
+      // its left-most value is caller-controlled and must not win.
+      ip: '203.0.113.9',
+      headers: {
+        'cf-connecting-ip': '198.51.100.7',
+        'x-forwarded-for': '1.2.3.4, 203.0.113.9',
+        host: 'localhost',
+      },
+    });
+    req.socket = { remoteAddress: '10.0.0.5' } as unknown as Request['socket'];
+    req.app = createTrustingApp(['10.0.0.0/8']);
+    mockGetMongodbUri.mockReturnValue('');
+
+    const ctx = await getCallContext(req, {} as Response);
+
+    expect(ctx.connectionInfo.ip).toBe('198.51.100.7');
+  });
+
+  test('ignores the client IP header when the peer is not a trusted proxy', async () => {
+    mockGetSecurityConfig.mockReturnValue({
+      trustedProxies: ['10.0.0.0/8'],
+      clientIpHeader: 'CF-Connecting-IP',
+    });
+    const req = createRequest({
+      ip: '203.0.113.9',
+      headers: {
+        // Forged by a caller connecting directly to the application port.
+        'cf-connecting-ip': '198.51.100.7',
+        host: 'localhost',
+      },
+    });
+    req.socket = { remoteAddress: '203.0.113.9' } as unknown as Request['socket'];
+    req.app = createTrustingApp(['10.0.0.0/8']);
+    mockGetMongodbUri.mockReturnValue('');
+
+    const ctx = await getCallContext(req, {} as Response);
+
+    expect(ctx.connectionInfo.ip).toBe('203.0.113.9');
+  });
+
+  test('falls back to req.ip when the client IP header is absent', async () => {
+    mockGetSecurityConfig.mockReturnValue({
+      trustedProxies: ['10.0.0.0/8'],
+      clientIpHeader: 'CF-Connecting-IP',
+    });
+    const req = createRequest({
+      ip: '203.0.113.9',
+      headers: { host: 'localhost' },
+    });
+    req.socket = { remoteAddress: '10.0.0.5' } as unknown as Request['socket'];
+    req.app = createTrustingApp(['10.0.0.0/8']);
+    mockGetMongodbUri.mockReturnValue('');
+
+    const ctx = await getCallContext(req, {} as Response);
+
+    expect(ctx.connectionInfo.ip).toBe('203.0.113.9');
+  });
+
+  test('normalizes an IPv4-mapped address from the client IP header', async () => {
+    mockGetSecurityConfig.mockReturnValue({
+      trustedProxies: ['10.0.0.0/8'],
+      clientIpHeader: 'cf-connecting-ip',
+    });
+    const req = createRequest({
+      headers: {
+        'cf-connecting-ip': '::ffff:198.51.100.7',
+        host: 'localhost',
+      },
+    });
+    req.socket = { remoteAddress: '10.0.0.5' } as unknown as Request['socket'];
+    req.app = createTrustingApp(['10.0.0.0/8']);
+    mockGetMongodbUri.mockReturnValue('');
+
+    const ctx = await getCallContext(req, {} as Response);
+
+    expect(ctx.connectionInfo.ip).toBe('198.51.100.7');
+  });
+
   test('uses socket remoteAddress when ip is not available', async () => {
     const req = createRequest({
       headers: { host: 'localhost' },
@@ -428,7 +537,8 @@ describe('app/server getCallContext', () => {
         'x-forwarded-host': 'tenant-sandbox-3cus3.sandbox.modelence.app',
         'x-forwarded-proto': 'https',
       },
-      protocol: 'http',
+      // Express resolves `protocol` from X-Forwarded-Proto for a trusted proxy.
+      protocol: 'https',
     });
     mockGetMongodbUri.mockReturnValue('');
 
@@ -437,12 +547,30 @@ describe('app/server getCallContext', () => {
     expect(ctx.connectionInfo.baseUrl).toBe('https://tenant-sandbox-3cus3.sandbox.modelence.app');
   });
 
-  test('uses the first value of comma-separated forwarded headers', async () => {
+  test('uses the first value of a comma-separated X-Forwarded-Host', async () => {
     const req = createRequest({
       headers: {
         host: '10.1.118.6:3000',
         'x-forwarded-host': 'public.example.com, internal.example.com',
         'x-forwarded-proto': 'https, http',
+      },
+      // Express already takes the left-most X-Forwarded-Proto value itself.
+      protocol: 'https',
+    });
+    mockGetMongodbUri.mockReturnValue('');
+
+    const ctx = await getCallContext(req, {} as Response);
+
+    expect(ctx.connectionInfo.baseUrl).toBe('https://public.example.com');
+  });
+
+  test('ignores X-Forwarded-Proto that Express did not trust', async () => {
+    const req = createRequest({
+      headers: {
+        host: 'app.example.com',
+        // A direct caller can send this, but Express leaves `protocol` alone
+        // when the peer is not a trusted proxy.
+        'x-forwarded-proto': 'https',
       },
       protocol: 'http',
     });
@@ -450,7 +578,7 @@ describe('app/server getCallContext', () => {
 
     const ctx = await getCallContext(req, {} as Response);
 
-    expect(ctx.connectionInfo.baseUrl).toBe('https://public.example.com');
+    expect(ctx.connectionInfo.baseUrl).toBe('http://app.example.com');
   });
 
   test('falls back to direct host and protocol without forwarded headers', async () => {
@@ -565,7 +693,11 @@ describe('app/server startServer', () => {
       channels: [],
     });
 
-    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', 'loopback,linklocal,uniquelocal');
+    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', [
+      'loopback',
+      'linklocal',
+      'uniquelocal',
+    ]);
   });
 
   test('MODELENCE_TRUSTED_PROXIES overrides the application security config', async () => {
@@ -580,7 +712,34 @@ describe('app/server startServer', () => {
       channels: [],
     });
 
-    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', '10.0.0.0/8');
+    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', ['10.0.0.0/8']);
+  });
+
+  test('trims whitespace around MODELENCE_TRUSTED_PROXIES entries', async () => {
+    process.env.MODELENCE_TRUSTED_PROXIES = ' loopback , 10.0.0.0/8 ';
+    const mockServer = createMockServer();
+
+    await startServer(mockServer, {
+      combinedModules: [],
+      channels: [],
+    });
+
+    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', ['loopback', '10.0.0.0/8']);
+  });
+
+  test('falls back to the security config when MODELENCE_TRUSTED_PROXIES is blank', async () => {
+    process.env.MODELENCE_TRUSTED_PROXIES = '   ';
+    mockGetSecurityConfig.mockReturnValue({
+      trustedProxies: ['loopback'],
+    });
+    const mockServer = createMockServer();
+
+    await startServer(mockServer, {
+      combinedModules: [],
+      channels: [],
+    });
+
+    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', ['loopback']);
   });
 
   test('sets custom frame-ancestors and omits X-Frame-Options', async () => {

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -91,6 +91,19 @@ export async function startServer(
 ) {
   const app = express();
 
+  // Express's proxy-addr implementation walks X-Forwarded-For from the socket
+  // toward the client and stops at the first untrusted hop.
+  // This is important for IP rate limits: selecting the left-most value would
+  // let a caller evade them by prepending an arbitrary address.
+  const { trustedProxies } = getSecurityConfig();
+  const envTrustedProxies = process.env.MODELENCE_TRUSTED_PROXIES?.trim();
+  // Keep the historical trust-all behavior when neither setting is present so
+  // upgrading does not collapse every client behind a reverse proxy into one
+  // rate-limit identity. Modelence-hosted environments set the trusted proxy
+  // ranges before rolling out this framework version.
+  const trustProxy = envTrustedProxies || trustedProxies;
+  app.set('trust proxy', trustProxy === undefined ? true : trustProxy);
+
   app.use(cookieParser());
 
   app.use(securityHeadersMiddleware());
@@ -368,13 +381,9 @@ function getRequestBaseUrl(req: Request): string {
 }
 
 function getClientIp(req: Request): string | undefined {
-  // On Heroku and other proxies, X-Forwarded-For contains the real client IP
-  const forwardedFor = req.headers['x-forwarded-for'];
-  if (forwardedFor) {
-    const firstIp = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor.split(',')[0];
-    return firstIp.trim();
-  }
-
+  // `req.ip` only incorporates X-Forwarded-For according to the application's
+  // `trust proxy` setting. Never parse the header directly: its left-most value
+  // is controlled by the caller unless every ingress proxy overwrites it.
   const directIp = req.ip || req.socket?.remoteAddress;
   if (directIp) {
     // Remove IPv6-to-IPv4 mapping prefix

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -96,12 +96,12 @@ export async function startServer(
   // This is important for IP rate limits: selecting the left-most value would
   // let a caller evade them by prepending an arbitrary address.
   const { trustedProxies } = getSecurityConfig();
-  const envTrustedProxies = process.env.MODELENCE_TRUSTED_PROXIES?.trim();
+  const envTrustedProxies = parseTrustedProxies(process.env.MODELENCE_TRUSTED_PROXIES);
   // Keep the historical trust-all behavior when neither setting is present so
   // upgrading does not collapse every client behind a reverse proxy into one
   // rate-limit identity. Modelence-hosted environments set the trusted proxy
   // ranges before rolling out this framework version.
-  const trustProxy = envTrustedProxies || trustedProxies;
+  const trustProxy = envTrustedProxies ?? trustedProxies;
   app.set('trust proxy', trustProxy === undefined ? true : trustProxy);
 
   app.use(cookieParser());
@@ -372,23 +372,74 @@ function getRequestBaseUrl(req: Request): string {
     (Array.isArray(forwardedHost) ? forwardedHost[0] : forwardedHost?.split(',')[0])?.trim() ||
     req.get('host');
 
-  const forwardedProto = req.headers['x-forwarded-proto'];
-  const protocol =
-    (Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto?.split(',')[0])?.trim() ||
-    req.protocol;
+  // Do not parse X-Forwarded-Proto directly: `req.protocol` already resolves it
+  // through the `trust proxy` setting, so an untrusted caller cannot influence
+  // the base URL used for auth callbacks and emails.
+  return `${req.protocol}://${host}`;
+}
 
-  return `${protocol}://${host}`;
+/**
+ * Parses the comma-separated `MODELENCE_TRUSTED_PROXIES` value into the array
+ * form Express expects. Returns undefined when unset or empty so the caller can
+ * fall back to the `startApp()` security config.
+ */
+function parseTrustedProxies(value: string | undefined): string[] | undefined {
+  const entries = value
+    ?.split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  return entries?.length ? entries : undefined;
+}
+
+/**
+ * Whether the immediate peer on the socket is one of the configured trusted
+ * proxies. Only the socket address is consulted: it is the one value in the
+ * request a caller cannot forge.
+ */
+function isPeerTrusted(req: Request): boolean {
+  const peerIp = req.socket?.remoteAddress;
+  if (!peerIp) {
+    return false;
+  }
+
+  // Express compiles the `trust proxy` setting into this predicate. It is
+  // absent when the app was never configured (older embeddings, tests), in
+  // which case we fall back to the `trust proxy` value itself.
+  const trust = req.app?.get?.('trust proxy fn');
+  if (typeof trust !== 'function') {
+    return req.app?.get?.('trust proxy') !== false;
+  }
+
+  return Boolean(trust(peerIp, 0));
 }
 
 function getClientIp(req: Request): string | undefined {
+  // Cloudflare and similar proxies expose the originating client in a
+  // single-value header. Prefer it over the X-Forwarded-For chain, which
+  // Cloudflare appends to rather than overwrites, but only when the peer is a
+  // trusted proxy - otherwise a direct caller could set it themselves.
+  const { clientIpHeader } = getSecurityConfig();
+  if (clientIpHeader && isPeerTrusted(req)) {
+    const forwardedIp = req.headers[clientIpHeader.toLowerCase()];
+    const clientIp = (Array.isArray(forwardedIp) ? forwardedIp[0] : forwardedIp)?.trim();
+    if (clientIp) {
+      return normalizeIp(clientIp);
+    }
+  }
+
   // `req.ip` only incorporates X-Forwarded-For according to the application's
   // `trust proxy` setting. Never parse the header directly: its left-most value
   // is controlled by the caller unless every ingress proxy overwrites it.
   const directIp = req.ip || req.socket?.remoteAddress;
   if (directIp) {
-    // Remove IPv6-to-IPv4 mapping prefix
-    return directIp.startsWith('::ffff:') ? directIp.substring(7) : directIp;
+    return normalizeIp(directIp);
   }
 
   return undefined;
+}
+
+function normalizeIp(ip: string): string {
+  // Remove IPv6-to-IPv4 mapping prefix
+  return ip.startsWith('::ffff:') ? ip.substring(7) : ip;
 }


### PR DESCRIPTION
## Summary

Adds secure, configurable trusted-proxy handling for client IP resolution and IP-based rate limiting.

Previously, Modelence selected the leftmost `X-Forwarded-For` value directly. Because clients can supply this header, an attacker could rotate its value to bypass authentication rate limits.

## Changes

- Use Express trusted-proxy chain resolution through `req.ip`.
- Add `security.trustedProxies` to `startApp()`.
- Add native `MODELENCE_TRUSTED_PROXIES` environment-variable support.
- Give the environment variable precedence over `startApp()` configuration.
- Preserve the legacy trust-all behavior when neither setting is provided to avoid breaking existing reverse-proxy deployments.
- Add documentation and regression tests.

### Environment configuration

```env
MODELENCE_TRUSTED_PROXIES="loopback,linklocal,uniquelocal,10.0.0.0/8"
```

### Application configuration

```ts
startApp({
  security: {
    trustedProxies: ['loopback', 'linklocal', 'uniquelocal'],
  },
});
```

## Backward compatibility

When no trusted-proxy configuration is provided, Modelence continues using the historical trust-all behavior. This prevents users behind an existing load balancer or router from unexpectedly sharing one rate-limit identity.

The legacy default remains susceptible to spoofed `X-Forwarded-For` values. Hosted environments should configure `MODELENCE_TRUSTED_PROXIES` before upgrading to activate secure proxy-chain resolution without disrupting client IP handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how client IP and public base URL are derived behind proxies, directly affecting authentication rate limits and callback URLs; misconfiguration can break limits or leave spoofing possible until explicit trusted proxies are set.
> 
> **Overview**
> Fixes **IP-based rate limit bypass** by no longer trusting the leftmost `X-Forwarded-For` value. Client IP for `connectionInfo.ip` now follows Express **`trust proxy`** resolution via `req.ip`, and **`baseUrl`** uses `req.protocol` so untrusted callers cannot spoof HTTPS for auth callbacks.
> 
> Adds **`security.trustedProxies`** on `startApp()` and **`MODELENCE_TRUSTED_PROXIES`** (env wins over app config). When neither is set, **trust-all** behavior remains for upgrade compatibility. Optional **`clientIpHeader`** (e.g. `cf-connecting-ip`) is honored only when the socket peer is a trusted proxy.
> 
> Documentation covers reverse-proxy and Cloudflare setup; tests cover proxy config, IP resolution, and env parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4906867982a301676c50cd264a4e18c298d9d547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->