### PR TITLE
fix: include scripts/ in deploy bundle

### DIFF
--- a/packages/modelence/src/bin/deploy.ts
+++ b/packages/modelence/src/bin/deploy.ts
@@ -80,7 +80,7 @@ async function createBundle(bundlePath: string) {
     'modelence.config.ts',
   ];
 
-  const bundleDirs = ['public', 'server', join('.modelence', 'build'), '.next'];
+  const bundleDirs = ['public', 'server', 'scripts', join('.modelence', 'build'), '.next'];
 
   for (const file of bundleFiles) {
     if (


### PR DESCRIPTION
The app-builder-empty-project template declares a `postinstall` hook that runs `node scripts/postinstall.mjs`, but `createBundle()` never packaged `scripts/`. In the CodeBuild container, `npm install --omit=dev` fires the hook against a file that isn't there and the Docker build fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change that makes deploy bundles match what npm lifecycle hooks expect; no runtime auth or data-path changes.
> 
> **Overview**
> **Deploy bundles now include the project `scripts/` directory** when zipping artifacts for Modelence Cloud.
> 
> Previously `createBundle()` only packaged `public`, `server`, `.modelence/build`, and `.next`, so templates that run **`node scripts/postinstall.mjs`** from a **`postinstall`** npm hook failed in CodeBuild when **`npm install --omit=dev`** ran inside the container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f5d056c0f1af593b6713fc96d49844b73bef3fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->