### PR TITLE
fix: capture method errors via captureError before ending transaction

### DIFF
--- a/packages/modelence/src/methods/index.test.ts
+++ b/packages/modelence/src/methods/index.test.ts
@@ -4,6 +4,7 @@ import type { Handler } from './types';
 const transactionEnd = vi.fn();
 const mockRequireServer = vi.fn();
 const mockStartTransaction = vi.fn();
+const mockCaptureError = vi.fn();
 const mockRequireAccess = vi.fn();
 
 vi.doMock('../utils', () => ({
@@ -12,6 +13,7 @@ vi.doMock('../utils', () => ({
 
 vi.doMock('@/telemetry', () => ({
   startTransaction: mockStartTransaction,
+  captureError: mockCaptureError,
   redactSensitive: (v: unknown) => v,
 }));
 
@@ -91,6 +93,21 @@ describe('methods/index', () => {
     createQuery('demo.fail', handlerSpy as never);
 
     await expect(runMethod('demo.fail', {}, { roles: [] } as never)).rejects.toThrow('fail');
+    expect(mockCaptureError).toHaveBeenCalledWith(expect.any(Error));
+    expect(transactionEnd).toHaveBeenCalledWith('error');
+  });
+
+  test('runLiveMethod captures errors and marks transaction', async () => {
+    const { createQuery, runLiveMethod } = await import('./index');
+    const handler: Handler = async () => {
+      throw new Error('live fail');
+    };
+    createQuery('demo.liveFail', handler as never);
+
+    await expect(runLiveMethod('demo.liveFail', {}, { roles: [] } as never)).rejects.toThrow(
+      'live fail'
+    );
+    expect(mockCaptureError).toHaveBeenCalledWith(expect.any(Error));
     expect(transactionEnd).toHaveBeenCalledWith('error');
   });
 });

--- a/packages/modelence/src/methods/index.ts
+++ b/packages/modelence/src/methods/index.ts
@@ -1,5 +1,5 @@
 import { requireServer } from '../utils';
-import { startTransaction, redactSensitive } from '@/telemetry';
+import { startTransaction, captureError, redactSensitive } from '@/telemetry';
 import { requireAccess } from '../auth/role';
 import { Method, MethodDefinition, MethodType, Args, Context } from './types';
 import { LiveData } from '../live-query';
@@ -83,7 +83,7 @@ export async function runMethod(name: string, args: Args, context: Context) {
     requireAccess(context.roles, method.permissions);
     response = await handler(args, context);
   } catch (error) {
-    // TODO: log error and associate it with the transaction
+    captureError(error instanceof Error ? error : new Error(String(error)));
     transaction.end('error');
     throw error;
   }
@@ -127,6 +127,7 @@ export async function runLiveMethod(name: string, args: Args, context: Context):
       );
     }
   } catch (error) {
+    captureError(error instanceof Error ? error : new Error(String(error)));
     transaction.end('error');
     throw error;
   }


### PR DESCRIPTION
## Summary
runMethod / runLiveMethod ended the transaction as 'error' but never reported the error itself, so failures were invisible in APM. This calls captureError() (normalizing non-Error throws) before transaction.end('error'), mirroring the cron-job pattern, and extends the methods/index tests to assert the capture on both paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change; errors are still rethrown and transaction behavior is unchanged aside from associating captured errors.
> 
> **Overview**
> Method handlers already ended telemetry transactions as **error** on failure but did not record the exception, so APM showed failed transactions without the underlying error. **`runMethod`** and **`runLiveMethod`** now call **`captureError`** in their catch blocks (coercing non-`Error` throws to `Error`) before **`transaction.end('error')`**, matching the existing cron-job pattern.
> 
> Tests mock **`captureError`** and assert it runs alongside the error transaction end for both standard and live method execution paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 178f2c3bfa0e523a82bdff11c12a18fdf9e0b8cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->