### PR TITLE
fix: reject asterisk in cors settings

### DIFF
--- a/packages/modelence/src/app/securityConfig.test.ts
+++ b/packages/modelence/src/app/securityConfig.test.ts
@@ -83,6 +83,14 @@ describe('securityConfig', () => {
     expect(() => setSecurityConfig({ allowedOrigins: ['*'] })).toThrow(
       /wildcards are not supported/
     );
+    // `*` is a legal hostname character, so these parse as valid URLs and would
+    // otherwise be stored as-is — never matching an Origin any browser sends.
+    expect(() => setSecurityConfig({ allowedOrigins: ['https://*.example.com'] })).toThrow(
+      /wildcards are not supported/
+    );
+    expect(() => setSecurityConfig({ allowedOrigins: ['https://*'] })).toThrow(
+      /wildcards are not supported/
+    );
   });
 
   test('rejects an origin that includes a path', async () => {

--- a/packages/modelence/src/app/securityConfig.ts
+++ b/packages/modelence/src/app/securityConfig.ts
@@ -199,6 +199,17 @@ function normalizeOrigin(entry: string): string {
         `Scheme ${JSON.stringify(url.protocol.replace(':', ''))} does not form a comparable origin.`
     );
   }
+  // `*` is a legal URL hostname character, so `https://*.example.com` parses and
+  // would be stored as-is. Browsers never send a literal `*` in `Origin`, so the
+  // entry could only ever fail to match — the same silent CORS failure the bare
+  // '*' check above exists to prevent.
+  if (url.hostname.includes('*')) {
+    throw new Error(
+      `Invalid security.allowedOrigins entry ${JSON.stringify(entry)}: wildcards are not supported, ` +
+        'since the response echoes one concrete origin to keep credentialed requests working. ' +
+        'List each allowed origin explicitly.'
+    );
+  }
   // A bare origin parses with pathname '/' — anything longer is a real path.
   if (url.pathname !== '/') {
     throw new Error(


### PR DESCRIPTION
* Reject asterisks in CORS settings, it's ignored by the browser in this case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only validation for CORS config; stricter checks may fail deploys that previously accepted invalid wildcard hostnames.
> 
> **Overview**
> **Tightens `security.allowedOrigins` validation** so wildcard-looking URLs cannot slip through startup checks.
> 
> Besides rejecting the bare `*` entry, `normalizeOrigin` now throws when the parsed hostname contains `*` (e.g. `https://*.example.com`, `https://*`). Those strings are valid URLs but browsers never send a literal `*` in `Origin`, so they would be stored and only fail CORS at runtime. Tests cover the new rejection cases with the same “wildcards are not supported” message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68139cfc34f668b9867980e4973af81cbd6a91da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->