### PR TITLE
refactor(rate-limit): extract shared filter in checkRateLimitRule

### DIFF
--- a/packages/modelence/src/rate-limit/rules.test.ts
+++ b/packages/modelence/src/rate-limit/rules.test.ts
@@ -130,4 +130,28 @@ describe('rate-limit/rules', () => {
 
     expect(mocks.upsertOne).not.toHaveBeenCalled();
   });
+
+  test('consumeRateLimit throws when rate limit count meets or exceeds limit threshold', async () => {
+    vi.useFakeTimers().setSystemTime(new Date('2024-01-01T00:01:00.000Z'));
+    const { initRateLimits, consumeRateLimit, mocks } = await loadModule();
+
+    initRateLimits([{ bucket: 'login', type: 'ip', window: 60_000, limit: 3 }]);
+
+    mocks.findOne.mockResolvedValue({
+      bucket: 'login',
+      type: 'ip',
+      value: '10.0.0.1',
+      windowMs: 60_000,
+      windowStart: new Date('2024-01-01T00:01:00.000Z'),
+      windowCount: 3,
+      prevWindowCount: 0,
+      expiresAt: new Date('2024-01-01T00:03:00.000Z'),
+    } as never);
+
+    await expect(
+      consumeRateLimit({ bucket: 'login', type: 'ip', value: '10.0.0.1' })
+    ).rejects.toThrow('Rate limit exceeded for login');
+
+    expect(mocks.upsertOne).not.toHaveBeenCalled();
+  });
 });

--- a/packages/modelence/src/rate-limit/rules.ts
+++ b/packages/modelence/src/rate-limit/rules.ts
@@ -50,12 +50,14 @@ async function checkRateLimitRule(rule: RateLimitRule, value: string, createErro
       : new RateLimitError(`Rate limit exceeded for ${rule.bucket}`);
   };
 
-  const record = await dbRateLimits.findOne({
+  const filter = {
     bucket: rule.bucket,
     type: rule.type,
     value,
     windowMs: rule.window,
-  });
+  };
+
+  const record = await dbRateLimits.findOne(filter);
 
   const now = Date.now();
   const currentWindowStart = Math.floor(now / rule.window) * rule.window;
@@ -82,10 +84,7 @@ async function checkRateLimitRule(rule: RateLimitRule, value: string, createErro
     Always use upsert, because there is a small chance the document might be auto-removed
     based on the expiration TTL index in between the check and the update
   */
-  await dbRateLimits.upsertOne(
-    { bucket: rule.bucket, type: rule.type, value, windowMs: rule.window },
-    modifier
-  );
+  await dbRateLimits.upsertOne(filter, modifier);
 }
 
 function getCount(record: (typeof dbRateLimits)['Doc'], currentWindowStart: number, now: number) {


### PR DESCRIPTION
Added test suite coverage in `rules.test.ts` verifying rate-limit threshold enforcement when count threshold is reached. All unit tests, formatting, and linting checks are passing cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rate-limit consumption logic used for abuse protection; the change is small but incorrect behavior could allow extra requests or block legitimate ones.
> 
> **Overview**
> **Fixes a TOCTOU-style consistency issue** in `checkRateLimitRule` by building one `filter` object and passing it to both `findOne` and `upsertOne`, so the read and increment always target the same rate-limit document instead of duplicating filter literals.
> 
> Adds a unit test where the stored count already equals the rule limit (`windowCount: 3`, `limit: 3`), asserting `consumeRateLimit` throws and **does not** call `upsertOne`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6869abfa475012e2c794639b82ae87f98f255954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->