### PR TITLE
refactor(cron): replace forEach with for...of in tickCronJobs

### DIFF
--- a/packages/modelence/src/cron/jobs.ts
+++ b/packages/modelence/src/cron/jobs.ts
@@ -106,7 +106,7 @@ async function tickCronJobs() {
     return;
   }
 
-  Object.values(cronJobs).forEach(async (job) => {
+  for (const job of Object.values(cronJobs)) {
     const { alias, params, state } = job;
     if (state.isRunning) {
       if (state.startTs && state.startTs + params.timeout < now) {
@@ -114,15 +114,15 @@ async function tickCronJobs() {
         captureError(timeoutError);
         state.isRunning = false;
       }
-      return;
+      continue;
     }
 
     // TODO: limit the number of jobs running concurrently
 
     if (state.scheduledRunTs && state.scheduledRunTs <= now) {
-      await runCronJob(job);
+      void runCronJob(job);
     }
-  });
+  }
 }
 
 async function runCronJob(job: CronJob) {


### PR DESCRIPTION
### Summary
Replaces the async `forEach` callback in `tickCronJobs` with a `for...of` loop and marks `runCronJob` with the `void` operator.

- Resolves lint warnings around async callbacks in `forEach` / floating promises.
- Preserves the existing `TODO` comment and lock behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local control-flow refactor in the cron ticker with the same non-blocking job start semantics; no auth, data model, or API surface changes.
> 
> **Overview**
> **`tickCronJobs`** no longer iterates jobs with an `async` `forEach` callback. It uses a **`for...of`** loop instead, with **`continue`** when a job is already running (replacing **`return`** inside the callback) and **`void runCronJob(job)`** instead of **`await runCronJob(job)`**.
> 
> This makes scheduled runs explicitly fire-and-forget and clears lint rules about async `forEach` and floating promises, without changing the distributed lock gate or the existing concurrent-run **`TODO`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d79743c0c1ef2615720610941437b3d310cc60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->