### PR TITLE
fix: improve oauth error message

### DIFF
--- a/docs/web/authentication/hooks.mdx
+++ b/docs/web/authentication/hooks.mdx
@@ -247,7 +247,7 @@ OAuth errors surface at the provider callback URL (`/api/_internal/auth/...`), w
 
 ### `oauthErrorRedirectUrl`
 
-Use `oauthErrorRedirectUrl` to send the browser back into your app when a web OAuth flow fails. It accepts a path or an absolute URL. The failure is appended as `?error=<message>&errorCode=<code>`, the same contract a mobile flow delivers on its deep link, so your app can show it on a real page.
+Use `oauthErrorRedirectUrl` to send the browser back into your app when a web OAuth flow fails. It accepts a path, resolved against your site URL (`MODELENCE_SITE_URL`), or an absolute URL. The failure is appended as `?error=<message>&errorCode=<code>`, the same contract a mobile flow delivers on its deep link, so your app can show it on a real page.
 
 ```typescript
 startApp({

--- a/docs/web/authentication/hooks.mdx
+++ b/docs/web/authentication/hooks.mdx
@@ -241,15 +241,41 @@ startApp({
 });
 ```
 
-## Error Rendering
+## Error Handling
 
-### `errorComponent`
+OAuth errors surface at the provider callback URL (`/api/_internal/auth/...`), which is a server route outside your client bundle. Nothing there can render your app's UI, so by default the user lands on a JSON body with no way back. Two options change that.
 
-Use `errorComponent` to customize how OAuth authentication errors are rendered. 
+### `oauthErrorRedirectUrl`
 
-By default, OAuth errors are returned as JSON. Providing `errorComponent` allows you to return a custom HTML response instead. 
+Use `oauthErrorRedirectUrl` to send the browser back into your app when a web OAuth flow fails. It accepts a path or an absolute URL. The failure is appended as `?error=<message>&errorCode=<code>`, the same contract a mobile flow delivers on its deep link, so your app can show it on a real page.
 
