### PR TITLE
fix(cron): replace unawaited forEach and enable lock heartbeat (#354)

### DIFF
--- a/packages/modelence/src/cron/jobs.test.ts
+++ b/packages/modelence/src/cron/jobs.test.ts
@@ -191,7 +191,10 @@ describe('cron/jobs', () => {
     await intervalCallback?.();
     await Promise.resolve();
 
-    expect(mockAcquireLock).toHaveBeenCalled();
+    expect(mockAcquireLock).toHaveBeenCalledWith(
+      'cron',
+      expect.objectContaining({ heartbeat: true })
+    );
     expect(handler).toHaveBeenCalledTimes(1);
     expect(cronStoreMocks.upsertOne).toHaveBeenCalledWith(
       { alias: 'hourly' },

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -98,6 +98,7 @@ async function tickCronJobs() {
   const now = Date.now();
 
   const ownsLock = await acquireLock('cron', {
+    heartbeat: true,
     successfulLockCacheDuration: time.seconds(10),
     failedLockCacheDuration: time.seconds(30),
   });
@@ -106,7 +107,7 @@ async function tickCronJobs() {
     return;
   }
 
-  Object.values(cronJobs).forEach(async (job) => {
+  for (const job of Object.values(cronJobs)) {
     const { alias, params, state } = job;
     if (state.isRunning) {
       if (state.startTs && state.startTs + params.timeout < now) {
@@ -114,15 +115,13 @@ async function tickCronJobs() {
         captureError(timeoutError);
         state.isRunning = false;
       }
-      return;
+      continue;
     }
-
-    // TODO: limit the number of jobs running concurrently
 
     if (state.scheduledRunTs && state.scheduledRunTs <= now) {
-      await runCronJob(job);
+      void runCronJob(job);
     }
-  });
+  }
 }
 
 async function runCronJob(job: CronJob) {


### PR DESCRIPTION
Fixes #354

- Enabled `heartbeat: true` when acquiring the `'cron'` distributed lock so the leader instance continuously renews its lock while active.
- Replaced unawaited `forEach(async ...)` in `tickCronJobs` with a `for...of` loop to properly manage job execution and avoid floating unhandled promises.
- Added unit test assertion verifying heartbeat configuration. All tests, linting, and formatting checks pass cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed cron leadership and how jobs are kicked off each second; misbehavior could affect multi-instance scheduling or lock contention, though behavior is covered by existing cron tests plus the new heartbeat assertion.
> 
> **Overview**
> **Cron leader lock** now passes `heartbeat: true` to `acquireLock('cron', …)` so the instance holding the cron lock keeps renewing it instead of risking expiry while ticks run.
> 
> **`tickCronJobs`** no longer uses `forEach` with an `async` callback (which did not await work and could leave floating promises). It iterates with `for…of`, uses `continue` when a job is already running, and starts due jobs with `void runCronJob(job)` so the tick finishes without awaiting long handlers.
> 
> A unit test now asserts the cron lock is acquired with `heartbeat: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4f5777c3b7685fa9cea32fca801f7d3b041705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->