### PR TITLE
feat(cron): add resource-weighted concurrency limit

### DIFF
--- a/packages/modelence/src/app/backendApi.test.ts
+++ b/packages/modelence/src/app/backendApi.test.ts
@@ -70,7 +70,7 @@ describe('app/backendApi', () => {
       };
 
       const cronJobsMetadata: CronJobMetadata[] = [
-        { alias: 'daily-job', description: 'runs daily', interval: 3600, timeout: 60 },
+        { alias: 'daily-job', description: 'runs daily', interval: 3600, timeout: 60, weight: 1 },
       ];
 
       const roles: Record<string, RoleDefinition> = {

--- a/packages/modelence/src/cron/jobs.test.ts
+++ b/packages/modelence/src/cron/jobs.test.ts
@@ -95,6 +95,7 @@ describe('cron/jobs', () => {
         description: 'cleanup',
         interval: 10_000,
         timeout: 120_000,
+        weight: 1,
       },
     ]);
 
@@ -284,5 +285,71 @@ describe('cron/jobs', () => {
 
     resolveHandler!();
     (Date.now as Mock).mockRestore();
+  });
+
+  test('cron loop respects weight-based capacity limit', async () => {
+    const handler1 = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+    const handler2 = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+    const handler3 = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    cronStoreMocks.fetch.mockResolvedValue([] as never);
+    defineCronJob('heavyJob', {
+      interval: mockSeconds(10),
+      weight: 8,
+      handler: handler1,
+    });
+    defineCronJob('lightJob1', {
+      interval: mockSeconds(10),
+      weight: 3,
+      handler: handler2,
+    });
+    defineCronJob('lightJob2', {
+      interval: mockSeconds(10),
+      weight: 1,
+      handler: handler3,
+    });
+
+    await startCronJobs();
+    await intervalCallback?.();
+
+    // heavyJob (8) starts → usedCapacity = 8
+    // lightJob1 (3): 8 + 3 = 11 > 10 → skipped
+    // lightJob2 (1): 8 + 1 = 9 <= 10 → starts
+    expect(handler1).toHaveBeenCalledTimes(1);
+    expect(handler2).not.toHaveBeenCalled();
+    expect(handler3).toHaveBeenCalledTimes(1);
+  });
+
+  test('cron loop uses default weight of 1 when not specified', async () => {
+    const handler = vi.fn(async () => {});
+    cronStoreMocks.fetch.mockResolvedValue([] as never);
+    defineCronJob('defaultWeight', {
+      interval: mockSeconds(10),
+      handler,
+    });
+
+    await startCronJobs();
+    const metadata = getCronJobsMetadata();
+    expect(metadata[0].weight).toBe(1);
+  });
+
+  test('cron loop respects custom weight per job', async () => {
+    const handler = vi.fn(async () => {});
+    cronStoreMocks.fetch.mockResolvedValue([] as never);
+    defineCronJob('customWeight', {
+      interval: mockSeconds(10),
+      weight: 5,
+      handler,
+    });
+
+    await startCronJobs();
+    const metadata = getCronJobsMetadata();
+    expect(metadata[0].weight).toBe(5);
   });
 });

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -124,7 +124,7 @@ async function tickCronJobs() {
     if (state.isRunning && state.startTs && state.startTs + params.timeout < now) {
       const timeoutError = new Error(`Cron job '${alias}' timed out after ${params.timeout}ms`);
       captureError(timeoutError);
-      handleCronJobCompletion(state, params);
+      state.isRunning = false;
     }
   }
 

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -118,26 +118,24 @@ async function tickCronJobs() {
   }
 
   const jobs = Object.values(cronJobs);
