### PR TITLE
Include package-lock.json in deploy bundle

### DIFF
--- a/packages/modelence/src/bin/deploy.ts
+++ b/packages/modelence/src/bin/deploy.ts
@@ -72,7 +72,13 @@ async function createBundle(bundlePath: string) {
 
   archive.pipe(output);
 
-  const bundleFiles = ['package.json', 'next.config.js', 'next.config.ts', 'modelence.config.ts'];
+  const bundleFiles = [
+    'package.json',
+    'package-lock.json',
+    'next.config.js',
+    'next.config.ts',
+    'modelence.config.ts',
+  ];
 
   const bundleDirs = ['public', 'server', join('.modelence', 'build'), '.next'];
 


### PR DESCRIPTION
Deploy bundles only shipped package.json, so every deploy re-resolved all dependencies from the live registry. When vitest 5.0.0 was published on Sep 3, npm 10.9.8 in the build image started crashing with `Cannot read properties of null (reading 'edgesOut')` for projects on vitest 4, which broke prod deploys with no change on the project's side.

This adds package-lock.json to the bundle when present. The existing `npm install --omit=dev` in the deploy Dockerfile honors it and skips live resolution. Projects without an npm lockfile behave as before.

Needs a version bump and `modelence@x.y.z` tag to publish.