### PR TITLE
fix(auth): add missing lastActiveDate field to sessionsCollection schema (#375)

### DIFF
--- a/packages/modelence/src/auth/session.test.ts
+++ b/packages/modelence/src/auth/session.test.ts
@@ -270,6 +270,51 @@ describe('auth/session', () => {
     });
   });
 
+  describe('_system.session.heartbeat', () => {
+    test('updates lastActiveDate and expiresAt on active session', async () => {
+      updateOneMock.mockResolvedValue({ acknowledged: true } as never);
+      const session = { authToken: 'token', expiresAt: new Date(), userId: new ObjectId() };
+
+      await sessionSystemModule.mutations.heartbeat.call(
+        sessionSystemModule,
+        {},
+        {
+          session,
+          user: { id: 'u', email: 'a@b' },
+          roles: [],
+          clientInfo: {} as never,
+          connectionInfo: {} as never,
+        }
+      );
+
+      expect(updateOneMock).toHaveBeenCalledWith(
+        { authToken: 'hashed-auth-token' },
+        {
+          $set: {
+            lastActiveDate: expect.any(Date),
+            expiresAt: expect.any(Date),
+          },
+        }
+      );
+    });
+
+    test('does nothing when session is null', async () => {
+      await sessionSystemModule.mutations.heartbeat.call(
+        sessionSystemModule,
+        {},
+        {
+          session: null,
+          user: null,
+          roles: [],
+          clientInfo: {} as never,
+          connectionInfo: {} as never,
+        }
+      );
+
+      expect(updateOneMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe('OAuth exchange codes', () => {
     const insertMock: Mock = vi.fn();
     const findOneAndDeleteMock: Mock = vi.fn();

--- a/packages/modelence/src/auth/session.ts
+++ b/packages/modelence/src/auth/session.ts
@@ -137,6 +137,7 @@ export const sessionsCollection = new Store('_modelenceSessions', {
     createdAt: schema.date(),
     expiresAt: schema.date(),
     userId: schema.userId().nullable(),
+    lastActiveDate: schema.date().optional(),
   },
   indexes: [
     { key: { authToken: 1 }, unique: true },


### PR DESCRIPTION
Fixes #375

### Summary
Adds the `lastActiveDate` field to `sessionsCollection`'s Store schema definition to match the fields written by `processSessionHeartbeat`.

- Adds `lastActiveDate: schema.date().optional()` to `sessionsCollection.schema` in `src/auth/session.ts`.
- Adds tests in `src/auth/session.test.ts` for the `_system.session.heartbeat` mutation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema metadata and test coverage only; heartbeat persistence behavior is unchanged.
> 
> **Overview**
> Aligns the sessions Store schema with what session heartbeat already writes to MongoDB.
> 
> Adds optional `lastActiveDate` to `sessionsCollection.schema` so it matches the `$set` in `processSessionHeartbeat` (fixes #375). New unit tests cover `_system.session.heartbeat`: it updates `lastActiveDate` and `expiresAt` for an active session and skips DB updates when `session` is null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f51fc3c20a2dae943158b83ae9d3040e12edd2bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->