### PR TITLE
fix(routes): capture unhandled route errors via captureError in createRouteHandler (#374)

### DIFF
--- a/packages/modelence/src/routes/handler.test.ts
+++ b/packages/modelence/src/routes/handler.test.ts
@@ -4,6 +4,7 @@ import type { Request, Response, NextFunction } from 'express';
 const mockAuthenticate = vi.fn();
 const mockGetMongodbUri = vi.fn();
 const mockStartTransaction = vi.fn();
+const mockCaptureError = vi.fn();
 
 vi.doMock('../auth', () => ({
   authenticate: mockAuthenticate,
@@ -33,6 +34,7 @@ function redactSensitive(value: unknown): unknown {
 vi.doMock('../telemetry', () => ({
   startTransaction: mockStartTransaction,
   redactSensitive,
+  captureError: mockCaptureError,
 }));
 
 const { ValidationError } = await import('../error');
@@ -189,26 +191,45 @@ describe('routes/handler', () => {
     expect(res.setHeader).toHaveBeenNthCalledWith(2, 'Content-Type', 'application/vnd.ms-excel');
   });
 
-  test('handles ModelenceError gracefully', async () => {
+  test('handles ModelenceError gracefully and reports to captureError', async () => {
+    const error = new ValidationError('fail');
     const handler = createRouteHandler('GET', '/test', async () => {
-      throw new ValidationError('fail');
+      throw error;
     });
 
     await handler(baseReq, res, next);
 
+    expect(mockCaptureError).toHaveBeenCalledWith(error);
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.send).toHaveBeenCalledWith('fail');
+    expect(transactionEnd).toHaveBeenCalledWith('error');
   });
 
-  test('logs generic errors and sends 500', async () => {
+  test('logs generic errors, captures in telemetry, and sends 500', async () => {
+    const error = new Error('boom');
     const handler = createRouteHandler('GET', '/test', async () => {
-      throw new Error('boom');
+      throw error;
     });
 
     await handler(baseReq, res, next);
 
+    expect(mockCaptureError).toHaveBeenCalledWith(error);
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalledWith('Error: boom');
+    expect(transactionEnd).toHaveBeenCalledWith('error');
+  });
+
+  test('wraps non-Error thrown values before passing to captureError', async () => {
+    const handler = createRouteHandler('GET', '/test', async () => {
+      throw 'string failure';
+    });
+
+    await handler(baseReq, res, next);
+
+    expect(mockCaptureError).toHaveBeenCalledWith(expect.any(Error));
+    expect(mockCaptureError.mock.calls[0][0].message).toBe('string failure');
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalledWith('string failure');
     expect(transactionEnd).toHaveBeenCalledWith('error');
   });
 });

--- a/packages/modelence/src/routes/handler.ts
+++ b/packages/modelence/src/routes/handler.ts
@@ -4,7 +4,7 @@ import { ModelenceError } from '../error';
 import { authenticate } from '../auth';
 import { getMongodbUri } from '../db/client';
 import type { Context } from '../methods/types';
-import { startTransaction, redactSensitive } from '../telemetry';
+import { startTransaction, redactSensitive, captureError } from '../telemetry';
 
 // TODO: Use cookies for authentication and automatically add session/user to context if accessing from browser
 export function createRouteHandler(method: string, path: string, handler: RouteHandler) {
@@ -73,6 +73,7 @@ export function createRouteHandler(method: string, path: string, handler: RouteH
         }
       }
     } catch (error) {
+      captureError(error instanceof Error ? error : new Error(String(error)));
       transaction.end('error');
 
       if (error instanceof ModelenceError) {


### PR DESCRIPTION
Fixes #374

### Summary
Invokes `captureError` for unhandled exceptions in `createRouteHandler` before closing the APM transaction, aligning route error telemetry with method calls and cron jobs.

- Calls `captureError(error instanceof Error ? error : new Error(String(error)))` in `createRouteHandler`'s `catch` block.
- Adds test cases in `routes/handler.test.ts` verifying that `captureError` is called on errors and that non-Error thrown values are properly wrapped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds observability in the existing catch path only; response status and bodies for errors are unchanged.
> 
> **Overview**
> Route handlers now send every caught exception to **`captureError`** before ending the APM transaction with `'error'`, matching how method calls and cron jobs record failures.
> 
> Non-`Error` throws are normalized with `new Error(String(error))` so telemetry always receives an `Error` instance. HTTP behavior is unchanged: `ModelenceError` still maps to its status/message; everything else still logs and returns 500.
> 
> Tests mock `captureError` and assert it is invoked for validation errors, generic errors, and string throws (including the wrapped message).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f8665aed5b479c428fb992f345ad470bd8098d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->