-
-  for (const job of jobs) {
-    const { alias, params, state } = job;
-    if (state.isRunning && state.startTs && state.startTs + params.timeout < now) {
-      const timeoutError = new Error(`Cron job '${alias}' timed out after ${params.timeout}ms`);
-      captureError(timeoutError);
-      state.isRunning = false;
-    }
-  }
-
   let usedCapacity = getUsedCapacity(jobs);
 
   for (const job of jobs) {
-    const { params, state } = job;
+    const { alias, params, state } = job;
+
     if (state.isRunning) {
+      if (state.startTs && state.startTs + params.timeout < now) {
+        const timeoutError = new Error(`Cron job '${alias}' timed out after ${params.timeout}ms`);
+        captureError(timeoutError);
+        state.isRunning = false;
+      }
       continue;
     }
+
     if (usedCapacity + params.weight > CRON_CAPACITY) {
       continue;
     }
+
     if (state.scheduledRunTs && state.scheduledRunTs <= now) {
       usedCapacity += params.weight;
       void runCronJob(job);
@@ -195,7 +193,11 @@ export default new Module('_system.cron', {
 function getUsedCapacity(jobs: CronJob[]): number {
   let used = 0;
   for (const job of jobs) {
-    if (job.state.isRunning) {
+    const { params, state } = job;
+    if (state.isRunning) {
+      if (state.startTs && state.startTs + params.timeout < Date.now()) {
+        continue;
+      }
       used += job.params.weight;
     }
   }

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -9,6 +9,10 @@ import { Store } from '../data/store';
 import { acquireLock } from '../lock/helpers';
 import { getMongodbUri } from '@/db/client';
 
+/** Total capacity slots available for concurrent cron jobs. Each job's weight is deducted from this pool when running. */
+const CRON_CAPACITY = 10;
+const DEFAULT_WEIGHT = 1;
+
 const cronJobs: Record<string, CronJob> = {};
 let cronJobsInterval: NodeJS.Timeout | null = null;
 
@@ -27,6 +31,7 @@ export function defineCronJob(
     description = '',
     interval,
     timeout = Math.min(Math.max(interval, time.minutes(1)), time.days(1)),
+    weight = DEFAULT_WEIGHT,
     handler,
   }: CronJobInputParams
 ) {
@@ -48,9 +53,15 @@ export function defineCronJob(
     throw new Error(`Cron job timeout should not be longer than 1 day [${alias}]`);
   }
 
+  if (weight < 1 || weight > CRON_CAPACITY) {
+    throw new Error(
+      `Cron job weight must be between 1 and ${CRON_CAPACITY} [${alias}], got ${weight}`
+    );
+  }
+
   cronJobs[alias] = {
     alias,
-    params: { description, interval, timeout },
+    params: { description, interval, timeout, weight },
     handler,
     state: {
       isRunning: false,
@@ -106,23 +117,32 @@ async function tickCronJobs() {
     return;
   }
 
-  Object.values(cronJobs).forEach(async (job) => {
+  const jobs = Object.values(cronJobs);
+
+  for (const job of jobs) {
     const { alias, params, state } = job;
+    if (state.isRunning && state.startTs && state.startTs + params.timeout < now) {
+      const timeoutError = new Error(`Cron job '${alias}' timed out after ${params.timeout}ms`);
+      captureError(timeoutError);
+      handleCronJobCompletion(state, params);
+    }
+  }
+
+  let usedCapacity = getUsedCapacity(jobs);
+
+  for (const job of jobs) {
+    const { params, state } = job;
     if (state.isRunning) {
-      if (state.startTs && state.startTs + params.timeout < now) {
-        const timeoutError = new Error(`Cron job '${alias}' timed out after ${params.timeout}ms`);
-        captureError(timeoutError);
-        state.isRunning = false;
-      }
-      return;
+      continue;
     }
-
-    // TODO: limit the number of jobs running concurrently
-
+    if (usedCapacity + params.weight > CRON_CAPACITY) {
+      continue;
+    }
     if (state.scheduledRunTs && state.scheduledRunTs <= now) {
-      await runCronJob(job);
+      usedCapacity += params.weight;
+      void runCronJob(job);
     }
-  });
+  }
 }
 
 async function runCronJob(job: CronJob) {
@@ -164,12 +184,23 @@ export function getCronJobsMetadata() {
     description: params.description,
     interval: params.interval,
     timeout: params.timeout,
+    weight: params.weight,
   }));
 }
 
 export default new Module('_system.cron', {
   stores: [cronJobsCollection],
 });
+
+function getUsedCapacity(jobs: CronJob[]): number {
+  let used = 0;
+  for (const job of jobs) {
+    if (job.state.isRunning) {
+      used += job.params.weight;
+    }
+  }
+  return used;
+}
 
 // const runCronJob = () => {
 //   const worker = new Worker(filePath, {

--- a/packages/modelence/src/cron/types.ts
+++ b/packages/modelence/src/cron/types.ts
@@ -6,6 +6,7 @@ export type CronJob = {
     description: string;
     interval: number;
     timeout: number;
+    weight: number;
   };
   handler: CronJobHandler;
   state: {
@@ -19,6 +20,7 @@ export type CronJobInputParams = {
   description?: string;
   interval: number;
   timeout?: number;
+  weight?: number;
   handler: CronJobHandler;
 };
 
@@ -27,4 +29,5 @@ export type CronJobMetadata = {
   description: string;
   interval: number;
   timeout: number;
+  weight: number;
 };


### PR DESCRIPTION
## Summary
Replace per-job maxConcurrent with a weight-based model that enforces a global capacity (CRON_CAPACITY=10). Each job declares a weight (1-10) that consumes slots from a shared pool, preventing resource exhaustion when heavy and light jobs run simultaneously.

- for...of + void — parallel execution, matches original behavior
- Weight-based capacity model — heavy jobs block light jobs
- getUsedCapacity() extracted as separate function
- Weight validation: 1 <= weight <= CRON_CAPACITY

Note: The current version only allows 10 jobs with lightest weight (1) .  So I am not sure if it is okay or not.
consider How many lightest job you want to run concurrently and we will give weightage to heavier jobs accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cron scheduling behavior: jobs that used to run together may now be deferred when weights exceed capacity, and iteration order affects which jobs start when the pool is tight.
> 
> **Overview**
> Cron jobs now share a **global concurrency pool** (`CRON_CAPACITY = 10`) instead of starting every scheduled job without limit. Each job declares an optional **`weight`** (1–10, default **1**); starting a job reserves that many slots until it finishes or is treated as timed out.
> 
> The cron tick loop was reworked from `forEach` + fire-and-forget async to a **`for...of`** pass that tracks **`usedCapacity`**, skips jobs that would exceed the pool, and still launches eligible runs in parallel via `void runCronJob(job)`. **`getUsedCapacity()`** sums weights of currently running jobs. Invalid weights fail at registration. **`weight`** is exposed on cron metadata/types and covered by new tests (capacity skipping, defaults, custom weights).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4696003e1333f283aaa72d3ba359bb5f1e3b385a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->