### PR TITLE
fix(cron): keep isRunning true after timeout to prevent re-run

### DIFF
--- a/packages/modelence/src/cron/jobs.test.ts
+++ b/packages/modelence/src/cron/jobs.test.ts
@@ -250,7 +250,7 @@ describe('cron/jobs', () => {
     expect(transaction.end).toHaveBeenCalledWith('error');
   });
 
-  test('cron loop handles and captures timeout when job runs past its timeout limit', async () => {
+  test('cron loop captures timeout when job runs past its timeout limit', async () => {
     mockCaptureError.mockClear();
     let resolveHandler: () => void;
     const handlerPromise = new Promise<void>((resolve) => {
@@ -281,6 +281,73 @@ describe('cron/jobs', () => {
         message: expect.stringContaining("Cron job 'timeoutJob' timed out after 5000ms"),
       })
     );
+
+    resolveHandler!();
+    (Date.now as Mock).mockRestore();
+  });
+
+  test('cron loop does not capture timeout error on every tick', async () => {
+    mockCaptureError.mockClear();
+    let resolveHandler: () => void;
+    const handlerPromise = new Promise<void>((resolve) => {
+      resolveHandler = resolve;
+    });
+    const handler = vi.fn(async () => {
+      await handlerPromise;
+    });
+
+    cronStoreMocks.fetch.mockResolvedValue([] as never);
+    defineCronJob('timeoutJob', {
+      interval: mockSeconds(10),
+      timeout: 5000,
+      handler,
+    });
+
+    await startCronJobs();
+
+    const startTs = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(startTs);
+    await intervalCallback?.();
+
+    (Date.now as Mock).mockReturnValue(startTs + 6000);
+    await intervalCallback?.();
+
+    (Date.now as Mock).mockReturnValue(startTs + 12000);
+    await intervalCallback?.();
+
+    expect(mockCaptureError).toHaveBeenCalledTimes(1);
+
+    resolveHandler!();
+    (Date.now as Mock).mockRestore();
+  });
+
+  test('cron loop does not restart timed-out job while handler is still in flight', async () => {
+    mockCaptureError.mockClear();
+    let resolveHandler: () => void;
+    const handlerPromise = new Promise<void>((resolve) => {
+      resolveHandler = resolve;
+    });
+    const handler = vi.fn(async () => {
+      await handlerPromise;
+    });
+
+    cronStoreMocks.fetch.mockResolvedValue([] as never);
+    defineCronJob('timeoutJob', {
+      interval: mockSeconds(10),
+      timeout: 5000,
+      handler,
+    });
+
+    await startCronJobs();
+
+    const startTs = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(startTs);
+    await intervalCallback?.();
+
+    (Date.now as Mock).mockReturnValue(startTs + 6000);
+    await intervalCallback?.();
+
+    expect(handler).toHaveBeenCalledTimes(1);
 
     resolveHandler!();
     (Date.now as Mock).mockRestore();

--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -109,10 +109,9 @@ async function tickCronJobs() {
   Object.values(cronJobs).forEach(async (job) => {
     const { alias, params, state } = job;
     if (state.isRunning) {
-      if (state.startTs && state.startTs + params.timeout < now) {
-        const timeoutError = new Error(`Cron job '${alias}' timed out after ${params.timeout}ms`);
-        captureError(timeoutError);
-        state.isRunning = false;
+      if (state.startTs && state.startTs + params.timeout < now && !state.timedOutAt) {
+        state.timedOutAt = now;
+        captureError(new Error(`Cron job '${alias}' timed out after ${params.timeout}ms`));
       }
       return;
     }
@@ -127,6 +126,7 @@ async function tickCronJobs() {
 
 async function runCronJob(job: CronJob) {
   const { alias, params, handler, state } = job;
+  state.timedOutAt = undefined;
   state.isRunning = true;
   state.startTs = Date.now();
 
@@ -155,6 +155,7 @@ async function runCronJob(job: CronJob) {
 function handleCronJobCompletion(state: CronJob['state'], params: CronJob['params']) {
   state.scheduledRunTs = state.startTs ? state.startTs + params.interval : Date.now();
   state.startTs = undefined;
+  state.timedOutAt = undefined;
   state.isRunning = false;
 }
 

--- a/packages/modelence/src/cron/types.ts
+++ b/packages/modelence/src/cron/types.ts
@@ -12,6 +12,7 @@ export type CronJob = {
     startTs?: number;
     scheduledRunTs?: number;
     isRunning: boolean;
+    timedOutAt?: number;
   };
 };
 


### PR DESCRIPTION
The timeout scan previously cleared isRunning while the handler was still executing. This allowed the same job to be started again on the next tick, running two copies concurrently and clobbering state.

Now isRunning stays true until handleCronJobCompletion runs. A timedOutAt timestamp ensures captureError fires once, not every tick.

Followed from #363 .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cron scheduling and timeout behavior; incorrect logic could wedge jobs or duplicate runs, but the change aligns state with in-flight handlers.
> 
> **Overview**
> Fixes a bug where **cron jobs could run twice concurrently** after a timeout: the scheduler used to set `isRunning` to false when a run exceeded `timeout`, even though the handler was still executing, so the next tick could start another run.
> 
> **`timedOutAt`** is added to job state so `captureError` for the timeout fires **once** per stuck run instead of on every tick. `isRunning` stays true until **`handleCronJobCompletion`** runs when the handler finishes or errors.
> 
> Tests cover single timeout reporting and that the handler is not invoked again while a timed-out run is still in flight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8e56d113919d5b7453330bb7db851995a3bef86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->