### PR TITLE
fix(auth): replace console.error with captureError in resetPassword landing handler (#334)

### DIFF
--- a/packages/modelence/src/auth/resetPassword.test.ts
+++ b/packages/modelence/src/auth/resetPassword.test.ts
@@ -33,6 +33,11 @@ const mockConsumeRateLimit = vi.fn();
 const mockGetConfig = vi.fn();
 const mockInvalidateAllUserSessions = vi.fn();
 const mockMagicLinkTokensDeleteMany = vi.fn();
+const mockCaptureError = vi.fn();
+
+vi.doMock('@/telemetry', () => ({
+  captureError: mockCaptureError,
+}));
 
 vi.doMock('./session', () => ({
   invalidateAllUserSessions: mockInvalidateAllUserSessions,
@@ -1236,6 +1241,11 @@ describe('auth/resetPassword', () => {
       const result = await handleResetPasswordLanding(makeParams('bad-token', cookie) as never);
 
       expect(cookie).not.toHaveBeenCalled();
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'This password reset link is invalid or has expired.',
+        })
+      );
       expect(result?.status).toBe(302);
       expect(result?.redirect).toContain('status=error');
       expect(result?.redirect).toContain(friendlyParam);
@@ -1253,6 +1263,11 @@ describe('auth/resetPassword', () => {
       const result = await handleResetPasswordLanding(makeParams('expired', cookie) as never);
 
       expect(cookie).not.toHaveBeenCalled();
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'This password reset link is invalid or has expired.',
+        })
+      );
       expect(result?.redirect).toContain('status=error');
       expect(result?.redirect).toContain(friendlyParam);
     });
@@ -1265,6 +1280,7 @@ describe('auth/resetPassword', () => {
       const result = await handleResetPasswordLanding(makeParams(undefined, cookie) as never);
 
       expect(cookie).not.toHaveBeenCalled();
+      expect(mockCaptureError).toHaveBeenCalledWith(expect.any(Error));
       expect(result?.redirect).toContain('status=error');
       // The friendly message — NOT the raw ZodError issues array.
       expect(result?.redirect).toContain(friendlyParam);

--- a/packages/modelence/src/auth/resetPassword.ts
+++ b/packages/modelence/src/auth/resetPassword.ts
@@ -15,6 +15,7 @@ import { getConfig } from '@/config/server';
 import { invalidateAllUserSessions } from './session';
 import { hashToken } from './tokenHash';
 import { resolveUrl } from './utils';
+import { captureError } from '@/telemetry';
 
 // Short-lived httpOnly cookie carrying the reset token from the landing route to
 // the `resetPassword` mutation, so it never appears on a client-rendered URL.
@@ -190,7 +191,8 @@ export async function handleResetPasswordLanding(params: RouteParams): Promise<R
   } catch (error) {
     // Surface a fixed, friendly message; never forward the raw error (ZodError or
     // DB error) into the redirect URL. Log the real cause server-side instead.
-    console.error('Error handling password reset landing:', error);
+    const err = error instanceof Error ? error : new Error(String(error));
+    captureError(err);
     const message = 'This password reset link is invalid or has expired.';
     return {
       status: 302,


### PR DESCRIPTION
Fixes #334

### Summary
Replaces raw `console.error` with `captureError` from `@/telemetry` in `handleResetPasswordLanding` (`packages/modelence/src/auth/resetPassword.ts`), bringing error reporting in the password reset landing route into alignment with APM structured telemetry sinks used across other production error paths.

### Changes
- **`packages/modelence/src/auth/resetPassword.ts`**:
  - Imported `captureError` from `@/telemetry`.
  - Replaced `console.error` with `captureError(err)` in the `catch` block of `handleResetPasswordLanding`.
- **`packages/modelence/src/auth/resetPassword.test.ts`**:
  - Mocked `@/telemetry`'s `captureError`.
  - Added assertions in `handleResetPasswordLanding` tests to verify that `captureError` is called when invalid, expired, or missing reset tokens are handled.

### Verification
- **Vitest**: All 36 tests in `src/auth/resetPassword.test.ts` passed.
- **ESLint & Prettier**: Passed with 0 errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change on an auth error path; user-facing redirects and messages are unchanged.
> 
> **Overview**
> Password reset **landing route** failures (invalid, expired, or missing token) still redirect users with the same friendly message, but the server now sends the underlying error to **structured telemetry** via `captureError` instead of `console.error`.
> 
> The catch block in `handleResetPasswordLanding` normalizes thrown values to an `Error` before reporting. Tests mock `@/telemetry` and assert `captureError` runs on the three error redirect paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309fc2d4774fdc8b5913af4ecfe5650b65219fc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->