### PR TITLE
feat: route server error logs to Elastic APM when telemetry is enabled

### DIFF
--- a/packages/modelence/src/app/server.test.ts
+++ b/packages/modelence/src/app/server.test.ts
@@ -56,6 +56,7 @@ const mockCreateRouteHandler =
 const mockGoogleAuthRouter = vi.fn();
 const mockGithubAuthRouter = vi.fn();
 const mockLogInfo = vi.fn();
+const mockReportError = vi.fn();
 const mockGetSecurityConfig = vi.fn();
 const mockGetWebsocketConfig = vi.fn();
 const mockExpressJson = vi.fn();
@@ -106,6 +107,7 @@ vi.doMock('@/auth/providers/github', () => ({
 
 vi.doMock('@/telemetry', () => ({
   logInfo: mockLogInfo,
+  reportError: mockReportError,
 }));
 
 vi.doMock('./securityConfig', () => ({

--- a/packages/modelence/src/app/server.ts
+++ b/packages/modelence/src/app/server.ts
@@ -4,7 +4,7 @@ import { runMethod } from '@/methods';
 import { getResponseTypeMap, sanitizeResult } from '@/methods/serialize';
 import { createRouteHandler } from '@/routes/handler';
 import { HttpMethod } from '@/server';
-import { logInfo } from '@/telemetry';
+import { logInfo, reportError } from '@/telemetry';
 import cookieParser from 'cookie-parser';
 import express, { Request, Response } from 'express';
 import http from 'http';
@@ -302,11 +302,9 @@ export async function getCallContext(req: Request, res: Response | null = null) 
 }
 
 function handleMethodError(res: Response, methodName: string, error: unknown) {
-  // TODO: add an option to silence these error console logs, especially when Elastic logs are configured
-
   if (error instanceof ModelenceError) {
     if (error.status >= 500 && error.status < 600) {
-      console.error(`Error calling ${methodName}:`, error);
+      reportError(error, `Error calling ${methodName}`);
     }
     // Surface a machine-readable code (when present) via a header so clients can
     // branch on the error kind without parsing the human-readable message. The
@@ -323,14 +321,14 @@ function handleMethodError(res: Response, methodName: string, error: unknown) {
     try {
       errorMessage = parseZodError(error as z.ZodError);
     } catch (parsingError) {
-      console.error(`Error parsing Zod error in ${methodName}:`, parsingError);
+      reportError(parsingError, `Error parsing Zod error in ${methodName}`);
       errorMessage = 'Validation failed';
     }
     res.status(400).send(errorMessage);
     return;
   }
 
-  console.error(`Error calling ${methodName}:`, error);
+  reportError(error, `Error calling ${methodName}`);
   res.status(500).send(error instanceof Error ? error.message : String(error));
 }
 

--- a/packages/modelence/src/routes/handler.test.ts
+++ b/packages/modelence/src/routes/handler.test.ts
@@ -4,6 +4,7 @@ import type { Request, Response, NextFunction } from 'express';
 const mockAuthenticate = vi.fn();
 const mockGetMongodbUri = vi.fn();
 const mockStartTransaction = vi.fn();
+const mockReportError = vi.fn();
 
 vi.doMock('../auth', () => ({
   authenticate: mockAuthenticate,
@@ -33,6 +34,7 @@ function redactSensitive(value: unknown): unknown {
 vi.doMock('../telemetry', () => ({
   startTransaction: mockStartTransaction,
   redactSensitive,
+  reportError: mockReportError,
 }));
 
 const { ValidationError } = await import('../error');

--- a/packages/modelence/src/routes/handler.ts
+++ b/packages/modelence/src/routes/handler.ts
@@ -4,7 +4,7 @@ import { ModelenceError } from '../error';
 import { authenticate } from '../auth';
 import { getMongodbUri } from '../db/client';
 import type { Context } from '../methods/types';
-import { startTransaction, redactSensitive } from '../telemetry';
+import { reportError, startTransaction, redactSensitive } from '../telemetry';
 
 // TODO: Use cookies for authentication and automatically add session/user to context if accessing from browser
 export function createRouteHandler(method: string, path: string, handler: RouteHandler) {
@@ -78,8 +78,7 @@ export function createRouteHandler(method: string, path: string, handler: RouteH
       if (error instanceof ModelenceError) {
         res.status(error.status).send(error.message);
       } else {
-        console.error(`Error in route handler: ${req.path}`);
-        console.error(error);
+        reportError(error, `Error in route handler: ${req.path}`);
         res.status(500).send(String(error));
       }
     }

--- a/packages/modelence/src/telemetry.ts
+++ b/packages/modelence/src/telemetry.ts
@@ -1,6 +1,7 @@
 export {
   startTransaction,
   captureError,
+  reportError,
   logInfo,
   logError,
   logDebug,

--- a/packages/modelence/src/telemetry/index.test.ts
+++ b/packages/modelence/src/telemetry/index.test.ts
@@ -190,4 +190,55 @@ describe('telemetry/index', () => {
 
     expect(captureError).toHaveBeenCalledWith(error);
   });
+
+  test('reportError logs to console with context when telemetry disabled', () => {
+    mockIsTelemetryEnabled.mockReturnValue(false);
+    const error = new Error('boom');
+
+    telemetry.reportError(error, 'Error calling myMethod');
+
+    expect(consoleError).toHaveBeenCalledWith('Error calling myMethod:', error);
+    expect(mockGetApm).not.toHaveBeenCalled();
+  });
+
+  test('reportError sends Error to APM with context, silent console, when enabled', () => {
+    mockIsTelemetryEnabled.mockReturnValue(true);
+    const captureError = vi.fn();
+    mockGetApm.mockReturnValue({ captureError });
+
+    const error = new Error('boom');
+    telemetry.reportError(error, 'Error calling myMethod');
+
+    expect(captureError).toHaveBeenCalledWith(error, {
+      custom: { context: 'Error calling myMethod' },
+    });
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('reportError wraps non-Error with searchable message and cause', () => {
+    mockIsTelemetryEnabled.mockReturnValue(true);
+    const captureError = vi.fn();
+    mockGetApm.mockReturnValue({ captureError });
+
+    telemetry.reportError('boom', 'Error calling myMethod');
+
+    expect(captureError).toHaveBeenCalledTimes(1);
+    const sent = captureError.mock.calls[0][0] as Error;
+    expect(sent).toBeInstanceOf(Error);
+    expect(sent.message).toBe('Error calling myMethod: boom');
+    expect((sent as Error & { cause: unknown }).cause).toBe('boom');
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('reportError falls back to console when APM throws', () => {
+    mockIsTelemetryEnabled.mockReturnValue(true);
+    const captureError = vi.fn(() => {
+      throw new Error('apm down');
+    });
+    mockGetApm.mockReturnValue({ captureError });
+
+    const error = new Error('boom');
+    expect(() => telemetry.reportError(error, 'Error calling myMethod')).not.toThrow();
+    expect(consoleError).toHaveBeenCalledWith('Error calling myMethod:', error);
+  });
 });

--- a/packages/modelence/src/telemetry/index.ts
+++ b/packages/modelence/src/telemetry/index.ts
@@ -107,3 +107,28 @@ export function captureError(error: Error) {
 
   getApm().captureError(error);
 }
+
+/**
+ * Single sink for server-side error reporting (method + route handlers).
+ *
+ * Elastic APM on → the error goes to APM once. Off (or APM unavailable) →
+ * the console is the only sink, so it goes to stderr where the container log
+ * driver picks it up. Never throws, so it is safe to call from Express catch
+ * blocks without breaking the response.
+ */
+export function reportError(error: unknown, message: string) {
+  try {
+    if (!isTelemetryEnabled()) {
+      console.error(`${message}:`, error);
+      return;
+    }
+    const apm = getApm();
+    if (error instanceof Error) {
+      apm.captureError(error, { custom: { context: message } });
+      return;
+    }
+    apm.captureError(Object.assign(new Error(`${message}: ${String(error)}`), { cause: error }));
+  } catch {
+    console.error(`${message}:`, error);
+  }
+}


### PR DESCRIPTION
## Summary
Replace unconditional console.error in handleMethodError (app/server.ts) and the route handler (routes/handler.ts) with a centralized telemetry.reportError sink: APM capture with method/route context when telemetry is on, console otherwise (with APM-failure fallback so responses never break). Non-Error throws keep a searchable message plus the raw value on cause.

## Note 
- Object.assign(new Error(msg), { cause }) vs new Error(msg, { cause: error }) — latter is idiomatic ES2022, non-enumerable cause. Current works, just unidiomatic.
- cron/jobs.ts:114,149 still uses raw captureError — fine (it already branches internally), but you now have two public APIs (captureError + reportError). Consider migrating cron to reportError later for one sink.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change: HTTP status bodies and client-visible errors are unchanged; risk is limited to where errors are logged when telemetry is enabled.
> 
> **Overview**
> Introduces **`telemetry.reportError`** as the shared server-side error sink for method and route handlers. When Elastic APM telemetry is on, failures are sent to APM once with a **context string** (e.g. method name or route path); when it is off, behavior stays **`console.error`** with that context. The helper **never throws** and falls back to the console if APM fails, so Express responses are unchanged.
> 
> **`handleMethodError`** in `app/server.ts` and the generic **`catch`** in `routes/handler.ts` now call `reportError` instead of raw `console.error` (including 5xx `ModelenceError`, Zod parse failures, and unknown throws). Non-`Error` values are wrapped for APM with a searchable message and **`cause`** preserved.
> 
> Tests cover the new telemetry behavior and wire **`reportError`** mocks in server and route handler tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d36529a9a0f145c9ca08402b094b7f72a657c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->