### PR TITLE
fix(methods): guard against null and undefined values in reviveResponseTypes (#373)

### DIFF
--- a/packages/modelence/src/methods/serialize.test.ts
+++ b/packages/modelence/src/methods/serialize.test.ts
@@ -215,5 +215,66 @@ describe('serialize', () => {
       const result = reviveResponseTypes(data);
       expect(result).toBe(data);
     });
+
+    test('should safely handle null and undefined with object typeMap', () => {
+      const typeMap = {
+        type: 'object',
+        props: {
+          createdAt: { type: 'date' },
+        },
+      };
+      expect(reviveResponseTypes(null, typeMap)).toBeNull();
+      expect(reviveResponseTypes(undefined, typeMap)).toBeUndefined();
+    });
+
+    test('should safely handle null and undefined with array typeMap', () => {
+      const typeMap = {
+        type: 'array',
+        elements: {
+          0: { type: 'date' },
+        },
+      };
+      expect(reviveResponseTypes(null, typeMap)).toBeNull();
+      expect(reviveResponseTypes(undefined, typeMap)).toBeUndefined();
+    });
+
+    test('should safely handle nested null objects in object typeMap', () => {
+      const data = {
+        user: null,
+        meta: {
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      };
+      const typeMap = {
+        type: 'object',
+        props: {
+          user: {
+            type: 'object',
+            props: {
+              joinedAt: { type: 'date' },
+            },
+          },
+          meta: {
+            type: 'object',
+            props: {
+              createdAt: { type: 'date' },
+            },
+          },
+        },
+      };
+      const result = reviveResponseTypes(data, typeMap) as typeof data;
+      expect(result.user).toBeNull();
+      expect(result.meta.createdAt).toBeInstanceOf(Date);
+    });
+
+    test('should safely return non-array data when typeMap is array', () => {
+      const typeMap = {
+        type: 'array',
+        elements: {
+          0: { type: 'date' },
+        },
+      };
+      expect(reviveResponseTypes('not-an-array' as unknown, typeMap)).toBe('not-an-array');
+    });
   });
 });

--- a/packages/modelence/src/methods/serialize.ts
+++ b/packages/modelence/src/methods/serialize.ts
@@ -107,7 +107,7 @@ export function getResponseTypeMap(result: unknown) {
 }
 
 export function reviveResponseTypes<T = unknown>(data: T, typeMap?: Record<string, unknown>): T {
-  if (!typeMap) {
+  if (!typeMap || data == null) {
     return data;
   }
 
@@ -116,18 +116,29 @@ export function reviveResponseTypes<T = unknown>(data: T, typeMap?: Record<strin
   }
 
   if (typeMap.type === 'array') {
+    if (!Array.isArray(data)) {
+      return data;
+    }
     return (data as unknown[]).map((item: unknown, index: number) =>
-      reviveResponseTypes(item, (typeMap.elements as Record<string, unknown>[])[index])
+      reviveResponseTypes(
+        item,
+        (typeMap.elements as Record<string, unknown>)?.[index] as
+          | Record<string, unknown>
+          | undefined
+      )
     ) as T;
   }
 
   if (typeMap.type === 'object') {
+    if (typeof data !== 'object' || data === null) {
+      return data;
+    }
     return Object.fromEntries(
       Object.entries(data as Record<string, unknown>).map(([key, value]) => [
         key,
         reviveResponseTypes(
           value,
-          (typeMap.props as Record<string, unknown>)[key] as Record<string, unknown>
+          (typeMap.props as Record<string, unknown>)?.[key] as Record<string, unknown>
         ),
       ])
     ) as T;


### PR DESCRIPTION
Fixes #373

### Summary
Guards `reviveResponseTypes` against `null` and `undefined` inputs or nested nullable values, and adds runtime type checks before mapping object and array structures.

- Returns `data` immediately when `data == null` or `!typeMap`.
- Ensures `Array.isArray(data)` before invoking `.map` in the `array` typeMap branch.
- Ensures `typeof data === 'object' && data !== null` before calling `Object.entries` in the `object` typeMap branch.
- Adds test cases for `null`, `undefined`, nested nullable objects, and non-array values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive serialization guards on the client response path; behavior for valid payloads is unchanged and tests cover edge cases.
> 
> **Overview**
> Hardens **`reviveResponseTypes`** so client-side method responses don’t throw when payloads are **`null`/`undefined`**, include **nullable nested fields**, or don’t match the **`typeMap`** shape.
> 
> The early return now applies when **`data == null`** (not only when **`typeMap`** is missing). **Array** revival skips **`.map`** unless **`data`** is actually an array; **object** revival skips **`Object.entries`** unless **`data`** is a non-null object. Nested lookups use optional chaining on **`typeMap.elements`** and **`typeMap.props`**.
> 
> New tests cover top-level **`null`/`undefined`**, nested **`user: null`** with sibling date revival, and non-array values with an array **`typeMap`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 361aa342576c542e2ff9614d78284b2633d06840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->