-This is useful when OAuth flows are triggered in a browser context.
+```typescript
+startApp({
+  auth: {
+    oauthErrorRedirectUrl: '/login',
+  },
+});
+```
+
+Then read the params on that page:
+
+```tsx
+import { useSearchParams } from 'react-router';
+
+function LoginPage() {
+  const [searchParams] = useSearchParams();
+  const oauthError = searchParams.get('error');
+  // ...render oauthError inline in the form
+}
+```
+
+`error` is for display and its wording may change. Branch on `errorCode` (`invalid_state`, `email_exists`, `account_inactive`, ...) for anything programmatic.
+
+When both `oauthErrorRedirectUrl` and `errorComponent` are set, the redirect wins and `errorComponent` is not called.
+
+### `errorComponent` (deprecated)
+
+`errorComponent` is deprecated in favor of `oauthErrorRedirectUrl`. It renders OAuth errors as a standalone HTML document at the callback URL instead of JSON, which means the page cannot use your app's UI. It is still honored for existing apps, but is ignored whenever `oauthErrorRedirectUrl` is set.
 
 ```typescript
 startApp({
@@ -307,12 +333,7 @@ startApp({
       }
       return email.split('@')[0];
     },
-    errorComponent: ({ error, statusCode }) => {
-      const escapeHtml = (str: string | number) => String(str).replace(/[&<>"']/g, m => ({
-        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;'
-      })[m as any] || m);
-      return `<html><body><h1>Error ${escapeHtml(statusCode)}</h1><p>${escapeHtml(error)}</p></body></html>`;
-    },
+    oauthErrorRedirectUrl: '/login',
     onAfterSignup: ({ user }) => {
       console.log('Welcome!', user.handle);
     },

--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -371,8 +371,9 @@ export type AuthConfig = {
   errorComponent?: (props: OAuthErrorInfo) => string | null | undefined;
 
   /**
-   * Where a failed web OAuth flow sends the browser. A path (`'/login'`) or an
-   * absolute URL. The failure is appended as `?error=<message>&errorCode=<code>`,
+   * Where a failed web OAuth flow sends the browser. A path (`'/login'`),
+   * resolved against `_system.site.url`, or an absolute URL. The failure is
+   * appended as `?error=<message>&errorCode=<code>`,
    * the same contract a mobile flow delivers on its deep link, so the app can
    * show the message on a real page instead of the raw callback response.
    *

--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -362,8 +362,38 @@ export type AuthConfig = {
    * (or `null`/`undefined` to fall back to the default JSON response).
    *
    * Always escape interpolated values to prevent XSS.
+   *
+   * @deprecated Use {@link AuthConfig.oauthErrorRedirectUrl} instead. It sends
+   * the browser back into the app, where the error can be shown on a real page
+   * with the app's own UI; this only ever renders a standalone document at the
+   * callback URL. Ignored when `oauthErrorRedirectUrl` is set.
    */
   errorComponent?: (props: OAuthErrorInfo) => string | null | undefined;
+
+  /**
+   * Where a failed web OAuth flow sends the browser. A path (`'/login'`) or an
+   * absolute URL. The failure is appended as `?error=<message>&errorCode=<code>`,
+   * the same contract a mobile flow delivers on its deep link, so the app can
+   * show the message on a real page instead of the raw callback response.
+   *
+   * OAuth errors surface at the provider callback URL, outside any client
+   * bundle, so nothing there can render app UI. Without this (or
+   * {@link AuthConfig.errorComponent}) the user lands on a JSON body with no
+   * way back. When both are set, the redirect wins and `errorComponent` is not
+   * called.
+   *
+   * `error` is for display and its wording may change; branch on `errorCode`.
+   *
+   * @example
+   * ```typescript
+   * startApp({
+   *   auth: {
+   *     oauthErrorRedirectUrl: '/login',
+   *   },
+   * });
+   * ```
+   */
+  oauthErrorRedirectUrl?: string;
 
   /**
    * Overrides the built-in rate limits for authentication endpoints. Each rule

--- a/packages/modelence/src/app/authConfig.ts
+++ b/packages/modelence/src/app/authConfig.ts
@@ -385,6 +385,11 @@ export type AuthConfig = {
    *
    * `error` is for display and its wording may change; branch on `errorCode`.
    *
+   * Applies to the provider callback only. A request rejected at the sign-in
+   * *initiation* endpoint (auth not configured, a disallowed mobile
+   * `redirectUri`, a missing `codeChallenge`) still answers the calling client
+   * with JSON, since nothing has left for the provider yet.
+   *
    * @example
    * ```typescript
    * startApp({

--- a/packages/modelence/src/auth/loginWithOAuth.e2e.test.ts
+++ b/packages/modelence/src/auth/loginWithOAuth.e2e.test.ts
@@ -25,7 +25,7 @@ const ctx = (o = {}) =>
 
 /**
  * Redemption-side invariants, paired with the initiation invariants in
- * providers/oauth-common.e2e.test.ts. Together they cover the two halves that
+ * providers/oauthCommon.e2e.test.ts. Together they cover the two halves that
  * must agree: a code is minted only with a binding, and redeemed only with the
  * matching verifier.
  */

--- a/packages/modelence/src/auth/providers/github.test.ts
+++ b/packages/modelence/src/auth/providers/github.test.ts
@@ -38,7 +38,7 @@ const mockPrepareOAuthInitiation = vi.fn(
   }
 );
 
-vi.doMock('./oauth-common', () => ({
+vi.doMock('./oauthCommon', () => ({
   getRedirectUri: mockGetRedirectUri,
   handleOAuthUserAuthentication: mockHandleOAuthUserAuthentication,
   handleOAuthProviderLink: mockHandleOAuthProviderLink,

--- a/packages/modelence/src/auth/providers/github.test.ts
+++ b/packages/modelence/src/auth/providers/github.test.ts
@@ -253,7 +253,7 @@ describe('auth/providers/github', () => {
 
   test('callback handler returns 400 when state invalid', async () => {
     mockValidateOAuthStateAndGetMode.mockImplementationOnce((req: Request, res: Response) => {
-      mockSendOAuthError(res, 400, 'Invalid OAuth state - possible CSRF attack');
+      mockSendOAuthError(res, 400, 'Your sign-in session has expired. Please sign in again.');
       return null;
     });
     const route = findRoute('/api/_internal/auth/github/callback');
@@ -271,7 +271,7 @@ describe('auth/providers/github', () => {
     expect(mockSendOAuthError).toHaveBeenCalledWith(
       res,
       400,
-      'Invalid OAuth state - possible CSRF attack'
+      'Your sign-in session has expired. Please sign in again.'
     );
   });
 

--- a/packages/modelence/src/auth/providers/github.test.ts
+++ b/packages/modelence/src/auth/providers/github.test.ts
@@ -114,7 +114,8 @@ describe('auth/providers/github', () => {
     expect(mockSendOAuthError).toHaveBeenCalledWith(
       res,
       503,
-      'GitHub authentication is not configured'
+      'GitHub authentication is not configured',
+      { platform: 'api' }
     );
     expect(next).not.toHaveBeenCalled();
   });

--- a/packages/modelence/src/auth/providers/github.ts
+++ b/packages/modelence/src/auth/providers/github.ts
@@ -18,7 +18,7 @@ import {
   prepareOAuthInitiation,
   resolveMobileOutcomeFromCookie,
   toOAuthOutcome,
-} from './oauth-common';
+} from './oauthCommon';
 
 interface GitHubTokenResponse {
   access_token: string;

--- a/packages/modelence/src/auth/providers/github.ts
+++ b/packages/modelence/src/auth/providers/github.ts
@@ -203,7 +203,9 @@ function getRouter(): ExpressRouter {
     const githubClientSecret = String(getConfig('_system.user.auth.github.clientSecret'));
 
     if (!githubEnabled || !githubClientId || !githubClientSecret) {
-      sendOAuthError(res, 503, 'GitHub authentication is not configured');
+      sendOAuthError(res, 503, 'GitHub authentication is not configured', {
+        platform: 'api',
+      });
       return;
     }
 

--- a/packages/modelence/src/auth/providers/google.test.ts
+++ b/packages/modelence/src/auth/providers/google.test.ts
@@ -38,7 +38,7 @@ const mockPrepareOAuthInitiation = vi.fn(
   }
 );
 
-vi.doMock('./oauth-common', () => ({
+vi.doMock('./oauthCommon', () => ({
   getRedirectUri: mockGetRedirectUri,
   handleOAuthUserAuthentication: mockHandleOAuthUserAuthentication,
   handleOAuthProviderLink: mockHandleOAuthProviderLink,

--- a/packages/modelence/src/auth/providers/google.test.ts
+++ b/packages/modelence/src/auth/providers/google.test.ts
@@ -225,7 +225,7 @@ describe('auth/providers/google', () => {
 
   test('callback handler returns 400 when state invalid', async () => {
     mockValidateOAuthStateAndGetMode.mockImplementationOnce((req, res) => {
-      mockSendOAuthError(res, 400, 'Invalid OAuth state - possible CSRF attack');
+      mockSendOAuthError(res, 400, 'Your sign-in session has expired. Please sign in again.');
       return null;
     });
     const route = findRoute('/api/_internal/auth/google/callback');
@@ -243,7 +243,7 @@ describe('auth/providers/google', () => {
     expect(mockSendOAuthError).toHaveBeenCalledWith(
       res,
       400,
-      'Invalid OAuth state - possible CSRF attack'
+      'Your sign-in session has expired. Please sign in again.'
     );
   });
 

--- a/packages/modelence/src/auth/providers/google.test.ts
+++ b/packages/modelence/src/auth/providers/google.test.ts
@@ -116,7 +116,8 @@ describe('auth/providers/google', () => {
     expect(mockSendOAuthError).toHaveBeenCalledWith(
       res,
       503,
-      'Google authentication is not configured'
+      'Google authentication is not configured',
+      { platform: 'api' }
     );
     expect(next).not.toHaveBeenCalled();
   });

--- a/packages/modelence/src/auth/providers/google.ts
+++ b/packages/modelence/src/auth/providers/google.ts
@@ -18,7 +18,7 @@ import {
   prepareOAuthInitiation,
   resolveMobileOutcomeFromCookie,
   toOAuthOutcome,
-} from './oauth-common';
+} from './oauthCommon';
 
 interface GoogleTokenResponse {
   access_token: string;

--- a/packages/modelence/src/auth/providers/google.ts
+++ b/packages/modelence/src/auth/providers/google.ts
@@ -150,7 +150,9 @@ function getRouter(): ExpressRouter {
     const googleClientSecret = String(getConfig('_system.user.auth.google.clientSecret'));
 
     if (!googleEnabled || !googleClientId || !googleClientSecret) {
-      sendOAuthError(res, 503, 'Google authentication is not configured');
+      sendOAuthError(res, 503, 'Google authentication is not configured', {
+        platform: 'api',
+      });
       return;
     }
 

--- a/packages/modelence/src/auth/providers/oauth-common.ts
+++ b/packages/modelence/src/auth/providers/oauth-common.ts
@@ -184,6 +184,7 @@ export function sendOAuthError(
       console.error('Unhandled error in authConfig.errorComponent:', err);
     }
   }
+
   return response.json({ error: errorMessage });
 }
 
@@ -677,10 +678,17 @@ export function validateOAuthStateAndGetMode(
     // Deep-link the failure back when the decoded target survives re-validation,
     // rather than stranding the user on JSON. Trusted because the allowlist just
     // approved it, not because the cookie said so.
+    //
+    // The message says "sign in again" rather than naming CSRF: the overwhelming
+    // majority of the users who see it are victims of an expired cookie, a stale
+    // bookmarked callback, or a back button — not of an attack. Someone actually
+    // forging a state learns nothing from being told so, while everyone else is
+    // handed an accusation instead of the one action that fixes it. `invalid_state`
+    // still identifies the case precisely for anything branching on it.
     sendOAuthError(
       res,
       400,
-      'Invalid OAuth state - possible CSRF attack',
+      'Your sign-in session has expired. Please sign in again.',
       mobileOutcome ?? { platform: 'web' },
       'invalid_state'
     );

--- a/packages/modelence/src/auth/providers/oauthCommon.e2e.test.ts
+++ b/packages/modelence/src/auth/providers/oauthCommon.e2e.test.ts
@@ -34,7 +34,7 @@ vi.doMock('@/app/server', () => ({ getCallContext: mockGetCallContext }));
 vi.doMock('@/config/server', () => ({ getConfig: mockGetConfig }));
 vi.doMock('../utils', () => ({ resolveUniqueHandle: vi.fn(async () => 'demo') }));
 
-const oauth = await import('./oauth-common');
+const oauth = await import('./oauthCommon');
 
 function makeRes() {
   return {
@@ -80,7 +80,7 @@ async function roundTrip(query: Record<string, string>, res: Response) {
  * derived from it — because the regressions this feature actually shipped all
  * lived in the seams between those steps, not inside any one of them.
  */
-describe('oauth-common — mobile end-to-end invariants', () => {
+describe('oauthCommon — mobile end-to-end invariants', () => {
   let res: Response;
 
   beforeEach(() => {
@@ -251,7 +251,7 @@ describe('oauth-common — mobile end-to-end invariants', () => {
  * integrity-checked, but these confirm that a value which nonetheless reaches
  * the decoder cannot escalate into a minted credential.
  */
-describe('oauth-common — mobile state tampering', () => {
+describe('oauthCommon — mobile state tampering', () => {
   let res: Response;
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/modelence/src/auth/providers/oauthCommon.mobile.test.ts
+++ b/packages/modelence/src/auth/providers/oauthCommon.mobile.test.ts
@@ -3,7 +3,7 @@ import { ObjectId } from 'mongodb';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 /**
- * Mobile OAuth paths. Kept separate from oauth-common.test.ts so the config mock
+ * Mobile OAuth paths. Kept separate from oauthCommon.test.ts so the config mock
  * can distinguish the site URL from the deep-link allowlist, and so the web-flow
  * regression suite stays untouched.
  */
@@ -41,7 +41,7 @@ vi.doMock('@/app/server', () => ({ getCallContext: mockGetCallContext }));
 vi.doMock('@/config/server', () => ({ getConfig: mockGetConfig }));
 vi.doMock('../utils', () => ({ resolveUniqueHandle: mockResolveUniqueHandle }));
 
-const oauth = await import('./oauth-common');
+const oauth = await import('./oauthCommon');
 
 function makeRes() {
   return {
@@ -61,7 +61,7 @@ const MOBILE_OUTCOME = {
   codeChallenge: 'device-challenge',
 } as const;
 
-describe('auth/providers/oauth-common — mobile', () => {
+describe('auth/providers/oauthCommon — mobile', () => {
   let res: Response;
 
   beforeEach(() => {

--- a/packages/modelence/src/auth/providers/oauthCommon.test.ts
+++ b/packages/modelence/src/auth/providers/oauthCommon.test.ts
@@ -1030,6 +1030,12 @@ describe('auth/providers/oauthCommon', () => {
     });
 
     describe('oauthErrorRedirectUrl', () => {
+      beforeEach(() => {
+        mockGetConfig.mockImplementation((key: string) =>
+          key === '_system.site.url' ? 'https://app.example.com' : undefined
+        );
+      });
+
       const redirectRes = () =>
         ({
           set: vi.fn(),
@@ -1052,7 +1058,7 @@ describe('auth/providers/oauthCommon', () => {
         );
 
         expect(webRes.redirect).toHaveBeenCalledWith(
-          '/login?error=Auth+failed&errorCode=email_exists'
+          'https://app.example.com/login?error=Auth+failed&errorCode=email_exists'
         );
         expect(webRes.status).not.toHaveBeenCalled();
         expect(webRes.json).not.toHaveBeenCalled();
@@ -1066,7 +1072,7 @@ describe('auth/providers/oauthCommon', () => {
         moduleExports.sendOAuthError(webRes, 500, 'Auth failed');
 
         expect(webRes.redirect).toHaveBeenCalledWith(
-          '/login?error=Auth+failed&errorCode=oauth_failed'
+          'https://app.example.com/login?error=Auth+failed&errorCode=oauth_failed'
         );
       });
 

--- a/packages/modelence/src/auth/providers/oauthCommon.test.ts
+++ b/packages/modelence/src/auth/providers/oauthCommon.test.ts
@@ -50,9 +50,9 @@ vi.doMock('../utils', () => ({
   resolveUniqueHandle: mockResolveUniqueHandle,
 }));
 
-const moduleExports = await import('./oauth-common');
+const moduleExports = await import('./oauthCommon');
 
-describe('auth/providers/oauth-common', () => {
+describe('auth/providers/oauthCommon', () => {
   const res = {
     cookie: vi.fn(),
     status: vi.fn().mockReturnThis(),
@@ -1027,6 +1027,89 @@ describe('auth/providers/oauth-common', () => {
 
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    });
+
+    describe('oauthErrorRedirectUrl', () => {
+      const redirectRes = () =>
+        ({
+          set: vi.fn(),
+          status: vi.fn().mockReturnThis(),
+          redirect: vi.fn(),
+          json: vi.fn(),
+          send: vi.fn(),
+        }) as unknown as Response;
+
+      test('redirects to the configured URL with error and errorCode', () => {
+        const webRes = redirectRes();
+        mockGetAuthConfig.mockReturnValue({ oauthErrorRedirectUrl: '/login' });
+
+        moduleExports.sendOAuthError(
+          webRes,
+          400,
+          'Auth failed',
+          { platform: 'web' },
+          'email_exists'
+        );
+
+        expect(webRes.redirect).toHaveBeenCalledWith(
+          '/login?error=Auth+failed&errorCode=email_exists'
+        );
+        expect(webRes.status).not.toHaveBeenCalled();
+        expect(webRes.json).not.toHaveBeenCalled();
+        expect(webRes.send).not.toHaveBeenCalled();
+      });
+
+      test('defaults errorCode to oauth_failed', () => {
+        const webRes = redirectRes();
+        mockGetAuthConfig.mockReturnValue({ oauthErrorRedirectUrl: '/login' });
+
+        moduleExports.sendOAuthError(webRes, 500, 'Auth failed');
+
+        expect(webRes.redirect).toHaveBeenCalledWith(
+          '/login?error=Auth+failed&errorCode=oauth_failed'
+        );
+      });
+
+      test('keeps the message out of the Referer header', () => {
+        const webRes = redirectRes();
+        mockGetAuthConfig.mockReturnValue({ oauthErrorRedirectUrl: '/login' });
+
+        moduleExports.sendOAuthError(webRes, 400, 'Auth failed');
+
+        expect(webRes.set).toHaveBeenCalledWith('Referrer-Policy', 'no-referrer');
+      });
+
+      test('takes precedence over errorComponent', () => {
+        const webRes = redirectRes();
+        const mockErrorComponent = vi.fn().mockReturnValue('<html></html>');
+        mockGetAuthConfig.mockReturnValue({
+          oauthErrorRedirectUrl: '/login',
+          errorComponent: mockErrorComponent,
+        });
+
+        moduleExports.sendOAuthError(webRes, 400, 'Auth failed');
+
+        expect(webRes.redirect).toHaveBeenCalled();
+        expect(mockErrorComponent).not.toHaveBeenCalled();
+        expect(webRes.send).not.toHaveBeenCalled();
+      });
+
+      test('does not apply to mobile flows, which use the deep link', () => {
+        const mobileRes = redirectRes();
+        mockGetAuthConfig.mockReturnValue({ oauthErrorRedirectUrl: '/login' });
+
+        moduleExports.sendOAuthError(
+          mobileRes,
+          400,
+          'Auth failed',
+          { platform: 'mobile', redirectUri: 'myapp://auth' },
+          'invalid_state'
+        );
+
+        expect(mobileRes.redirect).toHaveBeenCalledTimes(1);
+        const target = (mobileRes.redirect as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+        expect(target.startsWith('myapp://auth')).toBe(true);
+      });
     });
   });
 });

--- a/packages/modelence/src/auth/providers/oauthCommon.test.ts
+++ b/packages/modelence/src/auth/providers/oauthCommon.test.ts
@@ -50,6 +50,7 @@ vi.doMock('../utils', () => ({
   resolveUniqueHandle: mockResolveUniqueHandle,
 }));
 
+const localConfig = await import('@/config/local');
 const moduleExports = await import('./oauthCommon');
 
 describe('auth/providers/oauthCommon', () => {
@@ -1098,6 +1099,58 @@ describe('auth/providers/oauthCommon', () => {
         expect(webRes.redirect).toHaveBeenCalled();
         expect(mockErrorComponent).not.toHaveBeenCalled();
         expect(webRes.send).not.toHaveBeenCalled();
+      });
+
+      test('falls back to the local site URL when _system.site.url is unset', () => {
+        const webRes = redirectRes();
+        mockGetConfig.mockReturnValue(undefined);
+        mockGetAuthConfig.mockReturnValue({ oauthErrorRedirectUrl: '/login' });
+
+        moduleExports.sendOAuthError(webRes, 400, 'Auth failed');
+
+        expect(webRes.redirect).toHaveBeenCalledWith(
+          'http://localhost:3000/login?error=Auth+failed&errorCode=oauth_failed'
+        );
+      });
+
+      test('falls back to JSON when the redirect cannot be built', () => {
+        const webRes = redirectRes();
+        // No usable base, so a relative target has nothing to resolve against.
+        mockGetConfig.mockReturnValue(undefined);
+        vi.spyOn(localConfig, 'getLocalSiteUrl').mockReturnValue('');
+        mockGetAuthConfig.mockReturnValue({ oauthErrorRedirectUrl: '/login' });
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        moduleExports.sendOAuthError(webRes, 400, 'Auth failed');
+
+        expect(webRes.redirect).not.toHaveBeenCalled();
+        expect(webRes.status).toHaveBeenCalledWith(400);
+        expect(webRes.json).toHaveBeenCalledWith({ error: 'Auth failed' });
+        expect(consoleError).toHaveBeenCalled();
+
+        consoleError.mockRestore();
+        // clearAllMocks leaves a spy's implementation in place, so this one
+        // would otherwise blank the site URL for every later test.
+        vi.restoreAllMocks();
+      });
+
+      test('does not apply to initiation-time errors, which stay JSON', () => {
+        const apiRes = redirectRes();
+        mockGetAuthConfig.mockReturnValue({ oauthErrorRedirectUrl: '/login' });
+
+        moduleExports.sendOAuthError(
+          apiRes,
+          400,
+          'A redirectUri is required for mobile authentication.',
+          { platform: 'api' },
+          'invalid_redirect'
+        );
+
+        expect(apiRes.redirect).not.toHaveBeenCalled();
+        expect(apiRes.status).toHaveBeenCalledWith(400);
+        expect(apiRes.json).toHaveBeenCalledWith({
+          error: 'A redirectUri is required for mobile authentication.',
+        });
       });
 
       test('does not apply to mobile flows, which use the deep link', () => {

--- a/packages/modelence/src/auth/providers/oauthCommon.ts
+++ b/packages/modelence/src/auth/providers/oauthCommon.ts
@@ -183,8 +183,14 @@ export function sendOAuthError(
     // The message is not a credential, but it is user-facing text about a
     // failed sign-in; keep it out of Referer like the mobile branch does.
     res.set('Referrer-Policy', 'no-referrer');
+    // Always set by the time a callback runs: `getRedirectUri` needs it to
+    // start the flow at all.
+    const siteUrl = getConfig('_system.site.url') as string;
     return res.redirect(
-      buildOAuthErrorRedirect(authConfig.oauthErrorRedirectUrl, { error: errorMessage, errorCode })
+      buildOAuthErrorRedirect(siteUrl, authConfig.oauthErrorRedirectUrl, {
+        error: errorMessage,
+        errorCode,
+      })
     );
   }
 

--- a/packages/modelence/src/auth/providers/oauthCommon.ts
+++ b/packages/modelence/src/auth/providers/oauthCommon.ts
@@ -20,6 +20,7 @@ import {
   buildMobileRedirect,
   getAllowedMobileRedirectUrls,
 } from './mobileRedirect';
+import { buildOAuthErrorRedirect } from './oauthErrorRedirect';
 
 /** Which kind of client started an OAuth flow. */
 export type OAuthPlatform = 'web' | 'mobile';
@@ -148,8 +149,9 @@ export type OAuthErrorCode =
 
 /*
  * Sends OAuth error response.
- * If `errorComponent` is configured, renders HTML.
- * Otherwise falls back to JSON.
+ * If `oauthErrorRedirectUrl` is configured, redirects there with the failure
+ * in the query string. Otherwise, if `errorComponent` is configured, renders
+ * HTML. Otherwise falls back to JSON.
  *
  * On a mobile flow, an HTML or JSON body would strand the user in the device
  * browser with no route back into the app, so the error is delivered as a
@@ -175,6 +177,17 @@ export function sendOAuthError(
   }
 
   const authConfig = getAuthConfig();
+
+  if (authConfig.oauthErrorRedirectUrl) {
+    // Same shape as the mobile deep link, so a client can handle both alike.
+    // The message is not a credential, but it is user-facing text about a
+    // failed sign-in; keep it out of Referer like the mobile branch does.
+    res.set('Referrer-Policy', 'no-referrer');
+    return res.redirect(
+      buildOAuthErrorRedirect(authConfig.oauthErrorRedirectUrl, { error: errorMessage, errorCode })
+    );
+  }
+
   const response = res.status(statusCode);
   if (authConfig.errorComponent) {
     try {

--- a/packages/modelence/src/auth/providers/oauthCommon.ts
+++ b/packages/modelence/src/auth/providers/oauthCommon.ts
@@ -11,6 +11,7 @@ import {
 import { getAuthConfig } from '@/app/authConfig';
 import { getCallContext } from '@/app/server';
 import { getConfig } from '@/config/server';
+import { getLocalSiteUrl } from '@/config/local';
 import { time } from '@/time';
 import { resolveUniqueHandle } from '../utils';
 import { User, Session, UserEmail, OAuthProvider } from '@/auth/types';
@@ -67,8 +68,16 @@ export type BoundMobileOutcome = {
  * Where an *error* should be delivered.
  *
  * A failure carries no credential, so it needs a destination but no binding.
+ *
+ * `api` is for failures raised at the initiation endpoint, which a client calls
+ * directly and can read a JSON body from. `web` is for the provider callback,
+ * where the browser has landed on a URL outside any client bundle and a JSON
+ * body would strand it.
  */
-export type OAuthErrorTarget = { platform: 'web' } | { platform: 'mobile'; redirectUri: string };
+export type OAuthErrorTarget =
+  | { platform: 'web' }
+  | { platform: 'api' }
+  | { platform: 'mobile'; redirectUri: string };
 
 /**
  * Resolves the outcome for a validated OAuth state.
@@ -157,6 +166,11 @@ export type OAuthErrorCode =
  * browser with no route back into the app, so the error is delivered as a
  * redirect to the app's deep link instead. Errors raised before the state is
  * decoded have no known platform and keep the default behaviour.
+ *
+ * `oauthErrorRedirectUrl` covers the `web` platform only: it exists for the
+ * provider callback, where the browser has landed outside any client bundle.
+ * An initiation-time failure (`api`) is answered by a client that called the
+ * endpoint directly and can read the JSON body, so it is never redirected.
  */
 export function sendOAuthError(
   res: Response,
@@ -178,20 +192,35 @@ export function sendOAuthError(
 
   const authConfig = getAuthConfig();
 
-  if (authConfig.oauthErrorRedirectUrl) {
-    // Same shape as the mobile deep link, so a client can handle both alike.
-    // The message is not a credential, but it is user-facing text about a
-    // failed sign-in; keep it out of Referer like the mobile branch does.
-    res.set('Referrer-Policy', 'no-referrer');
-    // Always set by the time a callback runs: `getRedirectUri` needs it to
-    // start the flow at all.
-    const siteUrl = getConfig('_system.site.url') as string;
-    return res.redirect(
-      buildOAuthErrorRedirect(siteUrl, authConfig.oauthErrorRedirectUrl, {
+  if (authConfig.oauthErrorRedirectUrl && outcome.platform === 'web') {
+    // `_system.site.url` is set by the time a *callback* runs, since
+    // `getRedirectUri` needs it to start the flow at all. It can still be
+    // missing in local dev, so fall back to the same value that seeds it there.
+    const siteUrl = (getConfig('_system.site.url') as string) || getLocalSiteUrl();
+    let redirectUrl: string | null = null;
+    try {
+      redirectUrl = buildOAuthErrorRedirect(siteUrl, authConfig.oauthErrorRedirectUrl, {
         error: errorMessage,
         errorCode,
-      })
-    );
+      });
+    } catch (err) {
+      // A relative `oauthErrorRedirectUrl` against an unusable base throws here.
+      // Report the original failure below rather than turning it into a 500.
+      console.error(
+        `[modelence] Could not build the OAuth error redirect from ` +
+          `${JSON.stringify(authConfig.oauthErrorRedirectUrl)} and site URL ` +
+          `${JSON.stringify(siteUrl)}. Falling back to the default error response.`,
+        err
+      );
+    }
+
+    if (redirectUrl) {
+      // Same shape as the mobile deep link, so a client can handle both alike.
+      // The message is not a credential, but it is user-facing text about a
+      // failed sign-in; keep it out of Referer like the mobile branch does.
+      res.set('Referrer-Policy', 'no-referrer');
+      return res.redirect(redirectUrl);
+    }
   }
 
   const response = res.status(statusCode);
@@ -834,7 +863,9 @@ export function resolveMobileRedirectRequest(
   const redirectUri = typeof req.query.redirectUri === 'string' ? req.query.redirectUri : '';
 
   if (!redirectUri) {
-    sendOAuthError(res, 400, 'A redirectUri is required for mobile authentication.');
+    sendOAuthError(res, 400, 'A redirectUri is required for mobile authentication.', {
+      platform: 'api',
+    });
     return { ok: false };
   }
 
@@ -851,7 +882,7 @@ export function resolveMobileRedirectRequest(
       res,
       400,
       describeRejectedRedirectUri(redirectUri),
-      undefined,
+      { platform: 'api' },
       'invalid_redirect'
     );
     return { ok: false };
@@ -871,7 +902,8 @@ export function resolveMobileRedirectRequest(
       res,
       400,
       'This sign-in request is missing a valid codeChallenge. Update the Modelence ' +
-        'client package — signInWithOAuth generates it automatically.'
+        'client package — signInWithOAuth generates it automatically.',
+      { platform: 'api' }
     );
     return { ok: false };
   }
@@ -913,7 +945,10 @@ export async function prepareOAuthInitiation(
         res,
         401,
         'Invalid or expired link nonce for OAuth linking.',
-        mobileRedirectUri ? { platform: 'mobile', redirectUri: mobileRedirectUri } : undefined,
+        mobileRedirectUri
+          ? { platform: 'mobile', redirectUri: mobileRedirectUri }
+          : // Also an initiation-time failure: the caller gets JSON, not a redirect.
+            { platform: 'api' },
         'invalid_link_nonce'
       );
       return null;

--- a/packages/modelence/src/auth/providers/oauthErrorRedirect.test.ts
+++ b/packages/modelence/src/auth/providers/oauthErrorRedirect.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest';
+import { buildOAuthErrorRedirect } from './oauthErrorRedirect';
+
+describe('auth/providers/oauthErrorRedirect', () => {
+  describe('buildOAuthErrorRedirect', () => {
+    test('appends error and errorCode to a relative path', () => {
+      const url = buildOAuthErrorRedirect('/login', {
+        error: 'Something went wrong',
+        errorCode: 'oauth_failed',
+      });
+
+      expect(url).toBe('/login?error=Something+went+wrong&errorCode=oauth_failed');
+    });
+
+    test('keeps a relative result relative', () => {
+      const url = buildOAuthErrorRedirect('/login', { error: 'x', errorCode: 'y' });
+
+      expect(url.startsWith('/')).toBe(true);
+      expect(url).not.toMatch(/^https?:/);
+    });
+
+    test('preserves existing unrelated query params on a relative path', () => {
+      const url = buildOAuthErrorRedirect('/login?_redirect=%2Fdashboard', {
+        error: 'nope',
+        errorCode: 'oauth_failed',
+      });
+
+      expect(url).toBe('/login?_redirect=%2Fdashboard&error=nope&errorCode=oauth_failed');
+    });
+
+    test('replaces stale error params rather than duplicating them', () => {
+      const url = buildOAuthErrorRedirect('/login?error=old&errorCode=stale', {
+        error: 'new',
+        errorCode: 'invalid_state',
+      });
+
+      expect(url).toBe('/login?error=new&errorCode=invalid_state');
+    });
+
+    test('supports an absolute URL', () => {
+      const url = buildOAuthErrorRedirect('https://app.example.com/login', {
+        error: 'nope',
+        errorCode: 'oauth_failed',
+      });
+
+      expect(url).toBe('https://app.example.com/login?error=nope&errorCode=oauth_failed');
+    });
+
+    test('preserves a hash fragment', () => {
+      const url = buildOAuthErrorRedirect('/login#form', {
+        error: 'nope',
+        errorCode: 'oauth_failed',
+      });
+
+      expect(url).toBe('/login?error=nope&errorCode=oauth_failed#form');
+    });
+
+    test('encodes characters that would otherwise break the URL', () => {
+      const url = buildOAuthErrorRedirect('/login', {
+        error: 'a&b=c <script>',
+        errorCode: 'oauth_failed',
+      });
+
+      expect(url).toBe('/login?error=a%26b%3Dc+%3Cscript%3E&errorCode=oauth_failed');
+    });
+  });
+});

--- a/packages/modelence/src/auth/providers/oauthErrorRedirect.test.ts
+++ b/packages/modelence/src/auth/providers/oauthErrorRedirect.test.ts
@@ -1,67 +1,77 @@
 import { describe, expect, test } from 'vitest';
 import { buildOAuthErrorRedirect } from './oauthErrorRedirect';
 
+const SITE_URL = 'https://app.example.com';
+
 describe('auth/providers/oauthErrorRedirect', () => {
   describe('buildOAuthErrorRedirect', () => {
-    test('appends error and errorCode to a relative path', () => {
-      const url = buildOAuthErrorRedirect('/login', {
+    test('resolves a path against the site URL and appends error and errorCode', () => {
+      const url = buildOAuthErrorRedirect(SITE_URL, '/login', {
         error: 'Something went wrong',
         errorCode: 'oauth_failed',
       });
 
-      expect(url).toBe('/login?error=Something+went+wrong&errorCode=oauth_failed');
+      expect(url).toBe(
+        'https://app.example.com/login?error=Something+went+wrong&errorCode=oauth_failed'
+      );
     });
 
-    test('keeps a relative result relative', () => {
-      const url = buildOAuthErrorRedirect('/login', { error: 'x', errorCode: 'y' });
-
-      expect(url.startsWith('/')).toBe(true);
-      expect(url).not.toMatch(/^https?:/);
-    });
-
-    test('preserves existing unrelated query params on a relative path', () => {
-      const url = buildOAuthErrorRedirect('/login?_redirect=%2Fdashboard', {
+    test('resolves against a site URL that has a base path', () => {
+      const url = buildOAuthErrorRedirect('https://example.com/app/', 'login', {
         error: 'nope',
         errorCode: 'oauth_failed',
       });
 
-      expect(url).toBe('/login?_redirect=%2Fdashboard&error=nope&errorCode=oauth_failed');
+      expect(url).toBe('https://example.com/app/login?error=nope&errorCode=oauth_failed');
+    });
+
+    test('preserves existing unrelated query params', () => {
+      const url = buildOAuthErrorRedirect(SITE_URL, '/login?_redirect=%2Fdashboard', {
+        error: 'nope',
+        errorCode: 'oauth_failed',
+      });
+
+      expect(url).toBe(
+        'https://app.example.com/login?_redirect=%2Fdashboard&error=nope&errorCode=oauth_failed'
+      );
     });
 
     test('replaces stale error params rather than duplicating them', () => {
-      const url = buildOAuthErrorRedirect('/login?error=old&errorCode=stale', {
+      const url = buildOAuthErrorRedirect(SITE_URL, '/login?error=old&errorCode=stale', {
         error: 'new',
         errorCode: 'invalid_state',
       });
 
-      expect(url).toBe('/login?error=new&errorCode=invalid_state');
+      expect(url).toBe('https://app.example.com/login?error=new&errorCode=invalid_state');
     });
 
-    test('supports an absolute URL', () => {
-      const url = buildOAuthErrorRedirect('https://app.example.com/login', {
+    test('takes an absolute target as is, ignoring the site URL', () => {
+      const url = buildOAuthErrorRedirect(SITE_URL, 'https://other.example.com/login', {
         error: 'nope',
         errorCode: 'oauth_failed',
       });
 
-      expect(url).toBe('https://app.example.com/login?error=nope&errorCode=oauth_failed');
+      expect(url).toBe('https://other.example.com/login?error=nope&errorCode=oauth_failed');
     });
 
     test('preserves a hash fragment', () => {
-      const url = buildOAuthErrorRedirect('/login#form', {
+      const url = buildOAuthErrorRedirect(SITE_URL, '/login#form', {
         error: 'nope',
         errorCode: 'oauth_failed',
       });
 
-      expect(url).toBe('/login?error=nope&errorCode=oauth_failed#form');
+      expect(url).toBe('https://app.example.com/login?error=nope&errorCode=oauth_failed#form');
     });
 
     test('encodes characters that would otherwise break the URL', () => {
-      const url = buildOAuthErrorRedirect('/login', {
+      const url = buildOAuthErrorRedirect(SITE_URL, '/login', {
         error: 'a&b=c <script>',
         errorCode: 'oauth_failed',
       });
 
-      expect(url).toBe('/login?error=a%26b%3Dc+%3Cscript%3E&errorCode=oauth_failed');
+      expect(url).toBe(
+        'https://app.example.com/login?error=a%26b%3Dc+%3Cscript%3E&errorCode=oauth_failed'
+      );
     });
   });
 });

--- a/packages/modelence/src/auth/providers/oauthErrorRedirect.ts
+++ b/packages/modelence/src/auth/providers/oauthErrorRedirect.ts
@@ -1,0 +1,43 @@
+/**
+ * Query params a failed web OAuth flow reports through. Stripped from the
+ * configured target before the fresh values are set, so a stale
+ * `?error=` left in `oauthErrorRedirectUrl` can never shadow the real one.
+ * Mirrors the mobile deep-link contract (see `mobileRedirect.ts`).
+ */
+const ERROR_PARAMS = ['error', 'errorCode'] as const;
+
+/**
+ * Placeholder origin used to parse a relative target. It never appears in the
+ * output: a target that came in relative goes out relative.
+ */
+const RELATIVE_BASE = 'http://relative.invalid';
+
+export type OAuthErrorRedirectParams = {
+  /** Human-readable message for display. Not a stable contract. */
+  error: string;
+  /** Stable identifier the app can branch on. */
+  errorCode: string;
+};
+
+/**
+ * Builds the URL a failed web OAuth flow redirects to.
+ *
+ * `target` is `authConfig.oauthErrorRedirectUrl`: a server-side, trusted value,
+ * so it is not allowlisted the way a mobile `redirectUri` is. It may be a path
+ * (`/login`) or an absolute URL. Existing unrelated query params and any hash
+ * fragment are preserved.
+ */
+export function buildOAuthErrorRedirect(target: string, params: OAuthErrorRedirectParams): string {
+  const isRelative = target.startsWith('/');
+  const url = new URL(target, RELATIVE_BASE);
+
+  for (const key of ERROR_PARAMS) {
+    url.searchParams.delete(key);
+  }
+
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+
+  return isRelative ? `${url.pathname}${url.search}${url.hash}` : url.toString();
+}

--- a/packages/modelence/src/auth/providers/oauthErrorRedirect.ts
+++ b/packages/modelence/src/auth/providers/oauthErrorRedirect.ts
@@ -6,12 +6,6 @@
  */
 const ERROR_PARAMS = ['error', 'errorCode'] as const;
 
-/**
- * Placeholder origin used to parse a relative target. It never appears in the
- * output: a target that came in relative goes out relative.
- */
-const RELATIVE_BASE = 'http://relative.invalid';
-
 export type OAuthErrorRedirectParams = {
   /** Human-readable message for display. Not a stable contract. */
   error: string;
@@ -20,16 +14,20 @@ export type OAuthErrorRedirectParams = {
 };
 
 /**
- * Builds the URL a failed web OAuth flow redirects to.
+ * Builds the absolute URL a failed web OAuth flow redirects to.
  *
  * `target` is `authConfig.oauthErrorRedirectUrl`: a server-side, trusted value,
- * so it is not allowlisted the way a mobile `redirectUri` is. It may be a path
- * (`/login`) or an absolute URL. Existing unrelated query params and any hash
- * fragment are preserved.
+ * so it is not allowlisted the way a mobile `redirectUri` is. A path such as
+ * `/login` is resolved against `siteUrl` (`_system.site.url`), the same base
+ * the email landing routes use; an absolute URL is taken as is. Existing
+ * unrelated query params and any hash fragment are preserved.
  */
-export function buildOAuthErrorRedirect(target: string, params: OAuthErrorRedirectParams): string {
-  const isRelative = target.startsWith('/');
-  const url = new URL(target, RELATIVE_BASE);
+export function buildOAuthErrorRedirect(
+  siteUrl: string,
+  target: string,
+  params: OAuthErrorRedirectParams
+): string {
+  const url = new URL(target, siteUrl);
 
   for (const key of ERROR_PARAMS) {
     url.searchParams.delete(key);
@@ -39,5 +37,5 @@ export function buildOAuthErrorRedirect(target: string, params: OAuthErrorRedire
     url.searchParams.set(key, value);
   }
 
-  return isRelative ? `${url.pathname}${url.search}${url.hash}` : url.toString();
+  return url.toString();
 }


### PR DESCRIPTION
I've faced this case multiple times, and it was never a possible CSRF attack; my sessions just expired. I've added oauthErrorRedirectUrl and deprecated errorComponent, I think it will do the job better. errorComponent requires an HTML page, which is not a good fit for the framework.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth error delivery and redirect behavior on provider callbacks; changes are opt-in via config and preserve JSON/errorComponent fallbacks, but misconfigured redirect URLs could still strand users until fallback.
> 
> **Overview**
> Adds **`auth.oauthErrorRedirectUrl`** so failed **web** OAuth callbacks redirect into the app (e.g. `/login`) with `?error=` and `errorCode=`, matching the mobile deep-link contract. Apps can read those params on a normal page instead of hitting raw JSON or a standalone HTML callback.
> 
> **`sendOAuthError`** now prefers that redirect for `platform: 'web'`, sets `Referrer-Policy: no-referrer`, and falls back to deprecated **`errorComponent`** then JSON if the URL cannot be built. A new **`platform: 'api'`** target keeps **initiation-time** failures (misconfigured provider, bad mobile `redirectUri`, missing `codeChallenge`) as JSON responses.
> 
> **`errorComponent`** is documented as deprecated; redirect wins when both are set. Invalid OAuth state user copy changes to *"Your sign-in session has expired…"* while **`invalid_state`** stays stable for branching.
> 
> OAuth shared code moves from **`oauth-common`** to **`oauthCommon`**, with **`buildOAuthErrorRedirect`** extracted and tests/docs updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98fb042dd20463cc6ddcca72b60d5509b38dc27e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->