### PR TITLE
Add CONTRIBUTING.md: no external code PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to Modelence
+
+Thanks for your interest in Modelence. We want your ideas, bug reports, and feature requests. What we don't accept is code from outside the core team.
+
+## We don't accept external pull requests
+
+Please don't open pull requests with code changes. They will be closed automatically.
+
+Instead, **describe the change you want** and we'll implement it ourselves. In practice, that means opening a GitHub issue that explains:
+
+- What you're trying to do and why the current behavior gets in the way
+- What you'd expect Modelence to do instead
+- For bugs: steps to reproduce, the Modelence version, and any relevant error output
+
+A clear description is worth more to us than a patch. Most changes are quick for us to make once we understand the problem, and doing it ourselves keeps the codebase consistent and lets us handle tests, docs, and release notes in one go. You'll be credited in the release notes when your idea ships.
+
+If it helps you explain the problem, a small code snippet or a link to a minimal reproduction repo is welcome inside the issue. Just don't send it as a PR.
+
+## Where to reach us
+
+- **Bugs and feature requests:** [GitHub Issues](https://github.com/modelence/modelence/issues)
+- **Questions and discussion:** [Discord](https://discord.gg/ghxu5PDnkZ)
+- **Security issues:** please do not open a public issue. Email [security@modelence.com](mailto:security@modelence.com) instead.
+
+## Running Modelence locally
+
+If you want to run the framework from source to debug something or verify a bug report, the [Local Development](README.md#local-development-modelence-framework) section of the README walks through the setup.

--- a/packages/modelence/README.md
+++ b/packages/modelence/README.md
@@ -38,7 +38,9 @@ For a more detailed guide, check out the [Quick Start](https://docs.modelence.co
 
 ### Local Development (Modelence Framework)
 
-If you want to contribute to Modelence itself (not just use it in an application), follow the steps below.
+> We don't accept external code pull requests. See [CONTRIBUTING.md](https://github.com/modelence/modelence/blob/main/CONTRIBUTING.md) for how to suggest changes.
+
+If you want to run the framework from source, follow the steps below.
 
 #### 1. Clone the repository
 ```bash


### PR DESCRIPTION
We're not accepting code PRs from outside the team anymore. People describe the change they want in an issue and we implement it ourselves. Also updated the README's local dev intro to match.

Next: an Action that auto-closes external PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy and README wording; no runtime, auth, or application code changes.
> 
> **Overview**
> **Documents that Modelence does not accept external code PRs** and steers contributors toward GitHub issues (with guidance on what to include), plus Discord, security email, and a pointer to local-from-source setup.
> 
> Adds **`CONTRIBUTING.md`** with that policy, issue expectations, contact channels, and a link to the README local development section.
> 
> Updates **`packages/modelence/README.md`** under **Local Development**: replaces “contribute to Modelence itself” with a callout linking to `CONTRIBUTING.md`, and reframes the steps as running the framework from source (clone/build unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44ae92e839ea9b3715248d369b171a96553c7f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->